### PR TITLE
Fix www deployment: replace deprecated Workers Sites config

### DIFF
--- a/www/wrangler.toml
+++ b/www/wrangler.toml
@@ -4,5 +4,5 @@ compatibility_date = "2024-01-01"
 [build]
 command = "npm run build"
 
-[site]
-bucket = "./dist"
+[assets]
+directory = "./dist"


### PR DESCRIPTION
## Summary
- Replace deprecated `[site]` config with `[assets]` in `wrangler.toml`
- Wrangler v4 dropped Workers Sites support, which required a `workers-site/index.js` entry point that doesn't exist in this Astro static site
- The `[assets]` directive serves static files directly without needing a worker script

## Test plan
- [ ] Verify Cloudflare deployment succeeds with the updated config
- [ ] Confirm the site loads correctly at the deployed URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)