### PR TITLE
Switch release pipeline to GoReleaser with Homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,18 +23,9 @@ jobs:
       - name: Run tests
         run: make test
 
-      - name: Build binaries
-        run: make dist
-
-      - name: Generate checksums
-        run: |
-          cd dist
-          sha256sum sdf-* > checksums.txt
-
-      - name: Create release
-        uses: softprops/action-gh-release@v2
+      - uses: goreleaser/goreleaser-action@v6
         with:
-          generate_release_notes: true
-          files: |
-            dist/sdf-*
-            dist/checksums.txt
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,48 @@
+version: 2
+
+builds:
+  - main: .
+    binary: sdf
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+    flags:
+      - -trimpath
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+
+brews:
+  - repository:
+      owner: pavelpascari
+      name: homebrew-tap
+    homepage: https://github.com/pavelpascari/sdf
+    description: Stacked Diffs Flow — manage chains of dependent PRs
+    license: MIT
+    install: |
+      bin.install "sdf"
+    test: |
+      system "#{bin}/sdf", "version"

--- a/README.md
+++ b/README.md
@@ -24,35 +24,37 @@ Run `sdf doctor` to verify all dependencies are available.
 
 ## Install
 
-### Download a binary (recommended)
+### Homebrew (macOS and Linux)
 
-Grab the latest release for your platform from [GitHub Releases](https://github.com/pavelpascari/sdf/releases/latest), or use curl:
+```sh
+brew install pavelpascari/tap/sdf
+```
+
+### Download a binary
+
+Grab the latest archive for your platform from [GitHub Releases](https://github.com/pavelpascari/sdf/releases/latest), or use curl:
 
 ```sh
 # macOS (Apple Silicon)
-curl -fsSL https://github.com/pavelpascari/sdf/releases/latest/download/sdf-darwin-arm64 -o sdf
-
+curl -fsSL https://github.com/pavelpascari/sdf/releases/latest/download/sdf-darwin-arm64.tar.gz | tar xz
 # macOS (Intel)
-curl -fsSL https://github.com/pavelpascari/sdf/releases/latest/download/sdf-darwin-amd64 -o sdf
-
+curl -fsSL https://github.com/pavelpascari/sdf/releases/latest/download/sdf-darwin-amd64.tar.gz | tar xz
 # Linux (x86_64)
-curl -fsSL https://github.com/pavelpascari/sdf/releases/latest/download/sdf-linux-amd64 -o sdf
-
+curl -fsSL https://github.com/pavelpascari/sdf/releases/latest/download/sdf-linux-amd64.tar.gz | tar xz
 # Linux (ARM)
-curl -fsSL https://github.com/pavelpascari/sdf/releases/latest/download/sdf-linux-arm64 -o sdf
+curl -fsSL https://github.com/pavelpascari/sdf/releases/latest/download/sdf-linux-arm64.tar.gz | tar xz
 ```
 
-Then make it executable and move it to your PATH:
+Then move the binary to your PATH:
 
 ```sh
-chmod +x sdf
 sudo mv sdf /usr/local/bin/
 ```
 
-Each release includes a `checksums.txt` file with SHA-256 hashes to verify your download:
+Each release includes a `checksums.txt` for verification:
 
 ```sh
-sha256sum --check checksums.txt
+curl -fsSL https://github.com/pavelpascari/sdf/releases/latest/download/checksums.txt | sha256sum --check --ignore-missing
 ```
 
 ### From source


### PR DESCRIPTION
- Add .goreleaser.yaml: cross-compiles linux/darwin/windows (amd64+arm64), produces tar.gz/zip archives with checksums, and publishes a Homebrew formula to pavelpascari/homebrew-tap
- Replace custom make dist + softprops/action-gh-release workflow with goreleaser/goreleaser-action@v6
- Update README install section: Homebrew as primary, curl from GitHub Releases as secondary, build-from-source as tertiary

To publish the first release:
  1. Create pavelpascari/homebrew-tap repo on GitHub
  2. git tag v0.1.0 && git push origin v0.1.0

https://claude.ai/code/session_01LyoejAwmkuJTy2zaPAEZKw