### PR TITLE
feat: add lightweight reconciliation during sync PR poll

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 
 	ghpkg "github.com/pavelpascari/sdf/internal/gh"
 	gitpkg "github.com/pavelpascari/sdf/internal/git"
@@ -62,7 +61,7 @@ func RunMerge(args []string) error {
 		fmt.Fprintf(os.Stderr, "warning: could not fast-forward %s: %v\n", s.Base, err)
 	}
 
-	refreshPRStates(s)
+	reconcileSyncPRStates(s)
 	stack.Save(root, s)
 
 	// Find head PR
@@ -149,33 +148,6 @@ func findHeadPR(s *stack.Stack) (*stack.Node, error) {
 		return node, nil
 	}
 	return nil, fmt.Errorf("all PRs in stack %q are merged", s.StackID)
-}
-
-// refreshPRStates fetches current PR states from GitHub and updates the stack.
-func refreshPRStates(s *stack.Stack) {
-	if !ghpkg.Available() {
-		return
-	}
-
-	branches := make([]string, len(s.Nodes))
-	for i, n := range s.Nodes {
-		branches[i] = n.Branch
-	}
-
-	prs, err := ghpkg.PRList(branches)
-	if err != nil {
-		return
-	}
-
-	for _, pr := range prs {
-		node := s.FindNode(pr.HeadRefName)
-		if node != nil {
-			node.PR = pr.Number
-			if strings.ToUpper(pr.State) == "MERGED" {
-				node.Status = "merged"
-			}
-		}
-	}
 }
 
 // findNextOpenNode returns the first open node after the given branch.

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -169,25 +169,7 @@ func runSyncFull(root, stackName string, skipConfirm, flagWithContent bool) erro
 	}
 
 	if ghpkg.Available() {
-		branches := make([]string, len(s.Nodes))
-		for i, n := range s.Nodes {
-			branches[i] = n.Branch
-		}
-
-		prs, err := ghpkg.PRList(branches)
-		if err == nil {
-			for _, pr := range prs {
-				node := s.FindNode(pr.HeadRefName)
-				if node != nil {
-					node.PR = pr.Number
-					if strings.ToUpper(pr.State) == "MERGED" {
-						node.Status = "merged"
-					}
-				}
-			}
-		} else {
-			fmt.Fprintf(os.Stderr, "warning: could not poll PR states: %v\n", err)
-		}
+		reconcileSyncPRStates(s)
 	}
 
 	// Load config for PR update settings
@@ -739,6 +721,57 @@ func (p *orderedPrinter) finish() {
 		if r != "" {
 			fmt.Println(r)
 		}
+	}
+}
+
+// reconcileSyncPRStates polls GitHub for PR states and applies lightweight
+// reconciliation. Routine changes (status/PR fills) are applied directly;
+// structural drift (base mismatches, missing PRs) triggers warnings.
+func reconcileSyncPRStates(s *stack.Stack) {
+	branches := make([]string, len(s.Nodes))
+	for i, n := range s.Nodes {
+		branches[i] = n.Branch
+	}
+
+	prs, err := ghpkg.PRList(branches)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not poll PR states: %v\n", err)
+		return
+	}
+
+	// Convert gh.PRInfo → stack.PRState
+	states := make([]stack.PRState, len(prs))
+	for i, pr := range prs {
+		states[i] = stack.PRState{
+			Number:      pr.Number,
+			HeadRefName: pr.HeadRefName,
+			BaseRefName: pr.BaseRefName,
+			State:       pr.State,
+		}
+	}
+
+	changes := stack.ReconcileFromPRs(s, states)
+
+	// Apply routine changes
+	for _, c := range changes {
+		if !c.Notable {
+			stack.ApplyRoutineChange(s, c)
+		}
+	}
+
+	// Print notable warnings
+	hasNotable := false
+	for _, c := range changes {
+		if c.Notable {
+			if !hasNotable {
+				fmt.Println()
+				hasNotable = true
+			}
+			fmt.Fprintf(os.Stderr, "  %s %s\n", ui.SymWarn, c.Detail)
+		}
+	}
+	if hasNotable {
+		fmt.Fprintf(os.Stderr, "\n  Run `sdf fetch` to reconcile structural changes.\n\n")
 	}
 }
 

