### PR TITLE
Remove sdf context feature references

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`sdf` is a lightweight CLI tool that manages stacked diffs (chains of dependent PRs) in a Git repository. It handles branch topology, cascade rebasing when head PRs merge, and context continuity so Claude can reason across the full stack when resolving conflicts or continuing work.
+`sdf` is a lightweight CLI tool that manages stacked diffs (chains of dependent PRs) in a Git repository. It handles branch topology and cascade rebasing when head PRs merge.
 
 The tool is a thin orchestration layer over three CLIs that developers already have: `git`, `gh`, and `claude`. No external dependencies beyond the Go stdlib.
 
@@ -13,8 +13,6 @@ The tool is a thin orchestration layer over three CLIs that developers already h
 **Stack topology management** — knowing the shape of the stack, persisting that metadata, and updating it as PRs merge.
 
 **Branch synchronization** — when a head PR merges into main, rebasing the next branch onto main, then cascading that rebase down the rest of the stack and updating PR bases in GitHub.
-
-**Context continuity** — ensuring Claude understands not just the current branch but the semantic intent of the whole stack when working on any individual PR, especially during conflict resolution.
 
 -----
 
@@ -37,23 +35,20 @@ sdf init --stack users-feature
 # Layer 1: schema
 sdf branch users/db-schema
 # ... implement migration, User table with id, email, created_at
-sdf context edit            # document: adds users table, pgx v5, AppError pattern
-sdf pr                      # gh pr create, body from context doc
+sdf pr
 
 # Layer 2: repository
 sdf branch users/repository # auto-bases off users/db-schema
 # ... implement UserRepository with FindByID, Create
-sdf context edit            # document: depends on users table schema, returns *User
 sdf pr
 
 # Layer 3: controller + tests
 sdf branch users/controller # auto-bases off users/repository
 # ... implement POST /users, GET /users/:id, integration tests
-sdf context edit            # document: calls repository, response shape, test coverage
 sdf pr
 ```
 
-At this point three PRs exist with correct base chains: `main ← db-schema ← repository ← controller`. All context docs are committed and visible in each PR.
+At this point three PRs exist with correct base chains: `main ← db-schema ← repository ← controller`.
 
 -----
 
@@ -68,7 +63,6 @@ git checkout users/db-schema
 # Add the missing column
 # ... add display_name varchar(255) to migration and User struct
 
-sdf context update          # Claude rewrites context doc to note new column
 git add . && git commit -m "add display_name to users table"
 git push
 
@@ -78,7 +72,7 @@ sdf sync
 
 `sdf sync` detects that `users/db-schema` has new commits since `users/repository` was branched. It rebases `users/repository` onto the new tip of `users/db-schema`, then rebases `users/controller` onto the new tip of `users/repository`, pushing each branch and updating its PR base in GitHub.
 
-If `users/repository` has code that conflicts with the new column (e.g. a `Scan()` call that now has the wrong arity), `sdf sync` invokes Claude with the conflict markers plus the updated context doc — which now documents `display_name` — so the resolution is correct and consistent.
+If `users/repository` has code that conflicts with the new column (e.g. a `Scan()` call that now has the wrong arity), `sdf sync` invokes Claude with the conflict markers plus the upstream diff summary and the PR description for resolution.
 
 After sync, the developer switches to `users/controller` to use the new attribute:
 
@@ -88,12 +82,11 @@ git checkout users/controller
 # The branch is already rebased and has the updated User struct available
 # ... add display_name to the POST /users response payload and test fixture
 
-sdf context update
 git add . && git commit -m "include display_name in user response"
 git push
 ```
 
-No manual rebase commands. No hunting for the right `--onto` incantation. The context docs ensure Claude knows why `display_name` was added and what the expected downstream usage is.
+No manual rebase commands. No hunting for the right `--onto` incantation.
 
 -----
 
@@ -133,7 +126,7 @@ sdf sync
 
 `sdf sync` pauses and constructs a Claude prompt containing:
 
