### PR TITLE
add sdf split command for AI-powered branch decomposition

### DIFF
--- a/cmd/split.go
+++ b/cmd/split.go
@@ -39,8 +39,8 @@ func init() {
 	splitCmd.Flags().Bool("dry-run", false, "show the split plan without executing")
 	splitCmd.Flags().BoolP("yes", "y", false, "skip confirmation prompt")
 	splitCmd.Flags().Bool("no-push", false, "create branches locally without pushing or creating PRs")
-	splitCmd.MarkFlagRequired("from")
-	splitCmd.MarkFlagRequired("stack")
+	_ = splitCmd.MarkFlagRequired("from")
+	_ = splitCmd.MarkFlagRequired("stack")
 }
 
 // RunSplit is a compatibility wrapper for tests.
@@ -194,7 +194,7 @@ func runSplitCmd(cmd *cobra.Command, args []string) error {
 						fmt.Fprintf(os.Stderr, "\n%s %s\n", ui.SymWarn, reason)
 						fmt.Println("Shared files deduplicated — each kept in its first layer.")
 						plan = splitpkg.DeduplicateSharedFiles(plan)
-						splitpkg.SavePlan(planPath, plan)
+						_ = splitpkg.SavePlan(planPath, plan)
 						displaySplitPlan(plan, stackName, base, fromBranch)
 					}
 
@@ -238,7 +238,7 @@ func runSplitCmd(cmd *cobra.Command, args []string) error {
 
 				continue
 			default:
-				// abort or empty (user cancelled)
+				// abort or empty (user canceled)
 				fmt.Println("Aborted.")
 				return nil
 			}
@@ -304,7 +304,7 @@ execute:
 	pushFailed := false
 	for _, b := range branches {
 		if err := gitpkg.PushNew(b); err != nil {
-			fmt.Fprintf(os.Stderr, "  %s could not push %s: %v\n", ui.SymWarn, ui.Branch(b), err)
+			fmt.Fprintf(os.Stderr, "  %s could not push %s: %v\n", ui.SymWarn, ui.Branch(b), err) //nolint:gosec // XSS not applicable in CLI output
 			pushFailed = true
 		} else {
 			fmt.Printf("  %s %s\n", ui.SymOK, ui.Branch(b))
@@ -312,7 +312,8 @@ execute:
 	}
 
 	// --- Create PRs ---
-	if !pushFailed && ghpkg.Available() {
+	switch {
+	case !pushFailed && ghpkg.Available():
 		s, err := stack.LoadStack(root, stackName)
 		if err == nil {
 			cfg, _ := cfgpkg.Load(root)
@@ -322,10 +323,10 @@ execute:
 				fmt.Println("  You can create them manually with: sdf pr (from each branch)")
 			}
 		}
-	} else if pushFailed {
+	case pushFailed:
 		fmt.Println("\nSkipped PR creation (push failed for some branches).")
 		fmt.Println("Push manually, then create PRs with: sdf pr")
-	} else {
+	default:
 		fmt.Println("\nSkipped PR creation (gh CLI not available).")
 		fmt.Println("Install gh from https://cli.github.com, then run: sdf pr")
 	}
@@ -484,4 +485,3 @@ func printStackChain(s *stack.Stack) {
 	}
 	fmt.Printf("\n  %s\n", strings.Join(parts, " ← "))
 }
-

--- a/cmd/split_test.go
+++ b/cmd/split_test.go
@@ -167,4 +167,3 @@ func TestBuildSplitPRBody(t *testing.T) {
 		t.Errorf("body should say PR 2 of 3, got:\n%s", body)
 	}
 }
-

--- a/www/src/data/cli-reference.json
+++ b/www/src/data/cli-reference.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-02-26T00:46:59Z",
+  "generated": "2026-02-26T00:50:48Z",
   "commands": [
     {
       "name": "ai",
@@ -190,6 +190,53 @@
       "use": "register",
       "short": "Discover and sync PR stacks from GitHub",
       "deprecated": "use `sdf fetch` instead"
+    },
+    {
+      "name": "split",
+      "category": "stack",
+      "use": "split",
+      "short": "Split a branch into a stack of smaller PRs",
+      "long": "Uses an AI agent to analyze a branch and decompose it into a chain of\nfocused, reviewable PRs managed as an sdf stack.\n\nRequires the Claude CLI to be installed. The original branch is never modified.",
+      "example": "  sdf split --from feature/big-change --stack my-feature\n  sdf split --from feature/big-change --stack my-feature --dry-run\n  sdf split --from feature/big-change --stack my-feature --base main -y",
+      "flags": [
+        {
+          "name": "base",
+          "type": "string",
+          "default": "",
+          "description": "base branch (default: auto-detected)"
+        },
+        {
+          "name": "dry-run",
+          "type": "bool",
+          "default": "false",
+          "description": "show the split plan without executing"
+        },
+        {
+          "name": "from",
+          "type": "string",
+          "default": "",
+          "description": "source branch to split (required)"
+        },
+        {
+          "name": "no-push",
+          "type": "bool",
+          "default": "false",
+          "description": "create branches locally without pushing or creating PRs"
+        },
+        {
+          "name": "stack",
+          "type": "string",
+          "default": "",
+          "description": "name for the new stack (required)"
+        },
+        {
+          "name": "yes",
+          "shorthand": "y",
+          "type": "bool",
+          "default": "false",
+          "description": "skip confirmation prompt"
+        }
+      ]
     },
     {
       "name": "status",


### PR DESCRIPTION
<!-- sdf:description -->
Adds the `sdf split` command, which uses an AI agent (Claude CLI) to analyze a large feature branch and decompose it into a chain of focused, reviewable PRs managed as an sdf stack. The command provides an interactive menu where users can review the proposed split plan, refine it through a Claude session, or execute it — creating branches, pushing to origin, and opening PRs with stack navigation. The original branch is never modified, and a tree identity check ensures the split is lossless. Includes precondition validation (clean tree, branch existence, stack name availability) and tests covering error paths.
<!-- /sdf:description -->

Part of stack: **feature-split**

Split from `claude/sdf-pr-stacking-plan-taR5V` — PR 8 of 9

Base: `feature-split/7-split-execution`

<!-- sdf:stack-nav -->
---
Stack: `feature-split`
1. https://github.com/pavelpascari/sdf/pull/57
2. https://github.com/pavelpascari/sdf/pull/58
3. https://github.com/pavelpascari/sdf/pull/59
4. https://github.com/pavelpascari/sdf/pull/60
5. https://github.com/pavelpascari/sdf/pull/61
6. https://github.com/pavelpascari/sdf/pull/62
7. https://github.com/pavelpascari/sdf/pull/63
8. https://github.com/pavelpascari/sdf/pull/64 ◀ this PR
9. https://github.com/pavelpascari/sdf/pull/65
<!-- /sdf:stack-nav -->