--- a/internal/stack/reconcile.go
+++ b/internal/stack/reconcile.go
@@ -1,13 +1,27 @@
 package stack
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // ReconcileChange describes a single difference between local and discovered state.
 type ReconcileChange struct {
-	Kind    string // "status", "pr-number", "append", "insert", "remove", "reorder", "base-change"
-	Branch  string
-	Detail  string // human-readable, e.g. "PR #21: open → merged"
-	Notable bool   // true = ⚠ (needs attention), false = ✓ (routine)
+	Kind      string // "status", "pr-number", "append", "insert", "remove", "reorder", "base-change", "base-mismatch", "pr-missing"
+	Branch    string
+	Detail    string // human-readable, e.g. "PR #21: open → merged"
+	Notable   bool   // true = ⚠ (needs attention), false = ✓ (routine)
+	NewStatus string // populated for "status" changes (used by ApplyRoutineChange)
+	NewPR     int    // populated for "pr-number" changes (used by ApplyRoutineChange)
+}
+
+// PRState mirrors gh.PRInfo fields needed for lightweight reconciliation.
+// Avoids importing the gh package from the stack package.
+type PRState struct {
+	Number      int
+	HeadRefName string
+	BaseRefName string
+	State       string // "OPEN", "MERGED", "CLOSED"
 }
 
 // Reconcile compares local stack state against a discovered PR chain from GitHub
@@ -158,4 +172,106 @@ func ApplyChanges(s *Stack, discovered DiscoveredStack, changes []ReconcileChang
 // from context. Returns empty string if no status can be determined.
 func prStateToNodeStatus(pr PRRecord) string {
 	return pr.Status
+}
+
+// ReconcileFromPRs compares local stack state against PR data from GitHub.
+// Unlike Reconcile(), this works from per-branch PR info (as returned by
+// ghpkg.PRList) without requiring a full DiscoverStacks call.
+//
+// It detects routine changes (status updates, PR number fills) and
+// structural drift (base mismatches, missing PRs). Structural changes
+// that require full reconciliation emit notable warnings.
+func ReconcileFromPRs(s *Stack, prs []PRState) []ReconcileChange {
+	var changes []ReconcileChange
+
+	// Build lookup: branch → PRState
+	prByBranch := make(map[string]PRState)
+	for _, pr := range prs {
+		prByBranch[pr.HeadRefName] = pr
+	}
+
+	for i := range s.Nodes {
+		node := &s.Nodes[i]
+
+		pr, found := prByBranch[node.Branch]
+		if !found {
+			// Node has a PR locally but GitHub didn't return it
+			if node.PR > 0 {
+				changes = append(changes, ReconcileChange{
+					Kind:    "pr-missing",
+					Branch:  node.Branch,
+					Detail:  fmt.Sprintf("PR #%d (%s) not found on GitHub", node.PR, node.Branch),
+					Notable: true,
+				})
+			}
+			continue
+		}
+
+		// Status change
+		newStatus := ghStateToNodeStatus(pr.State)
+		if newStatus != "" && node.Status != newStatus {
+			changes = append(changes, ReconcileChange{
+				Kind:      "status",
+				Branch:    node.Branch,
+				Detail:    fmt.Sprintf("PR #%d: %s → %s", pr.Number, node.Status, newStatus),
+				Notable:   false,
+				NewStatus: newStatus,
+			})
+		}
+
+		// PR number fill
+		if node.PR == 0 && pr.Number != 0 {
+			changes = append(changes, ReconcileChange{
+				Kind:   "pr-number",
+				Branch: node.Branch,
+				Detail: fmt.Sprintf("%s: PR #%d discovered", node.Branch, pr.Number),
+				NewPR:  pr.Number,
+			})
+		}
+
+		// Base mismatch: check if GitHub's baseRefName matches expected parent
+		expectedParent := s.ParentBranch(node.Branch)
+		if pr.BaseRefName != "" && pr.BaseRefName != expectedParent {
+			changes = append(changes, ReconcileChange{
+				Kind:    "base-mismatch",
+				Branch:  node.Branch,
+				Detail:  fmt.Sprintf("PR #%d (%s) base is %s, expected %s", pr.Number, node.Branch, pr.BaseRefName, expectedParent),
+				Notable: true,
+			})
+		}
+	}
+
+	return changes
+}
+
+// ApplyRoutineChange applies a single non-notable change to the stack.
+func ApplyRoutineChange(s *Stack, c ReconcileChange) {
+	node := s.FindNode(c.Branch)
+	if node == nil {
+		return
+	}
+	switch c.Kind {
+	case "status":
+		if c.NewStatus != "" {
+			node.Status = c.NewStatus
+		}
+	case "pr-number":
+		if c.NewPR != 0 {
+			node.PR = c.NewPR
+		}
+	}
+}
+
+// ghStateToNodeStatus converts a GitHub PR state string to a node status.
+func ghStateToNodeStatus(state string) string {
+	switch strings.ToUpper(state) {
+	case "MERGED":
+		return "merged"
+	case "CLOSED":
+		return "closed"
+	case "OPEN":
+		return "open"
+	default:
+		return ""
+	}
 }

--- a/internal/stack/reconcile_test.go
+++ b/internal/stack/reconcile_test.go
@@ -298,6 +298,164 @@ func TestApplyChanges_BaseChange(t *testing.T) {
 	}
 }
 