-- The assembled context docs for `users/db-schema` (which now documents `email_address`) and `users/repository` (which documents its dependency on the schema)
+- The PR description for the current branch (fetched from GitHub)
 - A diff summary of what changed in `users/db-schema` during this sync cycle
 - The full content of the conflicted file with conflict markers
 
@@ -143,43 +136,7 @@ If the conflict touches test fixtures or multiple files, Claude handles them all
 
 -----
 
-### Scenario 5: Resuming work with full context
-
-A developer comes back to a branch after a few days away, or a second developer picks up the stack. They need to understand the full picture before making changes.
-
-```
-git checkout users/controller
-
-sdf context show
-```
-
-Output:
-
-```
-=== STACK: users-feature ===
-
-[users/db-schema]
-Intent: adds users table with id, email_address, display_name, created_at.
-Uses pgx v5. Errors follow AppError{Code, Message} pattern.
-Decisions: email stored as-is (no normalisation), display_name nullable.
-
-[users/repository]
-Intent: implements UserRepository with FindByID(ctx, id) and Create(ctx, *User).
-Depends on: users table schema above.
-Decisions: no caching layer, returns ErrNotFound sentinel, Create sets created_at in Go not DB.
-
-[users/controller ← current]
-Intent: implements POST /users and GET /users/:id. Calls UserRepository.
-Response shape: { id, email_address, display_name, created_at }.
-Tests: integration tests against real DB using testcontainers.
-Open: rate limiting not implemented yet.
-```
-
-This output can be piped directly into Claude: `sdf context show | claude` to start a working session with full stack awareness, or used as a briefing document for a code review.
-
------
-
-### Scenario 6: sdf status — at-a-glance stack health
+### Scenario 5: sdf status — at-a-glance stack health
 
 ```
 sdf status
@@ -202,14 +159,11 @@ sdf status
 ```
 sdf init <name>           # initialize stack, auto-detect base branch from origin HEAD
 sdf branch [--no-prefix] <name>  # create branch, register in stack, push tracking branch
-sdf pr                    # gh pr create with body pre-populated from context doc
+sdf pr                    # gh pr create for the current branch
 sdf sync [<stack>]        # detect merged PRs via gh, cascade rebase, push
 sdf status [<stack>]      # show stack topology with PR state
-sdf switch [<branch>]     # checkout a branch, show its stack context
+sdf switch [<branch>]     # checkout a branch
 sdf <branch>              # shorthand for switch
-sdf context show          # print assembled context for the current branch
-sdf context edit          # open context doc in $EDITOR
-sdf context update        # ask Claude to rewrite context doc based on current state
 sdf config show           # display effective (merged) configuration
 sdf config set <key> <val>  # set a value in repo config (or --global)
 ```
@@ -234,18 +188,10 @@ All three dependencies (`git`, `gh`, `claude`) are version-checked at startup.
   stacks/
     auth-overhaul.json    # stack topology, PR numbers, sync state
     billing.json          # multiple stacks can coexist
-  context/
-    auth/db-schema.md
-    auth/session-api.md
-    auth/ui-login.md
   local.json              # ephemeral state (gitignored)
 ```
 
-Stack files and context docs are committed alongside code. This means:
-
-- Stack topology is available on any clone and in CI
-- Context docs appear in PR reviews — reviewers see the intent alongside the diff
-- `git log` on a context doc shows how intent evolved over the life of the PR
+Stack files are committed alongside code, so stack topology is available on any clone and in CI.
 
 The only exception is ephemeral state (active Claude session IDs, in-progress sync state), which lives in `.sdf/local.json` and is gitignored.
 
