### PR TITLE
Isolate spy recording behind spyrecord build tag

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,8 +36,8 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Build sdf
-        run: make build
+      - name: Build sdf (with spy recording)
+        run: make build-spy
 
       - name: Check E2E prerequisites
         run: |

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ BUILD    := go build -ldflags "$(LDFLAGS)" -trimpath
 build:
 	$(BUILD) -o bin/$(BINARY) .
 
+# Build with spy recording enabled (for E2E tests)
+.PHONY: build-spy
+build-spy:
+	$(BUILD) -tags spyrecord -o bin/$(BINARY) .
+
 # Run the binary
 .PHONY: run
 run: build
@@ -43,7 +48,7 @@ test-golden-update:
 
 # E2E tests against a real GitHub repo (requires SDF_E2E_REPO and GH_TOKEN)
 .PHONY: test-e2e
-test-e2e:
+test-e2e: build-spy
 	go test -tags e2e -v -count=1 -timeout 10m ./e2e/...
 
 # Run vet and static checks
@@ -102,6 +107,7 @@ install:
 help:
 	@echo "sdf build targets:"
 	@echo "  make build      Build for current platform → bin/sdf"
+	@echo "  make build-spy  Build with spy recording (for E2E tests)"
 	@echo "  make dist       Cross-compile for all platforms → dist/"
 	@echo "  make build-for OS=linux ARCH=arm64"
 	@echo "                  Build for a specific platform → bin/sdf-<os>-<arch>"

--- a/internal/claude/claude.go
+++ b/internal/claude/claude.go
@@ -9,25 +9,11 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-
-	"github.com/pavelpascari/sdf/internal/spy"
 )
 
 // Binary is the name (or path) of the claude executable.
 // Tests can override this to point at a fake binary.
 var Binary = "claude"
