### PR TITLE
Implement sdf CLI tool with cross-platform build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,13 @@ profile.cov
 go.work
 go.work.sum
 
+# Build output
+bin/
+dist/
+
+# sdf local state (ephemeral, not committed)
+.sdf/local.json
+
 # env file
 .env
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,85 @@
+BINARY   := sdf
+MODULE   := github.com/pavelpascari/sdf
+VERSION  ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+LDFLAGS  := -s -w -X main.version=$(VERSION)
+BUILD    := go build -ldflags "$(LDFLAGS)" -trimpath
+
+# Default: build for current platform
+.PHONY: build
+build:
+	$(BUILD) -o bin/$(BINARY) .
+
+# Run the binary
+.PHONY: run
+run: build
+	./bin/$(BINARY) $(ARGS)
+
+# Run tests
+.PHONY: test
+test:
+	go test ./...
+
+# Run vet and static checks
+.PHONY: vet
+vet:
+	go vet ./...
+
+# Format code
+.PHONY: fmt
+fmt:
+	gofmt -s -w .
+
+# Clean build artifacts
+.PHONY: clean
+clean:
+	rm -rf bin/ dist/
+
+# ── Cross-compilation ──────────────────────────────────────────────
+
+PLATFORMS := \
+	linux/amd64 \
+	linux/arm64 \
+	darwin/amd64 \
+	darwin/arm64 \
+	windows/amd64 \
+	windows/arm64
+
+.PHONY: dist
+dist: clean
+	@mkdir -p dist
+	@for platform in $(PLATFORMS); do \
+		os=$${platform%/*}; \
+		arch=$${platform#*/}; \
+		output="dist/$(BINARY)-$${os}-$${arch}"; \
+		if [ "$$os" = "windows" ]; then output="$${output}.exe"; fi; \
+		echo "Building $$os/$$arch → $$output"; \
+		GOOS=$$os GOARCH=$$arch $(BUILD) -o $$output . || exit 1; \
+	done
+	@echo "\nAll binaries built in dist/"
+	@ls -lh dist/
+
+# Build a single platform: make build-for OS=linux ARCH=arm64
+.PHONY: build-for
+build-for:
+	@test -n "$(OS)" || (echo "usage: make build-for OS=<os> ARCH=<arch>" && exit 1)
+	@test -n "$(ARCH)" || (echo "usage: make build-for OS=<os> ARCH=<arch>" && exit 1)
+	@mkdir -p bin
+	GOOS=$(OS) GOARCH=$(ARCH) $(BUILD) -o bin/$(BINARY)-$(OS)-$(ARCH) .
+
+# Install to GOPATH/bin
+.PHONY: install
+install:
+	go install -ldflags "$(LDFLAGS)" .
+
+.PHONY: help
+help:
+	@echo "sdf build targets:"
+	@echo "  make build      Build for current platform → bin/sdf"
+	@echo "  make dist       Cross-compile for all platforms → dist/"
+	@echo "  make build-for OS=linux ARCH=arm64"
+	@echo "                  Build for a specific platform → bin/sdf-<os>-<arch>"
+	@echo "  make install    Install to GOPATH/bin"
+	@echo "  make test       Run tests"
+	@echo "  make vet        Run go vet"
+	@echo "  make fmt        Format code"
+	@echo "  make clean      Remove build artifacts"

