### PR TITLE
Automate release workflow trigger on tag creation

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -35,3 +35,8 @@ jobs:
         run: |
           git tag "v${{ inputs.version }}"
           git push origin "v${{ inputs.version }}"
+
+      - name: Trigger release workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run release.yml --ref "v${{ inputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
This change automates the release workflow by triggering it immediately after a release tag is created, eliminating the need for manual workflow execution.

## Key Changes
- **create-release-tag.yml**: Added a step to automatically trigger the `release.yml` workflow after pushing the version tag using the GitHub CLI
- **release.yml**: Added `workflow_dispatch` trigger to allow manual workflow execution in addition to automatic tag-based triggers

## Implementation Details
- The new step uses `gh workflow run` with the `GH_TOKEN` secret to authenticate and trigger the release workflow
- The workflow is triggered with the specific tag reference (`--ref "v${{ inputs.version }}"`) to ensure the correct version is released
- The `workflow_dispatch` trigger enables flexibility for manual releases if needed, while the automated trigger handles the standard release flow

https://claude.ai/code/session_017GMHqQgAyr1FQdk42YgoUQ