-
-// Spy, when non-nil, records every invocation for later analysis.
-// Enable during E2E tests to capture real Claude API responses.
-var Spy *spy.Recorder
-var fullSpy *spy.Recorder
-
-func init() {
-	if dir := os.Getenv("SDF_SPY_DIR"); dir != "" {
-		Spy = spy.NewRecorderFor(dir, "sdf", "claude")
-		fullSpy = spy.NewRecorder(dir, "full")
-	}
-}
 
 // Available returns true if the claude CLI is installed and accessible.
 func Available() bool {
@@ -53,14 +39,11 @@ func RunPrompt(sessionName, prompt string) (string, error) {
 	out, err := cmd.CombinedOutput()
 	output := strings.TrimSpace(string(out))
 
-	if Spy != nil {
-		exitCode := 0
-		if err != nil {
-			exitCode = 1
-		}
-		Spy.Record([]string{"-p", prompt}, output, exitCode)
-		fullSpy.RecordAs("sdf", "claude", []string{"-p", prompt}, output, exitCode)
+	exitCode := 0
+	if err != nil {
+		exitCode = 1
 	}
+	recordRun([]string{"-p", prompt}, output, exitCode)
 
 	if err != nil {
 		return output, fmt.Errorf("claude %s: %s", sessionName, output)

--- a/internal/claude/record_noop.go
+++ b/internal/claude/record_noop.go
@@ -1,0 +1,7 @@
+//go:build !spyrecord
+
+package claude
+
+// recordRun is a no-op in production builds.
+// With -tags spyrecord, the real implementation records invocations.
+func recordRun(args []string, output string, exitCode int) {}

--- a/internal/claude/record_spy.go
+++ b/internal/claude/record_spy.go
@@ -1,0 +1,26 @@
+//go:build spyrecord
+
+package claude
+
+import (
+	"os"
+
+	"github.com/pavelpascari/sdf/internal/spy"
+)
+
+var spyRec *spy.Recorder
+var fullSpy *spy.Recorder
+
+func init() {
+	if dir := os.Getenv("SDF_SPY_DIR"); dir != "" {
+		spyRec = spy.NewRecorderFor(dir, "sdf", "claude")
+		fullSpy = spy.NewRecorder(dir, "full")
+	}
+}
+
+func recordRun(args []string, output string, exitCode int) {
+	if spyRec != nil {
+		spyRec.Record(args, output, exitCode)
+		fullSpy.RecordAs("sdf", "claude", args, output, exitCode)
+	}
+}

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -4,21 +4,9 @@ package gh
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
-
-	"github.com/pavelpascari/sdf/internal/spy"
 )
-
-var fullSpy *spy.Recorder
-
-func init() {
-	if dir := os.Getenv("SDF_SPY_DIR"); dir != "" {
-		Spy = spy.NewRecorderFor(dir, "sdf", "gh")
-		fullSpy = spy.NewRecorder(dir, "full")
-	}
-}
 
 // PRInfo represents pull request information from gh.
 type PRInfo struct {
@@ -35,24 +23,17 @@ type PRInfo struct {
 // Tests can override this to point at a fake binary.
 var Binary = "gh"
 
-// Spy, when non-nil, records every invocation for later analysis.
-// Enable during E2E tests to capture real API responses.
-var Spy *spy.Recorder
-
 // run executes a gh command and returns its trimmed stdout.
 func run(args ...string) (string, error) {
 	cmd := exec.Command(Binary, args...)
 	out, err := cmd.CombinedOutput()
 	output := strings.TrimSpace(string(out))
 
-	if Spy != nil {
-		exitCode := 0
-		if err != nil {
-			exitCode = 1
-		}
-		Spy.Record(args, output, exitCode)
-		fullSpy.RecordAs("sdf", "gh", args, output, exitCode)
+	exitCode := 0
+	if err != nil {
+		exitCode = 1
 	}
+	recordRun(args, output, exitCode)
 
 	if err != nil {
 		return output, fmt.Errorf("gh %s: %s", strings.Join(args, " "), output)

--- a/internal/gh/record_noop.go
+++ b/internal/gh/record_noop.go
@@ -1,0 +1,7 @@
+//go:build !spyrecord
+
+package gh
+
+// recordRun is a no-op in production builds.
+// With -tags spyrecord, the real implementation records invocations.
+func recordRun(args []string, output string, exitCode int) {}

--- a/internal/gh/record_spy.go
+++ b/internal/gh/record_spy.go
@@ -1,0 +1,26 @@
+//go:build spyrecord
+
+package gh
+
+import (
+	"os"
+
+	"github.com/pavelpascari/sdf/internal/spy"
+)
+
+var spyRec *spy.Recorder
+var fullSpy *spy.Recorder
+
+func init() {
+	if dir := os.Getenv("SDF_SPY_DIR"); dir != "" {
+		spyRec = spy.NewRecorderFor(dir, "sdf", "gh")
+		fullSpy = spy.NewRecorder(dir, "full")
+	}
+}
+
+func recordRun(args []string, output string, exitCode int) {
+	if spyRec != nil {
+		spyRec.Record(args, output, exitCode)
+		fullSpy.RecordAs("sdf", "gh", args, output, exitCode)
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -7,25 +7,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-
-	"github.com/pavelpascari/sdf/internal/spy"
 )
 
 // Binary is the name (or path) of the git executable.
 // Tests can override this to point at a fake binary.
 var Binary = "git"
-
-// Spy, when non-nil, records every invocation for later analysis.
-// Enable during E2E tests to capture real git operations.
-var Spy *spy.Recorder
-var fullSpy *spy.Recorder
-
-func init() {
-	if dir := os.Getenv("SDF_SPY_DIR"); dir != "" {
-		Spy = spy.NewRecorderFor(dir, "sdf", "git")
-		fullSpy = spy.NewRecorder(dir, "full")
-	}
-}
 
 // run executes a git command and returns its trimmed stdout.
 func run(args ...string) (string, error) {
@@ -33,14 +19,11 @@ func run(args ...string) (string, error) {
 	out, err := cmd.CombinedOutput()
 	output := strings.TrimSpace(string(out))
 
-	if Spy != nil {
-		exitCode := 0
-		if err != nil {
-			exitCode = 1
-		}
-		Spy.Record(args, output, exitCode)
-		fullSpy.RecordAs("sdf", "git", args, output, exitCode)
+	exitCode := 0
+	if err != nil {
+		exitCode = 1
 	}
+	recordRun(args, output, exitCode)
 
 	if err != nil {
 		return output, fmt.Errorf("git %s: %s", strings.Join(args, " "), output)

--- a/internal/git/record_noop.go
+++ b/internal/git/record_noop.go
@@ -1,0 +1,7 @@
+//go:build !spyrecord
+
+package git
+
+// recordRun is a no-op in production builds.
+// With -tags spyrecord, the real implementation records invocations.
+func recordRun(args []string, output string, exitCode int) {}

--- a/internal/git/record_spy.go
+++ b/internal/git/record_spy.go
@@ -1,0 +1,26 @@
+//go:build spyrecord
+
+package git
+
+import (
+	"os"
+
+	"github.com/pavelpascari/sdf/internal/spy"
+)
+
+var spyRec *spy.Recorder
+var fullSpy *spy.Recorder
+
+func init() {
+	if dir := os.Getenv("SDF_SPY_DIR"); dir != "" {
+		spyRec = spy.NewRecorderFor(dir, "sdf", "git")
+		fullSpy = spy.NewRecorder(dir, "full")
+	}
+}
+
+func recordRun(args []string, output string, exitCode int) {
+	if spyRec != nil {
+		spyRec.Record(args, output, exitCode)
+		fullSpy.RecordAs("sdf", "git", args, output, exitCode)
+	}
+}

--- a/internal/testutil/fakebin.go
+++ b/internal/testutil/fakebin.go
@@ -8,8 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/pavelpascari/sdf/internal/spy"
 )
 
 // FakeBin creates a shell script at dir/<name> that logs its arguments
@@ -118,17 +116,3 @@ func SetBinary(t *testing.T, target *string, fakePath string) {
 	t.Cleanup(func() { *target = orig })
 }
 
-// SetSpy sets a package-level Spy variable and registers cleanup.
-// Usage:
-//
-//	rec := spy.NewRecorder(dir, "gh")
-//	SetSpy(t, &gh.Spy, rec)
-func SetSpy(t *testing.T, target **spy.Recorder, rec *spy.Recorder) {
-	t.Helper()
-	orig := *target
-	*target = rec
-	t.Cleanup(func() {
-		rec.Close()
-		*target = orig
-	})
-}


### PR DESCRIPTION
## Summary

- Moves spy recording infrastructure out of production code using Go build-tagged file pairs (`record_noop.go` / `record_spy.go`) per wrapper package (`git`, `gh`, `claude`)
- Production binary no longer imports `internal/spy`, declares spy variables, or runs `init()` checks — the empty `recordRun()` is inlined to nothing by the compiler
- Adds `make build-spy` target and updates E2E workflow to use it, since child `sdf` processes need `-tags spyrecord` for invocation recording

## Test plan

- [x] `go build ./...` — production build compiles without spy imports
- [x] `go build -tags spyrecord ./...` — spy-enabled build compiles
- [x] `go vet ./...` — no issues
- [x] `go test -count=1 ./...` — all unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)