--- a/cmd/branch.go
+++ b/cmd/branch.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	ctxpkg "github.com/pavelpascari/sdf/internal/context"
+	gitpkg "github.com/pavelpascari/sdf/internal/git"
+	"github.com/pavelpascari/sdf/internal/stack"
+)
+
+func RunBranch(args []string) error {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: sdf branch <name>")
+		os.Exit(1)
+	}
+
+	branchName := args[0]
+
+	root, err := stack.FindRoot()
+	if err != nil {
+		return err
+	}
+
+	s, err := stack.Load(root)
+	if err != nil {
+		return err
+	}
+
+	// Check if branch already exists in the stack
+	if s.FindNode(branchName) != nil {
+		return fmt.Errorf("branch %q already exists in stack %q", branchName, s.StackID)
+	}
+
+	// Determine parent: the last node in the stack, or the base
+	parent := s.Base
+	if len(s.Nodes) > 0 {
+		parent = s.Nodes[len(s.Nodes)-1].Branch
+	}
+
+	// Get the current tip of the parent for tracking
+	parentTip, err := gitpkg.RevParse(parent)
+	if err != nil {
+		return fmt.Errorf("cannot resolve parent branch %s: %w", parent, err)
+	}
+
+	// Create the git branch
+	if err := gitpkg.CreateBranch(branchName); err != nil {
+		return fmt.Errorf("cannot create branch: %w", err)
+	}
+
+	// Add node to stack
+	s.Nodes = append(s.Nodes, stack.Node{
+		Branch:  branchName,
+		Status:  "open",
+		BaseTip: parentTip,
+	})
+
+	if err := stack.Save(root, s); err != nil {
+		return err
+	}
+
+	// Create stub context document
+	if err := ctxpkg.CreateStub(root, branchName, parent); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not create context stub: %v\n", err)
+	}
+
+	// Push tracking branch to origin
+	if err := gitpkg.PushNew(branchName); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not push to origin: %v\n", err)
+		fmt.Fprintln(os.Stderr, "  You can push later with: git push -u origin", branchName)
+	}
+
+	fmt.Printf("Created branch %q in stack %q (based on %s)\n", branchName, s.StackID, parent)
+	fmt.Printf("Context doc: .sdf/context/%s.md\n", branchName)
+	fmt.Println("Next: implement your changes, then run `sdf context edit` and `sdf pr`.")
+	return nil
+}

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -1,0 +1,171 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	claudepkg "github.com/pavelpascari/sdf/internal/claude"
+	ctxpkg "github.com/pavelpascari/sdf/internal/context"
+	gitpkg "github.com/pavelpascari/sdf/internal/git"
+	"github.com/pavelpascari/sdf/internal/stack"
+)
+
+func RunContext(args []string) error {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: sdf context <show|edit|update>")
+		os.Exit(1)
+	}
+
+	subcmd := args[0]
+	switch subcmd {
+	case "show":
+		return runContextShow()
+	case "edit":
+		return runContextEdit()
+	case "update":
+		return runContextUpdate()
+	default:
+		return fmt.Errorf("unknown context subcommand: %s (use show, edit, or update)", subcmd)
+	}
+}
+
+func runContextShow() error {
+	root, err := stack.FindRoot()
+	if err != nil {
+		return err
+	}
+
+	s, err := stack.Load(root)
+	if err != nil {
+		return err
+	}
+
+	branch, err := gitpkg.CurrentBranch()
+	if err != nil {
+		return err
+	}
+
+	if s.FindNode(branch) == nil {
+		return fmt.Errorf("branch %q is not in stack %q", branch, s.StackID)
+	}
+
+	assembled, err := ctxpkg.Assemble(root, s, branch)
+	if err != nil {
+		return err
+	}
+
+	fmt.Print(assembled)
+	return nil
+}
+
+func runContextEdit() error {
+	root, err := stack.FindRoot()
+	if err != nil {
+		return err
+	}
+
+	s, err := stack.Load(root)
+	if err != nil {
+		return err
+	}
+
+	branch, err := gitpkg.CurrentBranch()
+	if err != nil {
+		return err
+	}
+
+	if s.FindNode(branch) == nil {
+		return fmt.Errorf("branch %q is not in stack %q", branch, s.StackID)
+	}
+
+	docPath := ctxpkg.DocPath(root, branch)
+
+	// Ensure doc exists
+	if !ctxpkg.Exists(root, branch) {
+		parent := s.ParentBranch(branch)
+		if err := ctxpkg.CreateStub(root, branch, parent); err != nil {
+			return fmt.Errorf("cannot create context doc: %w", err)
+		}
+	}
+
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = "vi"
+	}
+
+	cmd := exec.Command(editor, docPath)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("editor exited with error: %w", err)
+	}
+
+	fmt.Printf("Context doc updated: %s\n", docPath)
+	return nil
+}
+
+func runContextUpdate() error {
+	root, err := stack.FindRoot()
+	if err != nil {
+		return err
+	}
+
+	s, err := stack.Load(root)
+	if err != nil {
+		return err
+	}
+
+	branch, err := gitpkg.CurrentBranch()
+	if err != nil {
+		return err
+	}
+
+	node := s.FindNode(branch)
+	if node == nil {
+		return fmt.Errorf("branch %q is not in stack %q", branch, s.StackID)
+	}
+
+	if !claudepkg.Available() {
+		return fmt.Errorf("claude CLI is required for context update — install it first")
+	}
+
+	// Get current context
+	currentCtx, _ := ctxpkg.Read(root, branch)
+
+	// Get diff from parent
+	parent := s.ParentBranch(branch)
+	diff, _ := gitpkg.DiffFull(parent, branch)
+
+	// Build prompt
+	prompt := fmt.Sprintf(`You are updating the context document for branch %q in a stacked diff workflow.
+
+=== CURRENT CONTEXT DOC ===
+%s
+
+=== DIFF FROM PARENT (%s) ===
+%s
+
+Rewrite the context document to accurately reflect the current state of this branch.
+Keep the same markdown structure (Intent, Constraints from upstream, Decisions made here, Open questions).
+Be concise and precise. Output ONLY the markdown content for the context doc, nothing else.`, branch, currentCtx, parent, diff)
+
+	sessionName := claudepkg.SanitizeSessionName("context-update", branch)
+
+	fmt.Printf("Asking Claude to update context doc for %s...\n", branch)
+	output, err := claudepkg.RunPrompt(sessionName, prompt)
+	if err != nil {
+		return fmt.Errorf("claude failed: %w", err)
+	}
+
+	// Write updated context
+	docPath := ctxpkg.DocPath(root, branch)
+	if err := os.WriteFile(docPath, []byte(output+"\n"), 0644); err != nil {
+		return fmt.Errorf("cannot write context doc: %w", err)
+	}
+
+	fmt.Printf("Context doc updated: %s\n", docPath)
+	return nil
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	gitpkg "github.com/pavelpascari/sdf/internal/git"
+	"github.com/pavelpascari/sdf/internal/stack"
+)
+
+func RunInit(args []string) error {
+	fs := flag.NewFlagSet("init", flag.ExitOnError)
+	stackName := fs.String("stack", "", "name for the stack (required)")
+	base := fs.String("base", "main", "base branch for the stack")
+	fs.Parse(args)
+
+	if *stackName == "" {
+		// If no --stack flag, use positional arg
+		if fs.NArg() > 0 {
+			*stackName = fs.Arg(0)
+		} else {
+			fmt.Fprintln(os.Stderr, "usage: sdf init --stack <name>")
+			fmt.Fprintln(os.Stderr, "       sdf init <name>")
+			os.Exit(1)
+		}
+	}
+
+	root, err := gitpkg.RepoRoot()
+	if err != nil {
+		return fmt.Errorf("not inside a git repository: %w", err)
+	}
+
+	// Check if already initialized
+	if _, err := os.Stat(root + "/.sdf/stack.json"); err == nil {
+		return fmt.Errorf(".sdf already exists in %s — use a different repo or remove .sdf/ first", root)
+	}
+
+	if err := stack.Init(root, *stackName, *base); err != nil {
+		return err
+	}
+
+	fmt.Printf("Initialized stack %q (base: %s) in %s/.sdf/\n", *stackName, *base, root)
+	fmt.Println("Next: run `sdf branch <name>` to create the first branch in the stack.")
+	return nil
+}

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	ctxpkg "github.com/pavelpascari/sdf/internal/context"
+	gitpkg "github.com/pavelpascari/sdf/internal/git"
+	ghpkg "github.com/pavelpascari/sdf/internal/gh"
+	"github.com/pavelpascari/sdf/internal/stack"
+)
+
+func RunPR(args []string) error {
+	fs := flag.NewFlagSet("pr", flag.ExitOnError)
+	title := fs.String("title", "", "PR title (default: branch name)")
+	fs.Parse(args)
+
+	root, err := stack.FindRoot()
+	if err != nil {
+		return err
+	}
+
+	s, err := stack.Load(root)
+	if err != nil {
+		return err
+	}
+
+	branch, err := gitpkg.CurrentBranch()
+	if err != nil {
+		return fmt.Errorf("cannot determine current branch: %w", err)
+	}
+
+	node := s.FindNode(branch)
+	if node == nil {
+		return fmt.Errorf("branch %q is not in stack %q — run `sdf branch` to add it", branch, s.StackID)
+	}
+
+	if node.PR > 0 {
+		return fmt.Errorf("branch %q already has PR #%d", branch, node.PR)
+	}
+
+	if !ghpkg.Available() {
+		return fmt.Errorf("gh CLI is required to create PRs — install it from https://cli.github.com")
+	}
+
+	// Determine base branch
+	base := s.ParentBranch(branch)
+
+	// Build PR body from context doc
+	body, err := ctxpkg.Read(root, branch)
+	if err != nil || body == "" {
+		body = fmt.Sprintf("Part of stack: **%s**\n\nBase: `%s`", s.StackID, base)
+	} else {
+		body = body + fmt.Sprintf("\n\n---\n*Part of stack: **%s***", s.StackID)
+	}
+
+	// Determine title
+	prTitle := *title
+	if prTitle == "" {
+		// Use branch name, replacing slashes and dashes with spaces
+		prTitle = branch
+		prTitle = strings.ReplaceAll(prTitle, "/", ": ")
+		prTitle = strings.ReplaceAll(prTitle, "-", " ")
+	}
+
+	// Push current branch first
+	fmt.Printf("Pushing %s to origin...\n", branch)
+	if err := gitpkg.Push(branch); err != nil {
+		// Try regular push if force-with-lease fails
+		if err := gitpkg.PushNew(branch); err != nil {
+			return fmt.Errorf("cannot push branch: %w", err)
+		}
+	}
+
+	// Create PR
+	fmt.Printf("Creating PR: %s (base: %s)...\n", prTitle, base)
+	url, err := ghpkg.PRCreate(prTitle, body, base, branch)
+	if err != nil {
+		return fmt.Errorf("cannot create PR: %w", err)
+	}
+
+	// Try to extract PR number from gh output
+	pr, err := ghpkg.PRView(branch)
+	if err == nil {
+		node.PR = pr.Number
+		node.Status = "open"
+	}
+
+	if err := stack.Save(root, s); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not update stack.json: %v\n", err)
+	}
+
+	fmt.Println(url)
+	return nil
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	gitpkg "github.com/pavelpascari/sdf/internal/git"
+	"github.com/pavelpascari/sdf/internal/gh"
+	"github.com/pavelpascari/sdf/internal/stack"
+)
+
+func RunStatus(args []string) error {
+	root, err := stack.FindRoot()
+	if err != nil {
+		return err
+	}
+
+	s, err := stack.Load(root)
+	if err != nil {
+		return err
+	}
+
+	if len(s.Nodes) == 0 {
+		fmt.Printf("  %s  (base: %s)\n\n", s.StackID, s.Base)
+		fmt.Println("  No branches in stack yet. Run `sdf branch <name>` to add one.")
+		return nil
+	}
+
+	// Try to get current branch for highlighting
+	currentBranch, _ := gitpkg.CurrentBranch()
+
+	// Try to fetch PR info from GitHub
+	branches := make([]string, len(s.Nodes))
+	for i, n := range s.Nodes {
+		branches[i] = n.Branch
+	}
+
+	prMap := make(map[string]gh.PRInfo)
+	if gh.Available() {
+		prs, err := gh.PRList(branches)
+		if err == nil {
+			for _, pr := range prs {
+				prMap[pr.HeadRefName] = pr
+			}
+		}
+	}
+
+	// Print header
+	fmt.Printf("  %s  (base: %s)\n\n", s.StackID, s.Base)
+
+	// Print each node
+	needsSync := []string{}
+	for i, node := range s.Nodes {
+		icon := "●"
+		status := node.Status
+
+		// Update status from GitHub if available
+		if pr, ok := prMap[node.Branch]; ok {
+			node.PR = pr.Number
+			switch strings.ToUpper(pr.State) {
+			case "MERGED":
+				status = "merged"
+				icon = "✓"
+			case "CLOSED":
+				status = "closed"
+				icon = "✗"
+			default:
+				status = "open"
+			}
+		}
+
+		// Check sync state
+		syncStatus := ""
+		parent := s.Base
+		if i > 0 {
+			parent = s.Nodes[i-1].Branch
+		}
+
+		if status != "merged" && status != "closed" {
+			// Check if parent has commits this branch hasn't seen
+			if node.BaseTip != "" {
+				currentParentTip, err := gitpkg.RevParse(parent)
+				if err == nil && currentParentTip != node.BaseTip {
+					syncStatus = "needs sync"
+					needsSync = append(needsSync, node.Branch)
+				} else {
+					syncStatus = "in sync"
+				}
+			}
+
+			// Count commits ahead
+			count, err := gitpkg.CommitCount(parent, node.Branch)
+			if err == nil && count != "0" {
+				syncStatus = count + " commits ahead, " + syncStatus
+			}
+		}
+
+		// Format the line
+		marker := " "
+		if node.Branch == currentBranch {
+			marker = "→"
+		}
+
+		prInfo := ""
+		if node.PR > 0 {
+			prInfo = fmt.Sprintf("PR #%-4d", node.PR)
+		} else {
+			prInfo = "        "
+		}
+
+		statusStr := fmt.Sprintf("%-8s", status)
+		syncStr := ""
+		if syncStatus != "" {
+			syncStr = "  " + syncStatus
+		}
+
+		fmt.Printf(" %s %s  %-30s %s %s%s\n", marker, icon, node.Branch, prInfo, statusStr, syncStr)
+	}
+
+	// Print sync suggestion
+	if len(needsSync) > 0 {
+		fmt.Println()
+		fmt.Printf("  run `sdf sync` to rebase %s\n", strings.Join(needsSync, ", "))
+	}
+
+	return nil
+}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -1,0 +1,310 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	claudepkg "github.com/pavelpascari/sdf/internal/claude"
+	ctxpkg "github.com/pavelpascari/sdf/internal/context"
+	gitpkg "github.com/pavelpascari/sdf/internal/git"
+	ghpkg "github.com/pavelpascari/sdf/internal/gh"
+	"github.com/pavelpascari/sdf/internal/stack"
+)
+
+func RunSync(args []string) error {
+	root, err := stack.FindRoot()
+	if err != nil {
+		return err
+	}
+
+	s, err := stack.Load(root)
+	if err != nil {
+		return err
+	}
+
+	if len(s.Nodes) == 0 {
+		fmt.Println("No branches in stack. Nothing to sync.")
+		return nil
+	}
+
+	// Check for clean working tree
+	clean, err := gitpkg.IsClean()
+	if err != nil {
+		return fmt.Errorf("cannot check working tree status: %w", err)
+	}
+	if !clean {
+		return fmt.Errorf("working tree is not clean — commit or stash changes before syncing")
+	}
+
+	// Remember current branch to restore later
+	originalBranch, err := gitpkg.CurrentBranch()
+	if err != nil {
+		return fmt.Errorf("cannot determine current branch: %w", err)
+	}
+
+	// Fetch latest from origin
+	fmt.Println("Fetching from origin...")
+	if err := gitpkg.FetchAll(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: fetch failed: %v\n", err)
+	}
+
+	// Poll PR states from GitHub
+	if ghpkg.Available() {
+		branches := make([]string, len(s.Nodes))
+		for i, n := range s.Nodes {
+			branches[i] = n.Branch
+		}
+
+		prs, err := ghpkg.PRList(branches)
+		if err == nil {
+			for _, pr := range prs {
+				node := s.FindNode(pr.HeadRefName)
+				if node != nil {
+					node.PR = pr.Number
+					if strings.ToUpper(pr.State) == "MERGED" {
+						node.Status = "merged"
+					}
+				}
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "warning: could not poll PR states: %v\n", err)
+		}
+	}
+
+	// Process merged nodes and cascade rebases
+	modified := false
+	for i := 0; i < len(s.Nodes); i++ {
+		node := &s.Nodes[i]
+
+		if node.Status == "merged" {
+			// This node is merged — the next node needs to rebase
+			fmt.Printf("  ✓ %s is merged\n", node.Branch)
+
+			// If there's a next node, rebase it
+			if i+1 < len(s.Nodes) {
+				next := &s.Nodes[i+1]
+				newBase := s.Base
+
+				// The new base for the node after a merged node is the stack base
+				// (since the merged node's commits are now in the base)
+				fmt.Printf("  → rebasing %s onto %s...\n", next.Branch, newBase)
+
+				oldBase := node.Branch
+				if err := gitpkg.RebaseOnto(newBase, oldBase, next.Branch); err != nil {
+					// Rebase conflict
+					if err := handleConflict(root, s, next.Branch, err); err != nil {
+						// Restore original branch on failure
+						gitpkg.Checkout(originalBranch)
+						return fmt.Errorf("rebase of %s failed: %w", next.Branch, err)
+					}
+				}
+
+				// Update base tip
+				newTip, _ := gitpkg.RevParse(newBase)
+				next.BaseTip = newTip
+
+				// Push the rebased branch
+				fmt.Printf("  → pushing %s...\n", next.Branch)
+				if err := gitpkg.Push(next.Branch); err != nil {
+					fmt.Fprintf(os.Stderr, "  warning: push failed for %s: %v\n", next.Branch, err)
+				}
+
+				// Update PR base in GitHub
+				if next.PR > 0 && ghpkg.Available() {
+					fmt.Printf("  → updating PR #%d base to %s\n", next.PR, newBase)
+					if err := ghpkg.PREditBase(next.PR, newBase); err != nil {
+						fmt.Fprintf(os.Stderr, "  warning: could not update PR base: %v\n", err)
+					}
+				}
+			}
+
+			// Remove the merged node
+			s.Nodes = append(s.Nodes[:i], s.Nodes[i+1:]...)
+			i-- // Adjust index after removal
+			modified = true
+			continue
+		}
+
+		// Check if this non-merged node needs rebasing onto its parent
+		parent := s.Base
+		if i > 0 {
+			parent = s.Nodes[i-1].Branch
+		}
+
+		currentParentTip, err := gitpkg.RevParse(parent)
+		if err != nil {
+			continue
+		}
+
+		if node.BaseTip != "" && currentParentTip != node.BaseTip {
+			fmt.Printf("  → rebasing %s onto updated %s...\n", node.Branch, parent)
+
+			if err := gitpkg.RebaseOnto(parent, node.BaseTip, node.Branch); err != nil {
+				if err := handleConflict(root, s, node.Branch, err); err != nil {
+					gitpkg.Checkout(originalBranch)
+					return fmt.Errorf("rebase of %s failed: %w", node.Branch, err)
+				}
+			}
+
+			node.BaseTip = currentParentTip
+			modified = true
+
+			// Push the rebased branch
+			fmt.Printf("  → pushing %s...\n", node.Branch)
+			if err := gitpkg.Push(node.Branch); err != nil {
+				fmt.Fprintf(os.Stderr, "  warning: push failed for %s: %v\n", node.Branch, err)
+			}
+
+			// Update PR base if needed
+			if node.PR > 0 && ghpkg.Available() {
+				fmt.Printf("  → updating PR #%d base to %s\n", node.PR, parent)
+				if err := ghpkg.PREditBase(node.PR, parent); err != nil {
+					fmt.Fprintf(os.Stderr, "  warning: could not update PR base: %v\n", err)
+				}
+			}
+		}
+	}
+
+	if modified {
+		// Save updated stack
+		if err := stack.Save(root, s); err != nil {
+			return fmt.Errorf("cannot save stack: %w", err)
+		}
+
+		// Commit the updated stack.json
+		if err := gitpkg.Add(".sdf/stack.json"); err == nil {
+			gitpkg.Commit("sdf: update stack after sync")
+		}
+
+		fmt.Println("\nSync complete. Stack updated.")
+	} else {
+		fmt.Println("\nEverything is in sync.")
+	}
+
+	// Restore original branch
+	gitpkg.Checkout(originalBranch)
+
+	return nil
+}
+
+func handleConflict(root string, s *stack.Stack, branch string, rebaseErr error) error {
+	conflicted, err := gitpkg.ConflictedFiles()
+	if err != nil || len(conflicted) == 0 {
+		// Not a conflict, just a regular error
+		gitpkg.RebaseAbort()
+		return rebaseErr
+	}
+
+	fmt.Printf("  ⚠ Conflict in %s — %d file(s)\n", branch, len(conflicted))
+
+	// Try Claude resolution if available
+	if claudepkg.Available() {
+		fmt.Println("  → invoking Claude for conflict resolution...")
+
+		stackCtx, _ := ctxpkg.Assemble(root, s, branch)
+		parent := s.ParentBranch(branch)
+		upstreamSummary, _ := gitpkg.DiffSummary(s.FindNode(branch).BaseTip, parent)
+
+		branchCtx, _ := ctxpkg.Read(root, branch)
+
+		conflictContents := make(map[string]string)
+		for _, f := range conflicted {
+			data, err := os.ReadFile(f)
+			if err == nil {
+				conflictContents[f] = string(data)
+			}
+		}
+
+		prompt := ctxpkg.BuildConflictPrompt(stackCtx, upstreamSummary, branchCtx, conflictContents)
+		sessionName := claudepkg.SanitizeSessionName("conflict", branch)
+
+		output, err := claudepkg.RunPrompt(sessionName, prompt)
+		if err == nil {
+			if err := applyResolutions(output, conflicted); err == nil {
+				if err := gitpkg.Add("."); err == nil {
+					if err := gitpkg.RebaseContinue(); err == nil {
+						fmt.Println("  ✓ Conflicts resolved by Claude")
+						return nil
+					}
+				}
+			}
+		}
+		fmt.Fprintf(os.Stderr, "  Claude resolution failed, falling back to manual resolution\n")
+	}
+
+	// Fall back: abort rebase and tell user
+	gitpkg.RebaseAbort()
+	return fmt.Errorf("conflicts in %s — resolve manually and run `sdf sync` again:\n  %s",
+		branch, strings.Join(conflicted, "\n  "))
+}
+
+// applyResolutions parses Claude's output for fenced code blocks and writes
+// the resolved content to the conflicted files.
+func applyResolutions(output string, conflicted []string) error {
+	// Parse fenced code blocks: ```<lang> <filename>
+	lines := strings.Split(output, "\n")
+	var currentFile string
+	var content strings.Builder
+	inBlock := false
+
+	resolved := make(map[string]string)
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "```") && !inBlock {
+			// Opening fence — extract filename
+			parts := strings.Fields(strings.TrimPrefix(line, "```"))
+			if len(parts) >= 2 {
+				currentFile = parts[len(parts)-1]
+				content.Reset()
+				inBlock = true
+			} else if len(parts) == 1 {
+				// Could be just the filename
+				currentFile = parts[0]
+				content.Reset()
+				inBlock = true
+			}
+			continue
+		}
+		if line == "```" && inBlock {
+			if currentFile != "" {
+				resolved[currentFile] = content.String()
+			}
+			inBlock = false
+			currentFile = ""
+			continue
+		}
+		if inBlock {
+			if content.Len() > 0 {
+				content.WriteString("\n")
+			}
+			content.WriteString(line)
+		}
+	}
+
+	if len(resolved) == 0 {
+		return fmt.Errorf("no resolved files found in Claude output")
+	}
+
+	for _, f := range conflicted {
+		resolvedContent, ok := resolved[f]
+		if !ok {
+			// Try matching by basename
+			for key, val := range resolved {
+				if strings.HasSuffix(f, key) || strings.HasSuffix(key, f) {
+					resolvedContent = val
+					ok = true
+					break
+				}
+			}
+		}
+		if !ok {
+			return fmt.Errorf("no resolution found for %s", f)
+		}
+		if err := os.WriteFile(f, []byte(resolvedContent+"\n"), 0644); err != nil {
+			return fmt.Errorf("cannot write resolved file %s: %w", f, err)
+		}
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/pavelpascari/sdf
+
+go 1.24.7

--- a/internal/claude/claude.go
+++ b/internal/claude/claude.go
@@ -1,0 +1,45 @@
+// Package claude provides shell-out helpers for the Claude CLI.
+package claude
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Available returns true if the claude CLI is installed and accessible.
+func Available() bool {
+	_, err := exec.LookPath("claude")
+	return err == nil
+}
+
+// Version returns the claude CLI version string.
+func Version() (string, error) {
+	cmd := exec.Command("claude", "--version")
+	out, err := cmd.CombinedOutput()
+	output := strings.TrimSpace(string(out))
+	if err != nil {
+		return output, fmt.Errorf("claude --version: %s", output)
+	}
+	return output, nil
+}
+
+// RunPrompt sends a prompt to Claude with a deterministic session name
+// and returns the response.
+func RunPrompt(sessionName, prompt string) (string, error) {
+	cmd := exec.Command("claude", "--session", sessionName, "-p", prompt)
+	out, err := cmd.CombinedOutput()
+	output := strings.TrimSpace(string(out))
+	if err != nil {
+		return output, fmt.Errorf("claude session %s: %s", sessionName, output)
+	}
+	return output, nil
+}
+
+// SanitizeSessionName produces a safe session name from a branch name.
+func SanitizeSessionName(prefix, branch string) string {
+	name := prefix + "-" + branch
+	name = strings.ReplaceAll(name, "/", "-")
+	name = strings.ReplaceAll(name, " ", "-")
+	return name
+}

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -1,0 +1,132 @@
+// Package context manages context documents for stack branches.
+package context
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pavelpascari/sdf/internal/stack"
+)
+
+// contextDir returns the path to the context directory.
+func contextDir(root string) string {
+	return filepath.Join(root, stack.SDFDir, "context")
+}
+
+// DocPath returns the path to the context document for a branch.
+func DocPath(root, branch string) string {
+	// Replace slashes in branch names with directory separators
+	return filepath.Join(contextDir(root), branch+".md")
+}
+
+// CreateStub creates a stub context document for a new branch.
+func CreateStub(root, branch, parentBranch string) error {
+	path := DocPath(root, branch)
+
+	// Ensure parent directory exists (for branches like "auth/db-schema")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("cannot create context directory: %w", err)
+	}
+
+	stub := fmt.Sprintf(`# %s
+
+## Intent
+<!-- Describe the purpose of this branch -->
+
+## Constraints from upstream
+<!-- What does this branch depend on from %s? -->
+
+## Decisions made here
+<!-- Key design decisions in this branch -->
+
+## Open questions / known debt
+<!-- Anything unresolved -->
+`, branch, parentBranch)
+
+	return os.WriteFile(path, []byte(stub), 0644)
+}
+
+// Read returns the content of a branch's context document.
+func Read(root, branch string) (string, error) {
+	path := DocPath(root, branch)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("cannot read context doc %s: %w", path, err)
+	}
+	return string(data), nil
+}
+
+// Exists returns true if a context document exists for the branch.
+func Exists(root, branch string) bool {
+	_, err := os.Stat(DocPath(root, branch))
+	return err == nil
+}
+
+// Assemble walks the stack from base to the given branch and concatenates
+// all ancestor context docs, producing a unified view.
+func Assemble(root string, s *stack.Stack, branch string) (string, error) {
+	idx := s.NodeIndex(branch)
+	if idx < 0 {
+		return "", fmt.Errorf("branch %s not found in stack", branch)
+	}
+
+	var parts []string
+	for i := 0; i <= idx; i++ {
+		node := s.Nodes[i]
+		content, err := Read(root, node.Branch)
+		if err != nil {
+			return "", err
+		}
+		if content == "" {
+			continue
+		}
+
+		marker := ""
+		if node.Branch == branch {
+			marker = " ← current"
+		}
+
+		part := fmt.Sprintf("[%s%s]\n%s", node.Branch, marker, content)
+		parts = append(parts, part)
+	}
+
+	header := fmt.Sprintf("=== STACK: %s ===\n\n", s.StackID)
+	return header + strings.Join(parts, "\n---\n\n"), nil
+}
+
+// BuildConflictPrompt constructs the conflict resolution prompt for Claude.
+func BuildConflictPrompt(stackContext, upstreamSummary, branchIntent string, conflictedFiles map[string]string) string {
+	var b strings.Builder
+
+	b.WriteString("You are resolving conflicts during a stack rebase.\n\n")
+	b.WriteString("=== STACK CONTEXT ===\n")
+	b.WriteString(stackContext)
+	b.WriteString("\n\n")
+
+	if upstreamSummary != "" {
+		b.WriteString("=== UPSTREAM CHANGE SUMMARY ===\n")
+		b.WriteString(upstreamSummary)
+		b.WriteString("\n\n")
+	}
+
+	if branchIntent != "" {
+		b.WriteString("=== CURRENT BRANCH INTENT ===\n")
+		b.WriteString(branchIntent)
+		b.WriteString("\n\n")
+	}
+
+	b.WriteString("=== CONFLICTS ===\n")
+	for filename, content := range conflictedFiles {
+		fmt.Fprintf(&b, "File: %s\n```\n%s\n```\n\n", filename, content)
+	}
+
+	b.WriteString("Resolve all conflicts. For each file output the complete resolved content in a\n")
+	b.WriteString("fenced code block with the filename: ```<lang> <filename>\n")
+
+	return b.String()
+}

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -1,0 +1,109 @@
+// Package gh provides shell-out helpers for the GitHub CLI (gh).
+package gh
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// PRInfo represents pull request information from gh.
+type PRInfo struct {
+	Number        int    `json:"number"`
+	HeadRefName   string `json:"headRefName"`
+	State         string `json:"state"`         // "OPEN", "MERGED", "CLOSED"
+	BaseRefName   string `json:"baseRefName"`
+	URL           string `json:"url"`
+	MergeCommit   string `json:"mergeCommit"`
+	StatusChecks  string `json:"statusCheckRollup"`
+}
+
+// run executes a gh command and returns its trimmed stdout.
+func run(args ...string) (string, error) {
+	cmd := exec.Command("gh", args...)
+	out, err := cmd.CombinedOutput()
+	output := strings.TrimSpace(string(out))
+	if err != nil {
+		return output, fmt.Errorf("gh %s: %s", strings.Join(args, " "), output)
+	}
+	return output, nil
+}
+
+// Available returns true if the gh CLI is installed and accessible.
+func Available() bool {
+	_, err := exec.LookPath("gh")
+	return err == nil
+}
+
+// Version returns the gh CLI version string.
+func Version() (string, error) {
+	return run("version")
+}
+
+// PRList returns PR information for the given branches.
+func PRList(branches []string) ([]PRInfo, error) {
+	out, err := run("pr", "list",
+		"--state", "all",
+		"--json", "number,headRefName,state,baseRefName,url",
+		"--limit", "100",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var prs []PRInfo
+	if err := json.Unmarshal([]byte(out), &prs); err != nil {
+		return nil, fmt.Errorf("cannot parse gh pr list output: %w", err)
+	}
+
+	// Filter to only branches we care about
+	branchSet := make(map[string]bool)
+	for _, b := range branches {
+		branchSet[b] = true
+	}
+
+	var filtered []PRInfo
+	for _, pr := range prs {
+		if branchSet[pr.HeadRefName] {
+			filtered = append(filtered, pr)
+		}
+	}
+
+	return filtered, nil
+}
+
+// PRCreate creates a PR with the given parameters.
+func PRCreate(title, body, base, head string) (string, error) {
+	args := []string{"pr", "create",
+		"--title", title,
+		"--body", body,
+		"--head", head,
+	}
+	if base != "" {
+		args = append(args, "--base", base)
+	}
+	return run(args...)
+}
+
+// PREditBase updates the base branch of a PR.
+func PREditBase(prNumber int, newBase string) error {
+	_, err := run("pr", "edit", fmt.Sprintf("%d", prNumber), "--base", newBase)
+	return err
+}
+
+// PRView returns PR info for a specific branch.
+func PRView(branch string) (*PRInfo, error) {
+	out, err := run("pr", "view", branch,
+		"--json", "number,headRefName,state,baseRefName,url",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var pr PRInfo
+	if err := json.Unmarshal([]byte(out), &pr); err != nil {
+		return nil, fmt.Errorf("cannot parse gh pr view output: %w", err)
+	}
+	return &pr, nil
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,0 +1,152 @@
+// Package git provides shell-out helpers for git operations.
+package git
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// run executes a git command and returns its trimmed stdout.
+func run(args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	out, err := cmd.CombinedOutput()
+	output := strings.TrimSpace(string(out))
+	if err != nil {
+		return output, fmt.Errorf("git %s: %s", strings.Join(args, " "), output)
+	}
+	return output, nil
+}
+
+// CurrentBranch returns the current checked-out branch name.
+func CurrentBranch() (string, error) {
+	return run("rev-parse", "--abbrev-ref", "HEAD")
+}
+
+// RepoRoot returns the top-level directory of the git repository.
+func RepoRoot() (string, error) {
+	return run("rev-parse", "--show-toplevel")
+}
+
+// IsClean returns true if the working tree has no uncommitted changes.
+func IsClean() (bool, error) {
+	out, err := run("status", "--porcelain")
+	if err != nil {
+		return false, err
+	}
+	return out == "", nil
+}
+
+// CreateBranch creates a new branch from the current HEAD.
+func CreateBranch(name string) error {
+	_, err := run("checkout", "-b", name)
+	return err
+}
+
+// Checkout switches to the given branch.
+func Checkout(branch string) error {
+	_, err := run("checkout", branch)
+	return err
+}
+
+// Push pushes a branch to origin, with force-with-lease for safety.
+func Push(branch string) error {
+	_, err := run("push", "--force-with-lease", "origin", branch)
+	return err
+}
+
+// PushNew pushes a new branch to origin and sets up tracking.
+func PushNew(branch string) error {
+	_, err := run("push", "-u", "origin", branch)
+	return err
+}
+
+// FetchAll fetches from origin.
+func FetchAll() error {
+	_, err := run("fetch", "origin")
+	return err
+}
+
+// RevParse returns the SHA for a given ref.
+func RevParse(ref string) (string, error) {
+	return run("rev-parse", ref)
+}
+
+// RebaseOnto performs: git rebase --onto <newBase> <oldBase> <branch>
+func RebaseOnto(newBase, oldBase, branch string) error {
+	_, err := run("rebase", "--onto", newBase, oldBase, branch)
+	return err
+}
+
+// RebaseAbort aborts an in-progress rebase.
+func RebaseAbort() error {
+	_, err := run("rebase", "--abort")
+	return err
+}
+
+// RebaseContinue continues a rebase after conflicts are resolved.
+func RebaseContinue() error {
+	cmd := exec.Command("git", "rebase", "--continue")
+	cmd.Env = append(cmd.Environ(), "GIT_EDITOR=true")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git rebase --continue: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// ConflictedFiles returns the list of files with merge conflicts.
+func ConflictedFiles() ([]string, error) {
+	out, err := run("diff", "--name-only", "--diff-filter=U")
+	if err != nil {
+		return nil, err
+	}
+	if out == "" {
+		return nil, nil
+	}
+	return strings.Split(out, "\n"), nil
+}
+
+// Add stages files.
+func Add(paths ...string) error {
+	args := append([]string{"add"}, paths...)
+	_, err := run(args...)
+	return err
+}
+
+// Commit creates a commit with the given message.
+func Commit(message string) error {
+	_, err := run("commit", "-m", message)
+	return err
+}
+
+// DiffSummary returns a short summary of changes between two refs.
+func DiffSummary(from, to string) (string, error) {
+	return run("diff", "--stat", from+".."+to)
+}
+
+// DiffFull returns the full diff between two refs.
+func DiffFull(from, to string) (string, error) {
+	return run("diff", from+".."+to)
+}
+
+// Log returns the oneline log between two refs.
+func Log(from, to string) (string, error) {
+	return run("log", "--oneline", from+".."+to)
+}
+
+// MergeBase returns the merge base between two refs.
+func MergeBase(a, b string) (string, error) {
+	return run("merge-base", a, b)
+}
+
+// BranchExists returns true if the branch exists locally.
+func BranchExists(branch string) bool {
+	_, err := run("rev-parse", "--verify", branch)
+	return err == nil
+}
+
+// CommitCount returns the number of commits between two refs.
+func CommitCount(from, to string) (string, error) {
+	return run("rev-list", "--count", from+".."+to)
+}

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -1,0 +1,139 @@
+// Package stack manages the .sdf/stack.json file and stack topology.
+package stack
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Node represents a single branch in the stack.
+type Node struct {
+	Branch  string `json:"branch"`
+	PR      int    `json:"pr,omitempty"`
+	Status  string `json:"status"` // "open", "merged", "draft"
+	BaseTip string `json:"base_tip,omitempty"`
+}
+
+// Stack represents the full stack topology persisted in stack.json.
+type Stack struct {
+	StackID string `json:"stack_id"`
+	Base    string `json:"base"`
+	Nodes   []Node `json:"nodes"`
+}
+
+// SDFDir is the name of the sdf metadata directory.
+const SDFDir = ".sdf"
+
+// StackFile is the filename for the stack topology.
+const StackFile = "stack.json"
+
+// LocalFile is the filename for ephemeral local state.
+const LocalFile = "local.json"
+
+// FindRoot walks up from the current directory to find the repo root
+// containing a .sdf directory.
+func FindRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine working directory: %w", err)
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, SDFDir, StackFile)); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errors.New("not inside an sdf stack (no .sdf/stack.json found)")
+		}
+		dir = parent
+	}
+}
+
+// Load reads the stack from the .sdf/stack.json in the given repo root.
+func Load(root string) (*Stack, error) {
+	path := filepath.Join(root, SDFDir, StackFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read %s: %w", path, err)
+	}
+	var s Stack
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("cannot parse %s: %w", path, err)
+	}
+	return &s, nil
+}
+
+// Save writes the stack back to .sdf/stack.json.
+func Save(root string, s *Stack) error {
+	path := filepath.Join(root, SDFDir, StackFile)
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("cannot marshal stack: %w", err)
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0644)
+}
+
+// FindNode returns the node for the given branch name, or nil.
+func (s *Stack) FindNode(branch string) *Node {
+	for i := range s.Nodes {
+		if s.Nodes[i].Branch == branch {
+			return &s.Nodes[i]
+		}
+	}
+	return nil
+}
+
+// NodeIndex returns the index of the node for the given branch, or -1.
+func (s *Stack) NodeIndex(branch string) int {
+	for i, n := range s.Nodes {
+		if n.Branch == branch {
+			return i
+		}
+	}
+	return -1
+}
+
+// ParentBranch returns the branch that the given branch is based on.
+// For the first node, this is the stack base (e.g. "main").
+func (s *Stack) ParentBranch(branch string) string {
+	idx := s.NodeIndex(branch)
+	if idx <= 0 {
+		return s.Base
+	}
+	return s.Nodes[idx-1].Branch
+}
+
+// Init creates the .sdf directory and writes an initial stack.json.
+func Init(root, stackID, base string) error {
+	sdfDir := filepath.Join(root, SDFDir)
+	if err := os.MkdirAll(sdfDir, 0755); err != nil {
+		return fmt.Errorf("cannot create %s: %w", sdfDir, err)
+	}
+
+	contextDir := filepath.Join(sdfDir, "context")
+	if err := os.MkdirAll(contextDir, 0755); err != nil {
+		return fmt.Errorf("cannot create %s: %w", contextDir, err)
+	}
+
+	s := &Stack{
+		StackID: stackID,
+		Base:    base,
+		Nodes:   []Node{},
+	}
+	if err := Save(root, s); err != nil {
+		return err
+	}
+
+	// Create .sdf/local.json (gitignored)
+	localPath := filepath.Join(sdfDir, LocalFile)
+	if err := os.WriteFile(localPath, []byte("{}\n"), 0644); err != nil {
+		return fmt.Errorf("cannot create %s: %w", localPath, err)
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/pavelpascari/sdf/cmd"
+)
+
+// version is set at build time via -ldflags.
+var version = "dev"
+
+func main() {
+	if len(os.Args) < 2 {
+		printUsage()
+		os.Exit(1)
+	}
+
+	command := os.Args[1]
+	args := os.Args[2:]
+
+	switch command {
+	case "init":
+		exitOnErr(cmd.RunInit(args))
+	case "branch":
+		exitOnErr(cmd.RunBranch(args))
+	case "status":
+		exitOnErr(cmd.RunStatus(args))
+	case "sync":
+		exitOnErr(cmd.RunSync(args))
+	case "pr":
+		exitOnErr(cmd.RunPR(args))
+	case "context":
+		exitOnErr(cmd.RunContext(args))
+	case "version", "--version", "-v":
+		fmt.Printf("sdf %s\n", version)
+	case "help", "--help", "-h":
+		printUsage()
+	case "doctor":
+		exitOnErr(runDoctor())
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n\n", command)
+		printUsage()
+		os.Exit(1)
+	}
+}
+
+func exitOnErr(err error) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func printUsage() {
+	fmt.Print(`sdf — Stacked Diffs Flow
+
+Usage:
+  sdf <command> [arguments]
+
+Stack commands:
+  init [--stack] <name>     Initialize a new stack in the current repo
+  branch <name>             Create a new branch in the stack
+  status                    Show stack topology and sync state
+  sync                      Detect merged PRs, cascade rebase, push
+  pr                        Create a GitHub PR for the current branch
+
+Context commands:
+  context show              Print assembled context for current branch
+  context edit              Open context doc in $EDITOR
+  context update            Ask Claude to rewrite context doc
+
+Other:
+  doctor                    Check that dependencies are available
+  version                   Print version
+  help                      Show this help
+`)
+}
+
+// runDoctor checks that all required dependencies are available.
+func runDoctor() error {
+	fmt.Println("sdf doctor — checking dependencies")
+	fmt.Println()
+	allOk := true
+
+	// git (required)
+	if path, err := exec.LookPath("git"); err != nil {
+		fmt.Println("  ✗ git        not found (required)")
+		allOk = false
+	} else {
+		ver := getVersion("git", "--version")
+		fmt.Printf("  ✓ git        %s (%s)\n", ver, path)
+	}
+
+	// gh (required for PR operations)
+	if path, err := exec.LookPath("gh"); err != nil {
+		fmt.Println("  ● gh         not found (needed for PR operations)")
+	} else {
+		ver := getVersion("gh", "version")
+		fmt.Printf("  ✓ gh         %s (%s)\n", ver, path)
+	}
+
+	// claude (optional, needed for context update and conflict resolution)
+	if path, err := exec.LookPath("claude"); err != nil {
+		fmt.Println("  ● claude     not found (needed for context update and conflict resolution)")
+	} else {
+		ver := getVersion("claude", "--version")
+		fmt.Printf("  ✓ claude     %s (%s)\n", ver, path)
+	}
+
+	fmt.Println()
+	if !allOk {
+		return fmt.Errorf("missing required dependencies")
+	}
+	fmt.Println("All required dependencies are available.")
+	return nil
+}
+
+func getVersion(name string, arg string) string {
+	cmd := exec.Command(name, arg)
+	out, err := cmd.Output()
+	if err != nil {
+		return "unknown"
+	}
+	// Take first line only
+	line := strings.Split(strings.TrimSpace(string(out)), "\n")[0]
+	return line
+}


### PR DESCRIPTION
Go binary with zero external dependencies that orchestrates git, gh,
and claude CLIs to manage stacked diffs.

Commands implemented:
- sdf init: initialize .sdf/ directory with stack.json
- sdf branch: create and register branches in the stack
- sdf status: display stack topology with PR and sync state
- sdf sync: cascade rebase on merged PRs with Claude conflict resolution
- sdf pr: create GitHub PRs with context doc as body
- sdf context show/edit/update: manage per-branch context documents
- sdf doctor: verify CLI dependencies are available

Cross-compilation via Makefile for linux/darwin/windows on amd64/arm64.

https://claude.ai/code/session_01DdVZ4YirdDa8HNKr8F3Lpo