### PR TITLE
ci: add workflow to auto-merge green dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -1,6 +1,8 @@
 name: Dependabot Auto-Merge
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: write
@@ -9,7 +11,9 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      (github.event.action != 'labeled' || github.event.label.name == 'auto-merge')
     steps:
       - name: Fetch Dependabot metadata
         id: metadata


### PR DESCRIPTION
Enables auto-merge (squash) for dependabot PRs that pass all required
CI checks, limited to minor and patch version updates. Major version
bumps still require manual review.

https://claude.ai/code/session_016mGK1sbfp2JDnnZb6MtuEv