### PR TITLE
Add GitHub Actions workflow for creating release tags

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -1,0 +1,37 @@
+name: Create Release Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. 0.1.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate version format
+        run: |
+          if ! echo "${{ inputs.version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+            echo "::error::Invalid version format '${{ inputs.version }}'. Expected semver (e.g. 0.1.0)"
+            exit 1
+          fi
+
+      - name: Check tag does not already exist
+        run: |
+          if git rev-parse "v${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "::error::Tag v${{ inputs.version }} already exists"
+            exit 1
+          fi
+
+      - name: Create and push tag
+        run: |
+          git tag "v${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"


### PR DESCRIPTION
## Summary
This PR introduces a new GitHub Actions workflow that automates the creation and pushing of release tags with proper validation.

## Key Changes
- Added `.github/workflows/create-release-tag.yml` workflow file that:
  - Accepts a version input via `workflow_dispatch` for manual triggering
  - Validates the version follows semantic versioning format (e.g., `0.1.0`, `1.0.0-beta`)
  - Checks that the tag doesn't already exist before creation
  - Creates and pushes the git tag with `v` prefix to the repository

## Implementation Details
- The workflow uses `workflow_dispatch` to allow manual triggering with a required version parameter
- Version validation uses regex pattern to enforce semver format: `^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$`
- Pre-creation check prevents accidental duplicate tags
- Requires `contents: write` permission to create and push tags
- Runs on `ubuntu-latest` with minimal dependencies (only `actions/checkout@v4`)

https://claude.ai/code/session_01EUzN42RqaTMtQqn12g8ghs