### PR TITLE
add design docs and implementation plans for sdf split

### DIFF
--- a/PLAN-pr-splitting.md
+++ b/PLAN-pr-splitting.md
@@ -1,0 +1,616 @@
+# sdf split — Turn a Large PR into a Stack
+
+## Problem Statement
+
+You've been working with an AI agent (or solo) and accumulated a 5,000+ line PR. Reviewers dread it. You want to break it into a chain of focused, reviewable PRs — but doing so manually is tedious: figuring out the right split points, cherry-picking, rebasing, creating branches, fixing up commits, and wiring the PR chain together.
+
+`sdf split` automates this. It analyzes a large branch, plans a logical decomposition into layers, and executes the git operations to produce a proper sdf-managed stack with PRs chained correctly.
+
+---
+
+## Two Modes of Operation
+
+### Mode 1: `sdf split --from <branch>` (AI-planned split)
+
+The "trust the tool" path. Claude analyzes the full diff, commit history, and file structure of the source branch and proposes a split plan. The user reviews and confirms (or edits) the plan, then sdf executes it.
+
+```
+sdf split --from feature/big-change
+```
+
+### Mode 2: `sdf split --from <branch> --plan <file>` (User-provided plan)
+
+The user provides a YAML/JSON plan file describing exactly which files/commits go into which layer. sdf validates and executes it without AI involvement.
+
+```
+sdf split --from feature/big-change --plan split-plan.yaml
+```
+
+### Mode 3: `sdf split --from <branch> --interactive` (Hybrid)
+
+Claude generates a plan, the user edits it in `$EDITOR`, then sdf executes the edited plan. This is Mode 1 with a mandatory edit step.
+
+---
+
+## The Split Plan
+
+The split plan is the central data structure. Whether AI-generated or user-authored, it's the same format:
+
+```yaml
+source_branch: feature/big-change
+base: main
+stack_name: big-change
+
+layers:
+  - name: db-schema
+    description: "Add users table with migration"
+    files:
+      - "migrations/001_create_users.sql"
+      - "internal/models/user.go"
+    commits: []  # empty = file-based assignment (see Strategy section)
+
+  - name: repository
+    description: "UserRepository with CRUD operations"
+    files:
+      - "internal/users/repository.go"
+      - "internal/users/repository_test.go"
+    depends_on_files:  # optional: files from earlier layers this layer references
+      - "internal/models/user.go"
+
+  - name: api-handler
+    description: "REST endpoints for user management"
+    files:
+      - "internal/users/handler.go"
+      - "internal/users/handler_test.go"
+      - "internal/users/routes.go"
+```
+
+### Plan Validation Rules
+
+Before execution, sdf validates:
+1. Every changed file in the source branch appears in exactly one layer
+2. No file appears in multiple layers
+3. Layer ordering is compatible with import/dependency relationships (best-effort)
+4. The plan covers the complete diff (no files left unassigned)
+5. Layer names are valid branch names
+
+---
+
+## Split Strategies
+
+There are two fundamentally different ways to decompose a branch:
+
+### Strategy A: File-based splitting (primary)
+
+Each layer gets a set of files. sdf constructs synthetic commits per layer by diffing the source branch against the base for just those files. This is the simplest and most reliable approach.
+
+**How it works:**
+1. Compute the full diff: `git diff main...feature/big-change`
+2. For each layer, extract the diff hunks for its assigned files
+3. Apply those hunks as a single commit on the layer's branch
+4. If the source had meaningful commit messages, use Claude to synthesize an appropriate commit message per layer
+
+**Tradeoff:** Commit history within the source branch is lost. Each layer gets one clean commit. For agent-generated code with messy intermediate commits, this is actually a feature.
+
+### Strategy B: Commit-based splitting (advanced, future)
+
+Each layer gets a set of commits by SHA. sdf cherry-picks them in order. This preserves commit granularity but is more fragile — commits may not apply cleanly out of order.
+
+**How it works:**
+1. List commits: `git log --oneline main..feature/big-change`
+2. For each layer, cherry-pick its assigned commits onto the parent layer's branch
+3. Handle conflicts (potentially via Claude)
+
+**Tradeoff:** Preserves history but requires commits to be somewhat self-contained. Conflicts are likely if commits touch overlapping files.
+
+**Recommendation:** Ship Strategy A first. It handles the 90% case (agent-generated code with messy commits). Strategy B can follow as an opt-in for repos with disciplined commit hygiene.
+
+---
+
+## AI Planning Phase (Mode 1)
+
+### What Claude Receives
+
+When `sdf split --from <branch>` is invoked, sdf constructs a prompt containing:
+
+1. **Diff stat** — `git diff --stat main...feature/big-change` (file-level overview)
+2. **Full diff** — `git diff main...feature/big-change` (complete changes) — or for very large diffs, a summarized version with full content only for key files
+3. **Commit log** — `git log --oneline main..feature/big-change` (intent signal from commit messages)
+4. **File tree** — `find` output of changed files with directory structure
+5. **Import/dependency graph** — (optional, language-aware) which changed files import which other changed files
+
+### What Claude Produces
+
+Claude returns a split plan in YAML format (as defined above). The prompt instructs Claude to:
+
+- Group files by logical concern (data layer, business logic, API, tests)
+- Order layers from foundational to dependent (schema before repository before handler)
+- Keep each layer under ~500 lines of diff where practical
+- Write a one-line description for each layer explaining the "why"
+- Ensure every changed file appears in exactly one layer
+- Consider test files: pair them with the code they test when practical
+
+### Prompt Template
+
+```
+You are analyzing a large branch to split it into a stack of smaller, reviewable PRs.
+
+SOURCE BRANCH: {{.SourceBranch}}
+BASE BRANCH: {{.Base}}
+TOTAL FILES CHANGED: {{.FileCount}}
+TOTAL LINES: +{{.Insertions}} -{{.Deletions}}
+
+=== DIFF STAT ===
+{{.DiffStat}}
+
+=== COMMIT LOG ===
+{{.CommitLog}}
+
+=== FULL DIFF ===
+{{.FullDiff}}
+
+Produce a split plan as YAML. Rules:
+1. Each layer should be a coherent, reviewable unit (aim for <500 lines each)
+2. Order layers from foundational to dependent
+3. Every changed file must appear in exactly one layer
+4. Group test files with the production code they test
+5. Name layers with short, descriptive kebab-case names
+6. Write a brief description for each layer
+
+Output ONLY the YAML, no explanation:
+
+source_branch: ...
+base: ...
+stack_name: ...
+layers:
+  - name: ...
+    description: "..."
+    files:
+      - ...
+```
+
+### Handling Large Diffs
+
+For branches with >10,000 lines of diff, sending the full diff to Claude may exceed context limits. The strategy:
+
+1. **First pass**: Send only the diff stat + commit log + file tree. Ask Claude to produce the plan based on file names and structure alone.
+2. **Validation pass**: For each proposed layer, send the actual diff of those files and ask Claude to confirm the grouping makes sense or suggest adjustments.
+
+This two-pass approach keeps each prompt manageable while still leveraging the full diff content.
+
+---
+
+## Execution Phase
+
+Once the plan is confirmed (user approved or provided), sdf executes it:
+
+### Step-by-step
+
+```
+1. Validate the plan (all files covered, no overlaps, names valid)
+
+2. Create the sdf stack:
+   sdf init <stack_name> --base <base> --branch <layers[0].name>
+
+3. For each layer (starting from the first):
+   a. If not the first layer: sdf branch <layer.name>
+   b. Extract the diff for this layer's files from the source branch
+   c. Apply the diff: git apply <layer-patch>
+   d. Commit: git commit -m "<layer.description>"
+   e. Push: git push -u origin <branch>
+
+4. For each layer that should have a PR:
+   sdf pr  (creates PR with layer description as body)
+
+5. Clean up:
+   - Save the split plan to .sdf/split-plans/<stack_name>.yaml for reference
+   - Optionally close/supersede the original large PR
+```
+
+### Extracting Per-Layer Diffs
+
+The key git operation is extracting a subset of the full diff:
+
+```bash
+# Get the full diff for specific files
+git diff main...feature/big-change -- file1.go file2.go > layer.patch
+
+# Apply it on the layer branch
+git apply layer.patch
+git add .
+git commit -m "Layer description"
+```
+
+This is reliable because:
+- `git diff` with file paths extracts exactly the changes to those files
+- `git apply` applies them cleanly (they're against the same base)
+- The first layer applies against `main`, the second against the first layer's tip, etc.
+
+**Important subtlety:** Later layers may depend on files introduced in earlier layers. When a later layer's files import/reference symbols from an earlier layer's files, those symbols are already present (from the earlier layer's commit). So the code compiles at each layer boundary — which is exactly what we want for reviewable PRs.
+
+### Handling Apply Failures
+
+If `git apply` fails for a layer (e.g., because files have cross-dependencies that make the diff not apply cleanly in isolation):
+
+1. **Try 3-way merge**: `git apply --3way layer.patch` — this uses the merge machinery and often succeeds
+2. **Fall back to Claude**: Send the failed patch + the current branch state to Claude for resolution
+3. **Fall back to manual**: Pause and let the user resolve, then `sdf split --continue`
+
+---
+
+## User Experience Flow
+
+### Happy Path (Mode 1)
+
+```
+$ sdf split --from feature/big-change
+
+Analyzing feature/big-change...
+  42 files changed, +4,832 -201 (vs main)
+  17 commits
+
+Planning split...
+  [streaming Claude output as it thinks]
+
+Proposed stack "big-change" (4 layers):
+
+  Layer 1: db-schema (12 files, +892 lines)
+    Add users and sessions tables with migrations
+
+  Layer 2: repository (8 files, +1,204 lines)
+    UserRepository and SessionRepository with tests
+
+  Layer 3: api-handlers (14 files, +1,891 lines)
+    REST endpoints for user and session management
+
+  Layer 4: integration-tests (8 files, +845 lines)
+    End-to-end integration tests with testcontainers
+
+  Total: 42 files, +4,832 lines across 4 layers
+
+? Proceed with this split? (Y/n/edit)
+  > Y    — execute the split as proposed
+  > n    — abort
+  > edit — open the plan in $EDITOR before executing
+
+Executing split...
+  ✓ Created stack "big-change" (base: main)
+  ✓ Layer 1: big-change/db-schema — 12 files committed
+  ✓ Layer 2: big-change/repository — 8 files committed
+  ✓ Layer 3: big-change/api-handlers — 14 files committed
+  ✓ Layer 4: big-change/integration-tests — 8 files committed
+  ✓ Created PR #201: db-schema
+  ✓ Created PR #202: repository (base: big-change/db-schema)
+  ✓ Created PR #203: api-handlers (base: big-change/repository)
+  ✓ Created PR #204: integration-tests (base: big-change/api-handlers)
+
+Stack created:
+  main ← db-schema (#201) ← repository (#202) ← api-handlers (#203) ← integration-tests (#204)
+
+The original branch feature/big-change is untouched.
+To close the original PR: gh pr close <number>
+```
+
+### Edit Flow
+
+When the user chooses "edit", sdf:
+1. Writes the proposed plan to a temp file
+2. Opens it in `$EDITOR`
+3. On save, validates the edited plan
+4. If valid, proceeds with execution
+5. If invalid, shows errors and re-opens the editor
+
+### Session Continuity (Advanced)
+
+For the case where the user wants to start a Claude Code session that has full context of the split plan:
+
+```
+$ sdf split --from feature/big-change --session
+
+[Claude plans the split as above]
+[User confirms]
+[sdf executes the split]
+
+Starting Claude Code session with stack context...
+  Session has full awareness of all 4 layers and their intent.
+  You can now ask Claude to make changes within the stack context.
+```
+
+This works by:
+1. Completing the split
+2. Writing context docs for each layer (`.sdf/context/<layer>.md`)
+3. Launching `claude` with `sdf context show` piped in as initial context
+4. The session name is deterministic: `split-<stack_name>` so it's resumable
+
+---
+
+## Implementation Plan
+
+### Phase 1: Core Plumbing (the git operations)
+
+**New files:**
+- `cmd/split.go` — Cobra command definition
+- `internal/split/plan.go` — Plan data structures, validation, YAML parsing
+- `internal/split/execute.go` — Plan execution (diff extraction, apply, commit)
+- `internal/split/plan_test.go` — Plan validation tests
+- `internal/split/execute_test.go` — Execution tests
+
+**New git helpers needed** (in `internal/git/git.go`):
+- `DiffFiles(from, to string, files []string) (string, error)` — diff for specific files
+- `Apply(patch string) error` — apply a patch
+- `ApplyThreeWay(patch string) error` — apply with 3-way merge fallback
+- `DiffNameOnly(from, to string) ([]string, error)` — list changed file names
+- `DiffStatFull(from, to string) (string, error)` — full diff stat
+
+**Cobra command:**
+```go
+var splitCmd = &cobra.Command{
+    Use:   "split",
+    Short: "Split a large branch into a stack of smaller PRs",
+    Long:  `Analyzes a branch and decomposes it into a chain of focused,
+reviewable PRs managed as an sdf stack.`,
+    RunE: runSplitCmd,
+}
+
+func init() {
+    rootCmd.AddCommand(splitCmd)
+    splitCmd.Flags().String("from", "", "source branch to split (required)")
+    splitCmd.Flags().String("plan", "", "path to a split plan file (skip AI planning)")
+    splitCmd.Flags().String("stack", "", "name for the resulting stack (default: derived from branch)")
+    splitCmd.Flags().String("base", "", "base branch (default: auto-detect)")
+    splitCmd.Flags().Bool("interactive", false, "open plan in $EDITOR before executing")
+    splitCmd.Flags().Bool("session", false, "start a Claude session after splitting")
+    splitCmd.Flags().Bool("yes", false, "skip confirmation prompt")
+    splitCmd.Flags().Bool("dry-run", false, "show the plan without executing")
+    splitCmd.Flags().Bool("json", false, "output machine-readable JSON")
+    splitCmd.MarkFlagRequired("from")
+}
+```
+
+**Plan structures:**
+```go
+// internal/split/plan.go
+
+type Plan struct {
+    SourceBranch string  `yaml:"source_branch" json:"source_branch"`
+    Base         string  `yaml:"base" json:"base"`
+    StackName    string  `yaml:"stack_name" json:"stack_name"`
+    Layers       []Layer `yaml:"layers" json:"layers"`
+}
+
+type Layer struct {
+    Name        string   `yaml:"name" json:"name"`
+    Description string   `yaml:"description" json:"description"`
+    Files       []string `yaml:"files" json:"files"`
+}
+
+func ParsePlan(data []byte) (*Plan, error) { ... }
+func (p *Plan) Validate(changedFiles []string) []error { ... }
+```
+
+**Execution:**
+```go
+// internal/split/execute.go
+
+type Executor struct {
+    Root    string
+    Git     gitInterface  // for testability
+    GH      ghInterface
+    Plan    *Plan
+}
+
+type Result struct {
+    StackID  string        `json:"stack_id"`
+    Layers   []LayerResult `json:"layers"`
+}
+
+type LayerResult struct {
+    Branch  string `json:"branch"`
+    Commits int    `json:"commits"`
+    PR      int    `json:"pr,omitempty"`
+    PRURL   string `json:"pr_url,omitempty"`
+}
+
+func (e *Executor) Execute() (*Result, error) { ... }
+```
+
+### Phase 2: AI Planning
+
+**New file:**
+- `internal/split/ai.go` — Prompt construction and response parsing
+
+**The prompt builder:**
+```go
+func BuildAnalysisPrompt(sourceBranch, base string, diffStat, commitLog, fullDiff string) string {
+    // Constructs the prompt template above
+    // If fullDiff > threshold, uses two-pass strategy
+}
+
+func ParsePlanFromResponse(response string) (*Plan, error) {
+    // Extracts YAML from Claude's response (handles fenced blocks)
+}
+```
+
+**Integration with Claude CLI:**
+- Uses `claudepkg.RunPromptStreaming()` for real-time output during planning
+- Falls back to `claudepkg.RunPrompt()` if streaming isn't available
+- Session name: `split-plan-<source-branch>`
+
+### Phase 3: User Interaction (confirm/edit flow)
+
+**Uses charmbracelet/huh for interactive prompts:**
+```go
+func PromptConfirmation(plan *Plan) (action string, err error) {
+    // Shows plan summary
+    // Returns "yes", "edit", or "abort"
+}
+
+func EditPlan(plan *Plan) (*Plan, error) {
+    // Writes plan to temp file
+    // Opens $EDITOR
+    // Reads back, parses, validates
+    // Returns edited plan or error
+}
+```
+
+### Phase 4: PR Creation and Context
+
+After execution, for each layer:
+1. Create a context doc (`.sdf/context/<stack>/<layer>.md`) with the description
+2. Run `sdf pr` to create the GitHub PR with the context doc as body
+3. Update stack navigation links across all PRs
+
+### Phase 5: Session Continuity (--session flag)
+
+After split + PR creation:
+1. Assemble full stack context via `sdf context show`
+2. Launch `claude --session split-<stack_name>` with the context piped in
+3. The session inherits awareness of all layers
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+**Plan validation** (`internal/split/plan_test.go`):
+- Missing files → error
+- Duplicate files across layers → error
+- File not in source diff → error
+- Empty layer → error
+- Invalid layer name → error
+- Valid plan → no errors
+- YAML parsing roundtrip
+
+**Diff extraction** (`internal/split/execute_test.go`):
+- Extract diff for subset of files
+- Apply patch to clean branch
+- Apply patch with 3-way merge
+- Handle binary files in diff
+
+**AI prompt construction** (`internal/split/ai_test.go`):
+- Prompt includes all required sections
+- Large diff triggers two-pass mode
+- YAML extraction from fenced blocks
+- Handles Claude returning invalid YAML gracefully
+
+### Integration Tests (with real git repos)
+
+**Test fixture: a repo with a known large branch:**
+```go
+func TestSplit_FileBasedThreeLayers(t *testing.T) {
+    // 1. Create temp git repo with main branch
+    // 2. Create feature branch with 15 files across 3 logical groups
+    // 3. Run split with a hardcoded plan
+    // 4. Verify: 3 branches created, each with correct files
+    // 5. Verify: each branch compiles (files present from earlier layers)
+    // 6. Verify: stack.json is correct
+}
+
+func TestSplit_PlanValidation(t *testing.T) {
+    // Verify all validation rules with edge cases
+}
+
+func TestSplit_DryRun(t *testing.T) {
+    // Verify dry-run shows plan without modifying repo
+}
+
+func TestSplit_UserProvidedPlan(t *testing.T) {
+    // Verify --plan flag reads and executes external plan file
+}
+```
+
+### Golden Tests
+
+- Snapshot the plan output format
+- Snapshot the execution summary output
+- Snapshot the prompt template for AI planning
+
+### E2E Tests
+
+```go
+func TestE2E_SplitAndCreatePRs(t *testing.T) {
+    // Requires SDF_E2E_REPO + GH_TOKEN
+    // 1. Create a large branch on the test repo
+    // 2. Run sdf split with a plan
+    // 3. Verify stack created with correct PR chain on GitHub
+    // 4. Verify PR bases are correct
+    // 5. Clean up
+}
+```
+
+---
+
+## Evaluation Criteria
+
+### Correctness
+
+1. **File coverage**: Every file in the source diff appears in exactly one layer branch
+2. **No data loss**: The union of all layer diffs equals the full source diff
+3. **Compilability**: Each layer branch should be a valid state (no dangling imports to files that arrive in later layers) — this is validated by the AI planner and can be checked with a build step
+4. **Stack integrity**: The resulting `.sdf/stacks/<name>.json` is valid and `sdf status` shows the correct topology
+5. **PR chain**: GitHub PRs have correct base branches forming a proper chain
+
+### AI Quality (for Mode 1)
+
+1. **Coherence**: Each layer is a logical unit (not random file groupings)
+2. **Layer sizing**: Layers are roughly balanced in size, ideally <500 LOC each
+3. **Dependency ordering**: Foundational changes come first (DB before business logic before API before tests)
+4. **Description quality**: Layer descriptions accurately capture intent
+
+### Robustness
+
+1. **Dirty working tree**: Refuses to operate (like `sdf move`)
+2. **Missing source branch**: Clear error
+3. **Existing stack name collision**: Clear error
+4. **Patch apply failure**: Graceful fallback (3-way merge → Claude → manual)
+5. **Network failure during PR creation**: Partial progress saved, resumable
+
+### Performance
+
+1. **Small branch (10 files)**: Split should complete in seconds (excluding Claude API time)
+2. **Large branch (100+ files)**: Git operations should still be fast; AI planning is the bottleneck
+3. **Very large diff (10k+ lines)**: Two-pass AI planning keeps prompts manageable
+
+---
+
+## Open Questions and Future Work
+
+### Open Questions
+
+1. **Should `sdf split` modify the source branch?** Current design leaves it untouched. Alternative: delete it or mark it as superseded.
+
+2. **How to handle non-file-splittable changes?** If a single file has changes that logically belong to two layers (e.g., a `go.mod` that adds deps for both the DB layer and the API layer), which layer gets it? Options:
+   - Always put shared files in the earliest layer that needs them
+   - Allow files to appear in multiple layers (with diff-level splitting — much more complex)
+   - Let the AI decide and document the rationale
+
+3. **Should we support hunk-level splitting?** Instead of assigning whole files to layers, assign individual diff hunks. This handles the `go.mod` case but adds significant complexity.
+
+### Future Work
+
+- **Strategy B (commit-based splitting)**: For repos with clean commit history
+- **Language-aware splitting**: Use LSP or tree-sitter to understand import graphs and validate layer boundaries at the symbol level
+- **Build verification**: After each layer, optionally run `make build` or equivalent to verify the layer compiles
+- **Review assignment**: Auto-assign reviewers per layer based on CODEOWNERS
+- **Split from PR number**: `sdf split --from-pr 42` — fetch the branch from the PR and split it
+- **Undo**: `sdf split --undo <stack-name>` — delete the stack and restore the original branch state
+- **Incremental updates**: If the source branch gets new commits, re-run split to update the stack
+
+---
+
+## Dependency Summary
+
+**Existing infrastructure leveraged:**
+- `internal/git/*` — all git operations (diff, apply, cherry-pick, branch, push)
+- `internal/gh/*` — PR creation and editing
+- `internal/claude/*` — AI prompt execution (both sync and streaming)
+- `internal/stack/*` — stack topology management
+- `internal/config/*` — prefix and naming configuration
+- `internal/ui/*` — terminal styling
+- `cmd/init.go`, `cmd/branch.go`, `cmd/pr.go` — reused for stack/branch/PR creation
+
+**New dependencies:**
+- `gopkg.in/yaml.v3` — YAML parsing for split plans (go.mod addition)
+
+**No new external tools required.** `sdf split` uses the same `git`, `gh`, and `claude` CLIs that sdf already depends on.

--- a/SPLIT-DESIGN.md
+++ b/SPLIT-DESIGN.md
@@ -1,0 +1,586 @@
+# `sdf split` — Design Document
+
+## Overview
+
+`sdf split` takes a single large branch and decomposes it into a stack of smaller, independently reviewable PRs — without touching the original branch. It uses a hybrid strategy that preserves clean commits, reshuffles messy ones, and decomposes large commits at the hunk level when needed.
+
+The split produces a standard sdf stack, so all existing commands (`sdf sync`, `sdf status`, `sdf merge`, `sdf pr`) work on the result immediately.
+
+```
+Before:  main ← big-feature (847 insertions, 23 files, 15 commits)
+
+After:   main ← stack/1-schema ← stack/2-api ← stack/3-ui ← stack/4-tests
+         big-feature (untouched, still points at the same commit)
+```
+
+-----
+
+## Core Guarantee
+
+**The original branch is never modified.** The split creates new branches and new commits. If the split looks wrong, delete the stack branches and try again. The user's work is never at risk.
+
+This is the trust anchor of the entire feature.
+
+-----
+
+## Command Surface
+
+```
+sdf split                        # analyze, propose plan, execute, push, create PRs
+sdf split --plan-only            # produce plan YAML, don't execute
+sdf split --local                # run build+tests per PR before pushing
+sdf split --dry-run              # show what would happen, touch nothing
+sdf split status                 # check CI status of split PRs
+sdf split fix                    # auto-fix common mid-stack CI failures, re-push
+```
+
+Default mode is ship: execute the split, push all branches, create PRs, let CI validate in parallel.
+
+-----
+
+## The Pipeline
+
+### Phase 1: Analysis
+
+Read-only. Gather all information needed to produce a split plan.
+
+**Inputs:**
+
+- Base branch (from stack metadata or auto-detect from `origin/HEAD`)
+- Full diff: `git diff base..HEAD`
+- Commit list: `git log base..HEAD` (SHAs, messages, per-commit diffs)
+- Per-commit file lists with change stats
+
+#### Step 1a: Commit Quality Assessment
+
+Classify each commit in the range `base..HEAD`:
+
+| Classification | Meaning | Example | Action |
+|---|---|---|---|
+| CLEAN | Single concern, well-scoped | "add user schema migration" | Preserve as-is |
+| MIXED | Multiple identifiable concerns | "add user API + fix linting" | Decompose by concern |
+| MESSY | No clear structure | "WIP", "stuff" | Full decomposition |
+| DEPENDENT | Fixes a prior commit's breakage | "fix tests" after a broken commit | Squash into parent |
+| SCATTERED | Touches multiple earlier concerns | "address review feedback" | Distribute by concern |
+
+This classification is performed by Claude, which reads each commit's diff and message to determine its nature.
+
+#### Step 1b: Semantic Theme Extraction
+
+Analyze the *entire diff* (not per-commit) to identify logical themes. Themes cut across commits — a "WIP" commit might contain schema changes, API code, and business logic. A "review feedback" commit scatters fixes across every theme.
+
+Example themes:
+```
+T1: Database schema + migrations     (c1, part of c3, part of c6)
+T2: API endpoints                    (part of c2, part of c3)
+T3: Business logic / services        (part of c3)
+T4: UI components                    (c5, part of c6)
+```
+
+#### Step 1c: Dependency Ordering
+
+Determine which themes depend on which. The natural order is typically:
+
+```
+Schema/types → API/interfaces → Business logic → UI/presentation
+                                     ↑
+                              Tests travel with each
+```
+
+Constraints:
+- Each PR must build and pass tests when applied on top of its parent
+- Types and interfaces must be defined before they're used
+- Tests travel with the code they test (not in a separate PR, unless pure integration tests that span the full surface)
+
+-----
+
+### Phase 2: Plan Generation
+
+Produce a structured split plan. This is what the user reviews before anything is executed.
+
+#### Split Strategies (per PR)
+
+The tool picks the right strategy per-PR, not one-size-fits-all:
+
+| Strategy | When Used | Git Operations |
+|---|---|---|
+| commit-preserving | Commits are already CLEAN | `git cherry-pick` directly |
+| commit-reshuffling | Commits are MIXED/SCATTERED but separable by file | `git cherry-pick -n` + selective staging by file |
+| commit-decomposition | Same file has changes belonging to different themes | `git cherry-pick -n` + selective staging by hunk |
+| synthesized-refactor | AI restructures code for cleaner separation | Generate new code (flagged explicitly to user) |
+
+#### The Hybrid Decision Flow
+
+For a branch with 15 commits, the analysis might conclude:
+
+```
+Commits 1-3:   CLEAN, single concern each       → commit-preserving
+Commits 4-10:  MIXED/MESSY, interleaved concerns → commit-reshuffling or decomposition
+Commits 11-13: CLEAN tests                       → commit-preserving
+Commit 14:     DEPENDENT (fixes c5)              → squash into c5's theme
+Commit 15:     SCATTERED (review feedback)       → distribute across themes
+```
+
+The first three commits become PR 1 as-is. Commits 4-10 are decomposed by theme and redistributed across PRs 2-3. Commits 11-13 get distributed to the PRs whose code they test. Commit 14 is absorbed. Commit 15 is scattered back to its origins.
+
+#### Same-File, Same-Method Splitting
+
+The hardest case: a single function contains changes belonging to different themes.
+
+```python
+# Original (on main):
+def get_user(user_id: int) -> User:
+    user = db.query(User).get(user_id)
+    if not user:
+        raise NotFoundError()
+    return user
+
+# Modified (on big-feature):
+def get_user(user_id: int, include_deleted: bool = False) -> UserResponse:
+    cache_key = f"user:{user_id}"
+    if cached := cache.get(cache_key):          # Theme: caching
+        return UserResponse.from_orm(cached)
+
+    query = db.query(User)
+    if not include_deleted:                      # Theme: soft-delete
+        query = query.filter(User.deleted_at.is_(None))
+
+    user = query.get(user_id)
+    if not user:
+        raise APIError(404, "User not found",    # Theme: API error reform
+                       error_code="USER_NOT_FOUND")
+
+    cache.set(cache_key, user, ttl=300)          # Theme: caching
+    response = UserResponse.from_orm(user)       # Theme: response models
+    return response
+```
+
+Three concerns are woven into the same function. The decision framework:
+
+1. **Are the changes separable without creating broken intermediate states?**
+   YES → Line-level split (commit-decomposition).
+   NO → Continue to 2.
+
+2. **Is one concern clearly dominant (>70% of changes to this region)?**
+   YES → Keep together, assign to dominant theme.
+   NO → Continue to 3.
+
+3. **Can a clean refactor create separation points?**
+   YES → Generate a refactor-first PR (synthesized-refactor). This is flagged explicitly to the user.
+   NO → Keep together in the most relevant theme.
+
+The tool defaults to option 2 (keep together) when in doubt. Broken intermediate states are worse than slightly larger PRs.
+
+#### Self-Containment Heuristic
+
+To avoid trivial one-line PRs:
+
+- If a theme produces fewer than ~10 meaningful lines, merge it into the most related theme
+- If splitting a function creates an intermediate state that doesn't compile or pass type-checking, keep it together
+- "Fixup" and "review feedback" commits are distributed back to their parent themes, not given their own PRs
+- Each PR should tell a coherent story — a reviewer should understand *why* these changes go together
+
+#### Plan Format
+
+```yaml
+split_plan:
+  original_branch: big-feature
+  base: main
+  strategy: hybrid
+
+  pr_stack:
+    - title: "Add user schema and migration"
+      strategy: commit-preserving
+      source_commits: [c1, c6(partial)]
+      files: [migrations/003.sql, models/user.go]
+      tests: [models/user_test.go]
+      estimated_diff: "+127 -31"
+
+    - title: "Add user API endpoints"
+      strategy: commit-decomposition
+      source_commits: [c2, c3(partial), c4, c6(partial)]
+      files: [api/users.go, handlers/users.go, errors.go]
+      tests: [api/users_test.go]
+      estimated_diff: "+389 -98"
+      notes:
+        - "get_user() rewrite kept together — caching + response model
+           touch same lines, intermediate state would be broken"
+        - "c4 ('fix tests') squashed into this PR — it fixed c2's breakage"
+
+    - title: "Add user management UI"
+      strategy: commit-preserving
+      source_commits: [c5, c6(partial)]
+      files: [components/UserList.tsx, components/UserForm.tsx]
+      tests: [components/UserList.test.tsx]
+      estimated_diff: "+241 -52"
+
+    - title: "Add user integration tests"
+      strategy: commit-preserving
+      source_commits: [c7]
+      files: [e2e/users_test.go]
+      estimated_diff: "+90 -22"
+
+  decisions:
+    - "c4 squashed into PR 2 — it only fixed a test c2 broke"
+    - "c6 ('review feedback') distributed across PRs 1, 2, 3 by concern"
+    - "Linting fix in c2 (3 lines) kept with PR 2 — not worth a separate PR"
+
+  file_overlap:
+    - files: [models/user.go]
+      prs: [1, 2]
+      regions: "non-overlapping (PR1: schema, PR2: methods)"
+```
+
+The plan shows the *reasoning* behind grouping decisions, so the user can make informed adjustments.
+
+-----
+
+### Phase 3: User Review
+
+The plan is presented to the user via an interactive prompt. They can:
+
+- **Accept** as-is
+- **Adjust boundaries** — move files or commits between PRs
+- **Change ordering** — reorder PRs in the stack
+- **Rename** — change PR titles
+- **Merge** — combine two proposed PRs into one
+- **Reject** — re-analyze with guidance ("keep caching and API together", "split tests into their own PR")
+
+The plan can also be written to a YAML file (`sdf split --plan-only`) for offline editing, then executed later (`sdf split --from-plan <file>`).
+
+-----
+
+### Phase 4: Execution
+
+Create branches and apply changes. The original branch is never modified.
+
+```
+For each PR in the plan (ordered base-to-tip):
+  1. Determine parent:
+     - PR 1: parent is base branch (e.g., main)
+     - PR N: parent is stack branch N-1
+  2. Create branch from parent tip
+  3. Apply changes using the strategy:
+     - commit-preserving:
+         git cherry-pick <commits>
+     - commit-reshuffling:
+         git cherry-pick -n <commits>
+         git reset HEAD
+         git add <files-for-this-PR>
+         git commit
+         git checkout -- .    # discard remaining changes
+     - commit-decomposition:
+         git cherry-pick -n <commits>
+         git reset HEAD
+         git add -p           # stage specific hunks
+         git commit
+         git checkout -- .
+     - synthesized-refactor:
+         Write generated files
+         git add <files>
+         git commit
+  4. Record branch in new stack
+```
+
+#### Branch Naming
+
+Follows existing sdf conventions. Uses the stack ID as prefix with the configured separator:
+
+```
+Stack ID: users-feature
+Separator: /
+
+Branches:
+  users-feature/1-schema
+  users-feature/2-api
+  users-feature/3-ui
+  users-feature/4-tests
+```
+
+Respects `branch_prefix` configuration. The numeric prefix ensures merge order is unambiguous.
+
+#### Stack Registration
+
+Creates a new `.sdf/stacks/<name>.json` with the split stack topology. This means all existing sdf commands work immediately:
+
+- `sdf status` shows the new stack
+- `sdf sync` cascade-rebases if any PR is amended
+- `sdf merge` merges the head PR and shifts the stack
+- Context docs can be added to each branch
+
+-----
+
+### Phase 5: Validation
+
+Runs automatically after execution. Four layers, from cheapest to most thorough.
+
+#### Layer 1: Tree Identity (instant, hard gate)
+
+The strongest guarantee. The final tree of the stack must be byte-identical to the original branch's tree.
+
+```bash
+git diff original-branch stack/last
+# Must produce: empty output
+```
+
+If this diff is empty, then mathematically no change was lost or invented. The stack is a lossless decomposition of the original.
+
+This is cheap, deterministic, and a hard gate — if it fails, the split is rejected and nothing is pushed.
+
+**Exception:** If the user opted into a synthesized refactor, the trees will intentionally differ. In that case, the tool flags the specific files that differ and why:
+
+```
+⚠ Tree differs from original branch (synthesized refactor in PR 3)
+
+  Files that differ:
+    api/users.go      — caching extracted to decorator
+    cache/decorators.go — new file (not in original)
+
+  Run tests to verify semantic equivalence.
+```
+
+#### Layer 2: Patch Accounting (instant, informational)
+
+Verify that the sum of all PR diffs equals the original diff:
+
+```
+Original diff: 23 files changed, +847 -203
+
+Stack accounting:
+  PR 1 (schema):     4 files,  +127  -31
+  PR 2 (API):        8 files,  +389  -98
+  PR 3 (UI):         6 files,  +241  -52
+  PR 4 (int tests):  5 files,   +90  -22
+  ─────────────────────────────────────────
+  Total:            23 files,  +847 -203  ✓ matches original
+
+Files in original but not in any PR: none  ✓
+Files in stack but not in original: none   ✓
+```
+
+#### Layer 3: File Overlap Analysis (instant, informational)
+
+When the same file appears in multiple adjacent PRs, verify the changes target non-overlapping regions:
+
+```
+File overlap analysis:
+  api/users.go appears in PR 2 and PR 3
+    PR 2 changes: lines 14-45 (endpoint handlers)
+    PR 3 changes: lines 89-102 (response serialization)
+    Overlap: none ✓
+
+  models/user.go appears in PR 1 and PR 2
+    PR 1 changes: lines 5-12 (add deleted_at column)
+    PR 2 changes: lines 5-8 (add deleted_at column) ⚠ OVERLAP
+    → Risk: PR 2 may conflict when rebased after PR 1 merges
+```
+
+#### Layer 4: Build + Test Verification (mode-dependent)
+
+For each PR in the stack, verify it independently:
+
+- **`--ship` mode (default):** Skip local verification. Push all PRs and let CI run in parallel across all of them simultaneously. This is faster (5 minutes CI vs 20 minutes sequential local) and CI is the canonical environment.
+
+- **`--local` mode:** Run build + typecheck + lint + tests per PR sequentially before pushing. For repos without CI, or when you want confidence before pushing to a shared repo.
+
+#### Validation Report
+
+After validation completes:
+
+```
+Split validation report
+═══════════════════════
+
+Tree identity:
+  git diff big-feature stack/4-tests  →  ✓ identical
+
+Patch accounting:
+  Files:       23/23 accounted for    ✓
+  Insertions:  847/847                ✓
+  Deletions:   203/203                ✓
+
+File overlap:
+  2 files in multiple PRs
+    models/user.go (PR 1, PR 2)  →  ✓ non-overlapping regions
+    api/users.go (PR 2, PR 3)    →  ✓ non-overlapping regions
+
+Result: Split is valid ✓
+```
+
+If any check fails, the split is rejected and the user sees the specific failure with a suggested fix.
+
+-----
+
+### Phase 6: Ship
+
+Default mode. Runs after validation passes.
+
+```
+For each PR in the stack:
+  1. git push -u origin <branch>
+  2. gh pr create --title <title> --body <body> --base <parent-branch>
+```
+
+All branches are pushed, then all PRs are created. PR bodies include:
+
+- Stack navigation links (reusing existing `prnav.go` logic)
+- The split plan's notes for this PR (explaining what's in it and why)
+- A reference to the original branch: "Split from `big-feature`"
+- Per-PR estimated diff stats
+
+The stack is then fully functional — mergeable head-to-tail, each PR independently reviewable, CI running on all PRs in parallel.
+
+-----
+
+### Phase 7: Post-Ship Monitoring
+
+#### `sdf split status`
+
+Check CI results across the entire split stack:
+
+```
+sdf split status
+
+  PR #201 (schema)     ✓ CI passed
+  PR #202 (API)        ✗ CI failed: ImportError 'UserResponse' (defined in PR 3)
+  PR #203 (UI)         ✓ CI passed
+  PR #204 (tests)      ✓ CI passed
+
+  Suggested fix: Move UserResponse definition from PR 3 to PR 2
+  Run: sdf split fix
+```
+
+#### `sdf split fix`
+
+Diagnoses common mid-stack CI failures and applies targeted fixes:
+
+- Missing imports (type defined in later PR, used in earlier one)
+- Missing migration dependencies
+- Undefined types or functions at intermediate stack levels
+- Test fixtures not available at the PR's stack level
+
+After fixing, force-pushes only the affected PRs. Other PRs are untouched.
+
+-----
+
+## Integration With Existing sdf
+
+The split creates a standard sdf stack. After splitting:
+
+| Command | Behavior |
+|---|---|
+| `sdf status` | Shows the split stack with all PRs and their CI state |
+| `sdf sync` | Cascade-rebases if any PR in the split is amended |
+| `sdf merge` | Merges the head PR and shifts the stack forward |
+| `sdf pr` | Works on new branches added to the split stack |
+| `sdf context` | Context docs can be created for each split branch |
+| `sdf switch` | Navigate between split branches |
+
+The original branch remains as a reference. The user can delete it when satisfied with the split, or keep it indefinitely.
+
+-----
+
+## Architecture
+
+Following existing codebase patterns. All packages shell out to `git`, `gh`, and `claude` — no reimplementation.
+
+| Component | Location | Purpose |
+|---|---|---|
+| `cmd/split.go` | Cobra command | CLI entry point, flags, orchestration |
+| `internal/split/analyze.go` | Analysis engine | Commit classification, theme extraction via Claude |
+| `internal/split/plan.go` | Plan model | Plan structure, YAML serialization, user-facing display |
+| `internal/split/execute.go` | Execution engine | Branch creation, cherry-pick, selective staging |
+| `internal/split/validate.go` | Validation suite | Tree identity, patch accounting, overlap analysis |
+| `internal/split/fix.go` | Post-ship repair | Diagnose + fix mid-stack CI failures |
+
+### Dependencies on existing packages
+
+- `internal/git` — branch creation, cherry-pick, diff, rebase operations
+- `internal/gh` — PR creation, PR editing, PR state queries
+- `internal/claude` — theme extraction, split reasoning, fix suggestions
+- `internal/stack` — stack creation, persistence, topology
+- `internal/config` — branch prefix, PR title generation
+- `internal/ui` — interactive plan review, progress display
+- `cmd/prnav.go` — stack navigation links in PR bodies
+
+### New git operations needed
+
+The existing `internal/git` package will need additions:
+
+```go
+// Cherry-pick without committing (for selective staging)
+func CherryPickNoCommit(sha string) (string, error)
+
+// Stage specific files (for commit-reshuffling)
+func AddFiles(paths []string) (string, error)
+
+// Stage specific hunks via patch (for commit-decomposition)
+func ApplyPatch(patch string) (string, error)
+
+// Compare two trees for identity
+func DiffTree(ref1, ref2 string) (string, error)
+
+// Get per-file diff stats between two refs
+func DiffStatFiles(base, head string) ([]FileStat, error)
+
+// Get hunks for a specific file between two refs
+func DiffFileHunks(base, head, file string) ([]Hunk, error)
+```
+
+-----
+
+## Testing Strategy
+
+Following existing patterns:
+
+| Test Type | What It Covers |
+|---|---|
+| Unit tests (`*_test.go`) | Plan generation, validation logic, commit classification |
+| Golden file tests | Plan YAML output, validation reports, PR body formatting |
+| Property-based tests | Invariant: tree identity holds for random commit sequences |
+| E2E tests | Full split pipeline against real GitHub sandbox repo |
+
+### Key test scenarios
+
+1. **Clean branch** — all commits are well-structured, commit-preserving strategy throughout
+2. **Messy branch** — WIP commits, fixups, review feedback scattered across concerns
+3. **Same-file split** — two themes modify the same file in non-overlapping regions
+4. **Same-function split** — two themes modify the same function (should keep together)
+5. **Single commit branch** — one giant commit that needs full decomposition
+6. **Already a stack** — branch is already well-structured, split is a no-op or trivial
+7. **Synthesized refactor** — tree identity check correctly flags intentional differences
+8. **Empty split** — no changes to split (error case)
+
+-----
+
+## Design Principles
+
+1. **Original branch is never touched.** The split is a non-destructive projection. This is non-negotiable.
+
+2. **Each PR builds and passes tests independently.** Mergeable head-to-tail. If merging PR 1 leaves failing tests, the split boundary is wrong.
+
+3. **Tests travel with the code they test.** Unit tests go in the PR that introduces the code. Integration tests go in the PR that completes the surface they exercise.
+
+4. **Tree identity is the mechanical trust anchor.** If `git diff original stack/tip` is empty, nothing was lost. Everything else validates that intermediate states are sane.
+
+5. **Ship fast, validate in CI.** Push all PRs and let CI run in parallel by default. Local validation is opt-in for repos without CI.
+
+6. **Hybrid strategy, not one-size-fits-all.** Clean commits are preserved. Messy commits are decomposed. The tool picks the right approach per-region automatically.
+
+7. **Transparent reasoning.** The plan shows *why* changes were grouped the way they were. No black-box splitting — the user sees the logic and can adjust.
+
+8. **Optimize for review experience.** Each PR should tell a coherent story. A reviewer should understand the intent without cross-referencing other PRs.
+
+-----
+
+## Open Questions
+
+1. **Plan editing UX** — Interactive TUI editor vs. YAML file editing vs. simple accept/reject/adjust prompts? The existing `charmbracelet/huh` prompts may be sufficient for simple adjustments; a YAML file is better for complex rearrangements.
+
+2. **Claude context window** — Very large diffs may exceed Claude's context. Strategy: hierarchical analysis (file-level first, then hunk-level for files that need decomposition) rather than sending the entire diff at once.
+
+3. **Partial re-split** — Should `sdf split fix` be able to re-split a single PR in the stack without touching the others? This would be useful when CI reveals that one PR is still too large or has the wrong boundaries.
+
+4. **Relationship to original branch** — After a successful split, should the tool suggest deleting the original branch? Or keep it as a permanent reference? Current design: keep it, let the user decide.
+
+5. **Config options** — What should be configurable? Candidates: minimum PR size threshold, default validation mode (ship vs local), branch naming pattern, whether to auto-create context docs for split branches.


### PR DESCRIPTION
<!-- sdf:description -->
Adds two design documents for the planned `sdf split` feature: a high-level implementation plan (`PLAN-pr-splitting.md`) and a detailed design document (`SPLIT-DESIGN.md`). The feature will allow users to take a large branch and automatically decompose it into a chain of smaller, independently reviewable PRs managed as an sdf stack. The documents cover three modes of operation (AI-planned, user-provided plan, and interactive hybrid), split strategies ranging from simple file-based assignment to hunk-level commit decomposition, a validation pipeline anchored by tree-identity checks, and post-ship CI monitoring with auto-fix capabilities. These docs establish the architectural foundation before implementation begins.
<!-- /sdf:description -->

Part of stack: **feature-split**

Split from `claude/sdf-pr-stacking-plan-taR5V` — PR 1 of 9

Base: `main`

<!-- sdf:stack-nav -->
---
Stack: `feature-split`
1. https://github.com/pavelpascari/sdf/pull/57 ◀ this PR
2. https://github.com/pavelpascari/sdf/pull/58
3. https://github.com/pavelpascari/sdf/pull/59
4. https://github.com/pavelpascari/sdf/pull/60
5. https://github.com/pavelpascari/sdf/pull/61
6. https://github.com/pavelpascari/sdf/pull/62
7. https://github.com/pavelpascari/sdf/pull/63
8. https://github.com/pavelpascari/sdf/pull/64
9. https://github.com/pavelpascari/sdf/pull/65
<!-- /sdf:stack-nav -->