### PR TITLE
Isolate spy recording behind spyrecord build tag

### DIFF
--- a/www/src/content/blog/testing-cli-tools-that-shell-out.mdx
+++ b/www/src/content/blog/testing-cli-tools-that-shell-out.mdx
@@ -175,25 +175,33 @@ graph TD
 Here's what a real test looks like with these two pieces combined:
 
 ```go
-func TestReconcilePRStates_FillsFromGitHub(t *testing.T) {
+func TestReconcileSyncPRStates_FillsFromGitHub(t *testing.T) {
     syncTestRepo(t) // sets up a temp git repo with branches
 
     dir := t.TempDir()
-    fake := testutil.FakeBin(t, dir, "gh", map[string]string{
+    fake := testutil.GHFakeBinWith(t, dir, map[string]string{
         "pr list": `[
-            {"number":10,"headRefName":"branchA","state":"OPEN"},
-            {"number":11,"headRefName":"branchB","state":"OPEN"},
-            {"number":12,"headRefName":"branchC","state":"OPEN"}
+            {"number":10,"headRefName":"branchA","state":"OPEN","baseRefName":"main","url":"https://github.com/test/pull/10"},
+            {"number":11,"headRefName":"branchB","state":"OPEN","baseRefName":"branchA","url":"https://github.com/test/pull/11"},
+            {"number":12,"headRefName":"branchC","state":"OPEN","baseRefName":"branchB","url":"https://github.com/test/pull/12"}
         ]`,
     })
     testutil.SetBinary(t, &ghpkg.Binary, fake)
 
-    s, _ := stack.Load(".")
+    s, err := stack.Load(".")
+    if err != nil {
+        t.Fatal(err)
+    }
     reconcileSyncPRStates(s)
 
     // Assert PRs were filled from the fake response
-    if s.Nodes[0].PR != 10 {
-        t.Errorf("expected PR #10, got #%d", s.Nodes[0].PR)
+    expected := map[string]int{
+        "branchA": 10, "branchB": 11, "branchC": 12,
+    }
+    for _, node := range s.Nodes {
+        if want, ok := expected[node.Branch]; ok && node.PR != want {
+            t.Errorf("expected PR #%d for %s, got #%d", want, node.Branch, node.PR)
+        }
     }
 
     // Assert gh was actually called
@@ -394,6 +402,10 @@ The key insight is **structural comparison, not value comparison**. We don't car
 
 ```go
 func JSONShape(s string) string {
+    s = strings.TrimSpace(s)
+    if len(s) == 0 {
+        return "empty"
+    }
     if s[0] == '[' {
         var arr []json.RawMessage
         json.Unmarshal([]byte(s), &arr)
@@ -405,7 +417,11 @@ func JSONShape(s string) string {
     if s[0] == '{' {
         var obj map[string]json.RawMessage
         json.Unmarshal([]byte(s), &obj)
-        keys := sortedKeys(obj)
+        keys := make([]string, 0, len(obj))
+        for k := range obj {
+            keys = append(keys, k)
+        }
+        sort.Strings(keys)
         return fmt.Sprintf("object{%s}", strings.Join(keys, ","))
     }
     return "scalar"
@@ -441,7 +457,11 @@ func recordRun(args []string, output string, exitCode int) {}
 
 package git
 
-import "github.com/pavelpascari/sdf/internal/spy"
+import (
+    "os"
+
+    "github.com/pavelpascari/sdf/internal/spy"
+)
 
 var spyRec *spy.Recorder
 var fullSpy *spy.Recorder


### PR DESCRIPTION
Move spy infrastructure out of production code using build-tagged file
pairs. Each wrapper package (git, gh, claude) now has record_noop.go
(empty no-op, compiled by default) and record_spy.go (real recording,
compiled only with -tags spyrecord). Production binary no longer
imports the spy package or runs init() checks.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>