### PR TITLE
Skip release checklist for patch versions

### DIFF
--- a/scripts/release-checklist.sh
+++ b/scripts/release-checklist.sh
@@ -27,6 +27,13 @@ else
   VERSION="${TAG#v}"
 fi
 
+# ── Skip patch releases (e.g. 1.2.3 where patch > 0) ─────────────────
+PATCH=$(echo "$VERSION" | cut -d. -f3 | cut -d- -f1)
+if [[ -n "$PATCH" && "$PATCH" -gt 0 ]]; then
+  echo "SKIP — v${VERSION} is a patch release; blog post not required."
+  exit 0
+fi
+
 echo "Checking release blog post for v${VERSION} ..."
 
 # ── Find a release blog post matching this version ──────────────────


### PR DESCRIPTION
Patch and fix releases (e.g. 1.2.3 where patch > 0) no longer require
a blog post. The release checklist now exits early with success for
patch versions, only enforcing blog post requirements for minor and
major releases.

https://claude.ai/code/session_011h1mbxnjqckGiFK5fWaDj9