### PR TITLE
Update GoReleaser configuration for v2 compatibility

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,11 +18,11 @@ builds:
       - arm64
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 checksum:
   name_template: checksums.txt
@@ -35,7 +35,7 @@ changelog:
       - "^test:"
       - "^ci:"
 
-brews:
+homebrew_casks:
   - repository:
       owner: pavelpascari
       name: homebrew-tap


### PR DESCRIPTION
## Summary
Updates the `.goreleaser.yaml` configuration file to be compatible with GoReleaser v2 by migrating deprecated configuration options to their new equivalents.

## Key Changes
- Changed `format` to `formats` (array syntax) in the archives section for both the default tar.gz format and Windows zip format override
- Renamed `brews` section to `homebrew_casks` to align with GoReleaser v2 naming conventions

## Details
These changes address breaking changes in GoReleaser v2:
- The archive format configuration now uses an array-based `formats` field instead of the singular `format` field
- The Homebrew configuration section has been renamed from `brews` to `homebrew_casks` for clarity and consistency with the tool's updated terminology

https://claude.ai/code/session_013By4eYerZWKbDgmqZmPms9