@@ -280,55 +226,6 @@ The only exception is ephemeral state (active Claude session IDs, in-progress sy
 1. Commit the updated `stacks/<name>.json`
 
 The `gh pr edit --base` step is easy to miss but critical — without it, GitHub shows every commit from `main` in the PR diff after rebasing.
-
------
-
-## Context Documents
-
-Each branch carries a context document at `.sdf/context/<branch-name>.md`. This is the mechanism for maintaining semantic continuity across the stack.
-
-### Structure
-
-```markdown
-# auth/session-api
-
-## Intent
-Implements session management API on top of the DB schema added in auth/db-schema.
-Downstream branches (auth/ui-login) will call POST /sessions and GET /sessions/:id.
-
-## Constraints from upstream
-- Sessions table has columns: id, user_id, token_hash, expires_at, created_at
-- Auth service uses pgx v5, not database/sql
-- Error types follow the pattern in db-schema: AppError with Code field
-
-## Decisions made here
-- Sessions are stored with bcrypt-hashed tokens, not raw
-- Expiry is enforced at the API layer, not the DB (no pg triggers)
-- Rate limiting is deferred to auth/ui-login to handle at the edge
-
-## Open questions / known debt
-- Token rotation not implemented (tracked in issue #89)
-```
-
-### Lifecycle
-
-|Event                |Action                                                                          |
-|---------------------|--------------------------------------------------------------------------------|
-|`sdf branch <name>`  |Creates stub context doc for the new branch                                     |
-|`sdf context edit`   |Opens context doc in `$EDITOR`                                                  |
-|`sdf context update` |Pipes current diff + upstream context to Claude, asks it to rewrite the doc     |
-|`sdf pr`             |Uses the Intent section as the PR description body                              |
-|`sdf sync` (conflict)|Upstream and current context docs are included in the conflict resolution prompt|
-
-### Context Assembly
-
-`sdf context show` walks the stack from base to current branch and concatenates all ancestor context docs, producing a unified view. This is what gets piped to Claude in any operation that needs full stack awareness.
-
-```
-[base context]
-[auth/db-schema context]
-[auth/session-api context]   ← current
-```
 
 -----
 
@@ -380,15 +277,12 @@ When `git rebase` exits non-zero during `sdf sync`, the tool hands off to Claude
 ```
 You are rebasing auth/ui-login onto the updated auth/session-api.
 
-=== STACK CONTEXT ===
-<assembled context docs for all ancestor branches>
-
 === UPSTREAM CHANGE SUMMARY ===
 auth/session-api changed after its own rebase:
   - bcrypt token hashing was changed to argon2id
   - POST /sessions now returns { token, session_id } instead of { token }
 
-=== CURRENT BRANCH INTENT (auth/ui-login) ===
+=== BRANCH PR DESCRIPTION ===
 Implements login UI calling POST /sessions, stores token in localStorage.
 
 === CONFLICTS ===
@@ -410,8 +304,8 @@ func resolveConflicts(stack *Stack, branch string) error {
     conflicted, _ := gitConflictedFiles()
 
     var prompt strings.Builder
-    prompt.WriteString(assembleStackContext(stack, branch))
     prompt.WriteString(buildUpstreamChangeSummary(stack, branch))
+    prompt.WriteString(branchPRDescription(stack, branch))
     for _, f := range conflicted {
         content, _ := os.ReadFile(f)
         fmt.Fprintf(&prompt, "File: %s\n```\n%s\n```\n\n", f, content)
@@ -448,17 +342,10 @@ The session name `conflict-<branch>` is deterministic, so the session can be res
 - `gh` integration for PR state polling
 - `sdf sync` with cascade rebase — error on conflict (no Claude yet)
 
-### Phase 2 — Context Scaffolding
-
-- Context doc creation and stub generation in `sdf branch`
-- `sdf context show/edit/update`
-- Context assembler that produces the unified stack view
-- `sdf pr` using context doc for PR body
-
-### Phase 3 — Claude Integration
+### Phase 2 — Claude Integration
 
 - Conflict resolution via Claude CLI session
-- `sdf context update` using Claude to rewrite docs post-change
+- PR content generation (titles and descriptions)
 - Iterative resolution loop if Claude produces unparseable output
 
 -----
@@ -466,8 +353,6 @@ The session name `conflict-<branch>` is deterministic, so the session can be res
 ## Design Principles
 
 **Shell out, don't reimplement.** `gh` handles GitHub auth, pagination, and API quirks. `git` handles the rebase mechanics. `claude` handles the intelligence. `sdf` is pure orchestration.
-
-**Context is a first-class artifact.** Intent doesn't live in someone's head or a Notion doc — it lives in the repo, versioned, visible in reviews, and available to Claude without reconstruction.
 
 **Fail loudly, recover gracefully.** Sync failures leave the repo in a known state (mid-rebase or pre-rebase). The tool always tells the user what state they're in and how to recover manually if automation fails.
 

--- a/PLAN-testing.md
+++ b/PLAN-testing.md
@@ -80,7 +80,7 @@ type Remote interface {
 
 3. **Test conflict resolution flow.** With a mock claude client, verify that:
    - Conflicted files are detected
-   - The right prompt is constructed (with context docs)
+   - The right prompt is constructed (with PR description and upstream diff)
    - Resolved files are staged and rebase continues
    - Failed resolution triggers abort
 

--- a/PLAN-ui.md
+++ b/PLAN-ui.md
@@ -72,7 +72,7 @@ The **Charm ecosystem** (charmbracelet) is the clear winner for sdf because:
 | **lipgloss** | Consistent styling: colors, borders, padding for all output |
 | **bubbles** | Spinner (during fetch/push), progress bar (sync), table (status) |
 | **huh** | Interactive prompts (conflict resolution, confirmations, branch selection) |
-| **glamour** | Rendering PR descriptions/context docs in terminal |
+| **glamour** | Rendering PR descriptions in terminal |
 
 #### What NOT to adopt (yet):
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -5,7 +5,7 @@
 
 ## Problem
 
-Running `sdf init status` creates the stack file but leaves the user on `main` with no branch, no context doc, and unclear next steps. The gap between init and productive work is too wide.
+Running `sdf init status` creates the stack file but leaves the user on `main` with no branch and unclear next steps. The gap between init and productive work is too wide.
 
 ## Design
 
@@ -23,8 +23,7 @@ sdf init <stack-name> [--base <branch>] [--branch <name>] [--json]
 4. Apply branch prefix (respecting config, same as `RunBranch`)
 5. Create git branch and checkout
 6. Register node in stack, save
-7. Create context doc stub
-8. Push tracking branch to origin
+7. Push tracking branch to origin
 9. Print summary + next steps (or JSON if `--json`)
 
 ### Implementation (Stacked Diffs — init-dx)

--- a/README.md
+++ b/README.md
@@ -1,25 +1,24 @@
 # sdf — Stacked Diffs Flow
 
-A lightweight CLI that manages stacked diffs (chains of dependent pull requests) in Git repositories. It orchestrates `git`, `gh`, and `claude` to handle stack topology, cascade rebasing, and semantic context continuity across branches.
+A lightweight CLI that manages stacked diffs (chains of dependent pull requests) in Git repositories. It orchestrates `git`, `gh`, and `claude` to handle stack topology and cascade rebasing across branches.
 
 ## Why
 
-Large features rarely fit in a single PR. Splitting work into a chain of dependent PRs keeps reviews focused, but the maintenance burden is real: rebasing cascades when upstream changes, PR bases drift after merges, and context about *why* each layer exists lives only in someone's head. `sdf` eliminates that overhead.
+Large features rarely fit in a single PR. Splitting work into a chain of dependent PRs keeps reviews focused, but the maintenance burden is real: rebasing cascades when upstream changes and PR bases drift after merges. `sdf` eliminates that overhead.
 
 ## What it does
 
 - **Stack topology** — tracks branch ordering and PR metadata in `.sdf/stacks/<name>.json`, committed alongside code
 - **Multiple stacks** — a single repo can have several independent stacks, each with its own base branch
 - **Cascade rebase** — when a head PR merges or an earlier branch is amended, `sdf sync` rebases every downstream branch, force-pushes, and updates PR bases in GitHub
-- **Context documents** — each branch carries a Markdown doc (`.sdf/context/<branch>.md`) describing intent, upstream constraints, decisions, and open questions
-- **AI conflict resolution** — when rebase conflicts occur, Claude receives the full assembled stack context plus the conflicted files and resolves them in-place
-- **PR creation** — `sdf pr` creates a GitHub PR with the context doc as the body, so reviewers see intent alongside the diff
+- **AI conflict resolution** — when rebase conflicts occur, Claude receives the PR description and upstream diff summary plus the conflicted files and resolves them in-place
+- **PR creation** — `sdf pr` creates a GitHub PR for the current branch
 
 ## Prerequisites
 
 - [git](https://git-scm.com/)
 - [gh](https://cli.github.com/) — GitHub CLI (required for PR operations)
-- [claude](https://docs.anthropic.com/en/docs/claude-code) — Claude CLI (optional, for conflict resolution and context updates)
+- [claude](https://docs.anthropic.com/en/docs/claude-code) — Claude CLI (optional, for conflict resolution and PR content generation)
 
 Run `sdf doctor` to verify all dependencies are available.
 
@@ -81,19 +80,16 @@ make install
 # Initialize a stack and create the first branch in one step
 sdf init users-feature --branch db-schema
 # ... write code ...
-sdf context edit          # document intent, decisions, constraints
-sdf pr                    # create PR with context doc as body
+sdf pr                    # create PR
 
 # Stack another branch on top
 sdf branch repository
 # ... write code ...
-sdf context edit
 sdf pr
 
 # Add a third layer
 sdf branch controller
 # ... write code ...
-sdf context edit
 sdf pr
 ```
 
@@ -124,7 +120,7 @@ sdf sync auth-feature
 # Check status of a specific stack
 sdf status billing-feature
 
-# Switch between branches (shows stack context)
+# Switch between branches
 sdf switch auth/db-schema
 # or just:
 sdf auth/db-schema
@@ -145,13 +141,8 @@ Stack commands:
   pr                                 Create a GitHub PR for the current branch
 
 Navigation:
-  switch [<branch>]                  Switch to a branch (shows stack context)
+  switch [<branch>]                  Switch to a branch
   <branch>                           Shorthand for switch <branch>
-
-Context commands:
-  context show              Print assembled context for current branch
-  context edit              Open context doc in $EDITOR
-  context update            Ask Claude to rewrite context doc
 
 Config commands:
   config show               Display effective (merged) configuration
@@ -171,7 +162,7 @@ Other:
 sdf init <name> [--base <branch>] [--branch <name>] [--json]
 ```
 
-- **Stack + branch** — creates the `.sdf/` metadata, a git branch, a context doc stub, and pushes to origin
+- **Stack + branch** — creates the `.sdf/` metadata, a git branch, and pushes to origin
 - **Branch name** defaults to the stack name. Override with `--branch <name>`
 - **Base branch** is auto-detected from `origin/HEAD`. Override with `--base <branch>`
 - **Branch prefix** is applied automatically (e.g. `sdf init users --branch db-schema` creates `users/db-schema`)
@@ -190,7 +181,6 @@ sdf init my-feature --json
   "stack": "my-feature",
   "base": "main",
   "branch": "my-feature/my-feature",
-  "context_doc": ".sdf/context/my-feature/my-feature.md",
   "pushed": true
 }
 ```
@@ -200,7 +190,7 @@ sdf init my-feature --json
 1. Polls GitHub for PR state via `gh`
 2. Walks merged nodes from the bottom of the stack upward
 3. Rebases each unmerged branch onto its new base
-4. If conflicts arise, invokes Claude with assembled stack context for resolution
+4. If conflicts arise, invokes Claude with the PR description and upstream diff for resolution
 5. Force-pushes updated branches and runs `gh pr edit --base` to fix PR diffs
 6. Updates `.sdf/stacks/<name>.json`
 
@@ -257,18 +247,10 @@ Use `sdf config show` to see the effective (merged) configuration and the file p
   stacks/
     users-feature.json      # stack topology, PR numbers, sync state
     auth-feature.json       # a second independent stack
-  context/
-    users/db-schema.md
-    users/repository.md
-    auth/db-schema.md
   local.json                # ephemeral state (gitignored)
 ```
 
-Both stack files and context docs are committed alongside code. This means:
-
-- Stack topology is available on any clone and in CI
-- Context docs appear in PR reviews — reviewers see the intent alongside the diff
-- `git log` on a context doc shows how intent evolved over the life of the PR
+Stack files are committed alongside code. This means stack topology is available on any clone and in CI.
 
 ## License
 

--- a/cmd/move_test.go
+++ b/cmd/move_test.go
@@ -64,7 +64,6 @@ func testRepo(t *testing.T) (repoDir string, shas map[string]string) {
 	writeFile("README.md", "# test\n")
 	writeFile(".gitignore", ".sdf/\n")
 	sdfDir := filepath.Join(dir, ".sdf")
-	os.MkdirAll(filepath.Join(sdfDir, "context"), 0755)
 	os.MkdirAll(filepath.Join(sdfDir, "stacks"), 0755)
 	git("add", "README.md", ".gitignore")
 	git("commit", "-m", "initial")

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -984,7 +984,7 @@ func tryClaude(root string, s *stack.Stack, branch, originalBranch string, nodeI
 	parent := s.ParentBranch(branch)
 	upstreamSummary, _ := gitpkg.DiffSummary(s.FindNode(branch).BaseTip, parent)
 
-	// Use PR description as context (replaces local context docs)
+	// Use PR description as context for conflict resolution
 	var branchDesc string
 	node := s.FindNode(branch)
 	if node != nil && node.PR > 0 && ghpkg.Available() {
@@ -1074,7 +1074,7 @@ func isBlocked(s *stack.Stack, i int, failed map[string]error) bool {
 }
 
 // buildConflictPrompt constructs the conflict resolution prompt for Claude,
-// using upstream changes and the PR description as context.
+// using upstream changes and the PR description for context.
 func buildConflictPrompt(upstreamSummary, branchDescription string, conflictedFiles map[string]string) string {
 	var b strings.Builder
 

--- a/cmd/sync_property_test.go
+++ b/cmd/sync_property_test.go
@@ -47,7 +47,6 @@ func propertyTestRepo(t *testing.T, n int) (string, *stack.Stack) {
 	git("config", "user.name", "Test")
 	git("config", "commit.gpgsign", "false")
 
-	os.MkdirAll(filepath.Join(dir, ".sdf", "context"), 0755)
 	os.WriteFile(filepath.Join(dir, "README.md"), []byte("# test\n"), 0644)
 	git("add", "README.md")
 	git("commit", "-m", "initial")

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -65,7 +65,6 @@ func syncTestRepo(t *testing.T) (repoDir string) {
 	git("config", "commit.gpgsign", "false")
 
 	// Initial commit on main
-	os.MkdirAll(filepath.Join(dir, ".sdf", "context"), 0755)
 	writeFile("README.md", "# test\n")
 	git("add", "README.md")
 	git("commit", "-m", "initial")

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -300,11 +300,6 @@ func Init(root, stackID, base string) error {
 		return fmt.Errorf("cannot create %s: %w", sdfDir, err)
 	}
 
-	contextDir := filepath.Join(sdfDir, "context")
-	if err := os.MkdirAll(contextDir, 0755); err != nil {
-		return fmt.Errorf("cannot create %s: %w", contextDir, err)
-	}
-
 	stacksDir := filepath.Join(sdfDir, StacksDir)
 	if err := os.MkdirAll(stacksDir, 0755); err != nil {
 		return fmt.Errorf("cannot create %s: %w", stacksDir, err)


### PR DESCRIPTION
Remove the context documents feature (`sdf context show/edit/update`,
`.sdf/context/` directory, context doc stubs) from the codebase:

- Remove context directory creation from stack.Init()
- Remove context directory creation from test helpers
- Update conflict resolution comments to reference PR descriptions
  instead of context docs
- Remove all context doc references from README, DESIGN, and PLAN docs
- Remove Context Documents section and Scenario 5 from DESIGN.md
- Remove Phase 2 (Context Scaffolding) from implementation phases
- Update command listings to remove context subcommands

https://claude.ai/code/session_019FErVHmnQEsoJ5gRk55MvZ