+// --- ReconcileFromPRs tests ---
+
+func TestReconcileFromPRs_NoChange(t *testing.T) {
+	s := &Stack{
+		StackID: "test",
+		Base:    "main",
+		Nodes: []Node{
+			{Branch: "branchA", PR: 10, Status: "open"},
+			{Branch: "branchB", PR: 11, Status: "open"},
+		},
+	}
+	prs := []PRState{
+		{Number: 10, HeadRefName: "branchA", BaseRefName: "main", State: "OPEN"},
+		{Number: 11, HeadRefName: "branchB", BaseRefName: "branchA", State: "OPEN"},
+	}
+
+	changes := ReconcileFromPRs(s, prs)
+	if len(changes) != 0 {
+		t.Errorf("expected 0 changes, got %d: %v", len(changes), changes)
+	}
+}
+
+func TestReconcileFromPRs_StatusMerged(t *testing.T) {
+	s := &Stack{
+		StackID: "test",
+		Base:    "main",
+		Nodes: []Node{
+			{Branch: "branchA", PR: 10, Status: "open"},
+		},
+	}
+	prs := []PRState{
+		{Number: 10, HeadRefName: "branchA", BaseRefName: "main", State: "MERGED"},
+	}
+
+	changes := ReconcileFromPRs(s, prs)
+	assertHasChange(t, changes, "status", "branchA", false)
+	if changes[0].NewStatus != "merged" {
+		t.Errorf("expected NewStatus=merged, got %s", changes[0].NewStatus)
+	}
+}
+
+func TestReconcileFromPRs_StatusClosed(t *testing.T) {
+	s := &Stack{
+		StackID: "test",
+		Base:    "main",
+		Nodes: []Node{
+			{Branch: "branchA", PR: 10, Status: "open"},
+		},
+	}
+	prs := []PRState{
+		{Number: 10, HeadRefName: "branchA", BaseRefName: "main", State: "CLOSED"},
+	}
+
+	changes := ReconcileFromPRs(s, prs)
+	assertHasChange(t, changes, "status", "branchA", false)
+	if changes[0].NewStatus != "closed" {
+		t.Errorf("expected NewStatus=closed, got %s", changes[0].NewStatus)
+	}
+}
+
+func TestReconcileFromPRs_PRNumberFill(t *testing.T) {
+	s := &Stack{
+		StackID: "test",
+		Base:    "main",
+		Nodes: []Node{
+			{Branch: "branchA", PR: 0, Status: "open"},
+		},
+	}
+	prs := []PRState{
+		{Number: 10, HeadRefName: "branchA", BaseRefName: "main", State: "OPEN"},
+	}
+
+	changes := ReconcileFromPRs(s, prs)
+	assertHasChange(t, changes, "pr-number", "branchA", false)
+	if changes[0].NewPR != 10 {
+		t.Errorf("expected NewPR=10, got %d", changes[0].NewPR)
+	}
+}
+
+func TestReconcileFromPRs_BaseMismatch(t *testing.T) {
+	s := &Stack{
+		StackID: "test",
+		Base:    "main",
+		Nodes: []Node{
+			{Branch: "branchA", PR: 10, Status: "open"},
+			{Branch: "branchB", PR: 11, Status: "open"},
+		},
+	}
+	prs := []PRState{
+		{Number: 10, HeadRefName: "branchA", BaseRefName: "main", State: "OPEN"},
+		// branchB's base was retargeted to main on GitHub (expected: branchA)
+		{Number: 11, HeadRefName: "branchB", BaseRefName: "main", State: "OPEN"},
+	}
+
+	changes := ReconcileFromPRs(s, prs)
+	assertHasChange(t, changes, "base-mismatch", "branchB", true)
+}
+
+func TestReconcileFromPRs_PRMissing(t *testing.T) {
+	s := &Stack{
+		StackID: "test",
+		Base:    "main",
+		Nodes: []Node{
+			{Branch: "branchA", PR: 10, Status: "open"},
+			{Branch: "branchB", PR: 11, Status: "open"},
+		},
+	}
+	// Only branchA returned — branchB's PR is missing
+	prs := []PRState{
+		{Number: 10, HeadRefName: "branchA", BaseRefName: "main", State: "OPEN"},
+	}
+
+	changes := ReconcileFromPRs(s, prs)
+	assertHasChange(t, changes, "pr-missing", "branchB", true)
+}
+
+func TestReconcileFromPRs_Mixed(t *testing.T) {
+	s := &Stack{
+		StackID: "test",
+		Base:    "main",
+		Nodes: []Node{
+			{Branch: "branchA", PR: 10, Status: "open"},
+			{Branch: "branchB", PR: 11, Status: "open"},
+			{Branch: "branchC", PR: 12, Status: "open"},
+		},
+	}
+	prs := []PRState{
+		{Number: 10, HeadRefName: "branchA", BaseRefName: "main", State: "MERGED"},
+		// branchB retargeted to main (was branchA)
+		{Number: 11, HeadRefName: "branchB", BaseRefName: "main", State: "OPEN"},
+		{Number: 12, HeadRefName: "branchC", BaseRefName: "branchB", State: "OPEN"},
+	}
+
+	changes := ReconcileFromPRs(s, prs)
+	assertHasChange(t, changes, "status", "branchA", false)      // merged
+	assertHasChange(t, changes, "base-mismatch", "branchB", true) // retargeted
+}
+
+func TestApplyRoutineChange_Status(t *testing.T) {
+	s := &Stack{
+		Nodes: []Node{{Branch: "branchA", PR: 10, Status: "open"}},
+	}
+	ApplyRoutineChange(s, ReconcileChange{Kind: "status", Branch: "branchA", NewStatus: "merged"})
+	if s.Nodes[0].Status != "merged" {
+		t.Errorf("expected merged, got %s", s.Nodes[0].Status)
+	}
+}
+
+func TestApplyRoutineChange_PRNumber(t *testing.T) {
+	s := &Stack{
+		Nodes: []Node{{Branch: "branchA", PR: 0, Status: "open"}},
+	}
+	ApplyRoutineChange(s, ReconcileChange{Kind: "pr-number", Branch: "branchA", NewPR: 42})
+	if s.Nodes[0].PR != 42 {
+		t.Errorf("expected PR 42, got %d", s.Nodes[0].PR)
+	}
+}
+
 // assertHasChange verifies that changes contains a change with the given kind, branch, and notable flag.
 func assertHasChange(t *testing.T, changes []ReconcileChange, kind, branch string, notable bool) {
 	t.Helper()


### PR DESCRIPTION
Part of stack: **stack-resilience**

Base: `stack-resilience/reconcile`

<!-- sdf:stack-nav -->
---
Stack: `stack-resilience`
1. https://github.com/pavelpascari/sdf/pull/27
2. https://github.com/pavelpascari/sdf/pull/32
3. https://github.com/pavelpascari/sdf/pull/29 ◀ this PR
4. https://github.com/pavelpascari/sdf/pull/30
5. https://github.com/pavelpascari/sdf/pull/31
<!-- /sdf:stack-nav -->