### PR TITLE
add design docs for hunk-level decomposition and plan refinement

### DIFF
--- a/docs/plans/2026-02-23-split-hunk-level-design.md
+++ b/docs/plans/2026-02-23-split-hunk-level-design.md
@@ -1,0 +1,364 @@
+# sdf split — Hunk-Level Decomposition (Iteration 4)
+
+## Summary
+
+Extend `sdf split` to split individual files across multiple layers at the diff hunk level. A file whose changes span multiple concerns can have its hunks assigned to different layers instead of being forced into the earliest one.
+
+Uses a two-phase Claude analysis: Phase 1 groups files into layers (same as iteration 3, but files *may* appear in multiple layers). Phase 2 runs only for "shared files" — sdf parses their diffs into numbered hunks and asks Claude to assign each hunk to a layer.
+
+Backward compatible — branches where every file belongs to a single layer behave identically to iteration 3.
+
+---
+
+## Command Interface
+
+No changes to the CLI. Same flags and behavior as iteration 3:
+
+```
+sdf split --from <branch> --stack <name>
+sdf split --from <branch> --stack <name> --dry-run
+sdf split --from <branch> --stack <name> --no-push
+sdf split --from <branch> --stack <name> --base <branch>
+sdf split --from <branch> --stack <name> -y
+```
+
+---
+
+## Two-Phase Analysis
+
+### Phase 1: File-Level Grouping
+
+Nearly identical to iteration 3. The key change: relax the "every file in exactly one layer" constraint.
+
+**Prompt change** (single line):
+```
+- A file MAY appear in multiple layers if its changes clearly serve different concerns.
+  When a file appears in multiple layers, we'll assign individual hunks in a follow-up step.
+- If all of a file's changes belong to one concern, list it in only one layer.
+```
+
+**Output**: same YAML format as iteration 3. Files may repeat across layers.
+
+### Phase 2: Hunk Assignment (conditional)
+
+Triggered only when Phase 1 produces "shared files" (files listed in >1 layer).
+
+For each shared file:
+
+1. sdf extracts the full diff: `git diff base...source -- <file>`
+2. sdf parses the diff into numbered hunks (0-indexed)
+3. sdf sends a targeted follow-up prompt via `--resume <session_id>`
+
+**Phase 2 prompt** (per batch of shared files):
+
+```
+Some files in your plan appear in multiple layers. I've extracted their diff hunks below.
+For each file, assign every hunk to exactly one of the layers you listed it in.
+
+## <filepath>
+Layers: <layer-a>, <layer-b>
+
+Hunk 0:
+@@ -10,7 +10,8 @@ func Foo() {
+ context
+-removed
++added
+ context
+
+Hunk 1:
+@@ -25,3 +26,5 @@ func Bar() {
+ context
++new line
+ context
+
+---
+
+Return ONLY this YAML (wrapped in ```yaml fences):
+
+```yaml
+hunk_assignments:
+  - file: <filepath>
+    assignments:
+      - hunk: 0
+        layer: <layer-name>
+      - hunk: 1
+        layer: <layer-name>
+```
+```
+
+**Retry**: same session-resume retry logic as Phase 1 (up to 3 retries), validating that every hunk is assigned to exactly one layer that originally listed the file.
+
+### Merging phases into final plan
+
+After Phase 2, sdf merges the results:
+
+1. Files in only one layer → `Layer.Files` (whole files, same as iteration 3)
+2. Shared files → removed from `Layer.Files`, added to `Layer.PartialFiles` with their hunk indices
+
+---
+
+## Plan Format
+
+### Extended data structures
+
+```go
+type Plan struct {
+    Layers []Layer `yaml:"layers"`
+}
+
+type Layer struct {
+    Name         string        `yaml:"name"`
+    Description  string        `yaml:"description"`
+    Files        []string      `yaml:"files"`
+    PartialFiles []PartialFile `yaml:"partial_files,omitempty"`
+}
+
+type PartialFile struct {
+    Path  string `yaml:"path"`
+    Hunks []int  `yaml:"hunks"`
+}
+```
+
+### Phase 2 response structures
+
+```go
+type HunkAssignmentResponse struct {
+    HunkAssignments []FileHunkAssignment `yaml:"hunk_assignments"`
+}
+
+type FileHunkAssignment struct {
+    File        string           `yaml:"file"`
+    Assignments []HunkAssignment `yaml:"assignments"`
+}
+
+type HunkAssignment struct {
+    Hunk  int    `yaml:"hunk"`
+    Layer string `yaml:"layer"`
+}
+```
+
+### Example merged plan
+
+```yaml
+layers:
+  - name: db-schema
+    description: "Add users table with migration"
+    files:
+      - migrations/001_create_users.sql
+    partial_files:
+      - path: internal/models/user.go
+        hunks: [0, 2]
+
+  - name: api-handlers
+    description: "REST endpoints for user management"
+    files:
+      - internal/handlers/users.go
+      - internal/handlers/users_test.go
+    partial_files:
+      - path: internal/models/user.go
+        hunks: [1, 3]
+```
+
+---
+
+## Hunk Parsing
+
+New package-level utilities in `internal/split/hunk.go`.
+
+### ParseHunks
+
+```go
+// Hunk represents a single diff hunk for one file.
+type Hunk struct {
+    Header string // the @@ line
+    Body   string // all lines after the header, up to the next hunk or file
+}
+
+// FileDiff represents all hunks for a single file in a unified diff.
+type FileDiff struct {
+    Header string // diff --git, index, ---, +++ lines
+    Path   string // file path extracted from the header
+    Hunks  []Hunk
+}
+
+// ParseDiff splits a unified diff string into per-file sections with numbered hunks.
+func ParseDiff(diff string) []FileDiff
+```
+
+### FilterHunks
+
+```go
+// FilterHunks reconstructs a valid patch containing only the specified hunks
+// from a FileDiff. The returned string is suitable for git apply.
+func FilterHunks(fd FileDiff, indices []int) string
+```
+
+The reconstructed patch includes the file header (`diff --git`, `index`, `---`, `+++`) followed by only the selected hunk headers and bodies. Line numbers in `@@` headers are left as-is — `git apply --3way` handles the merge correctly since it falls back to three-way merge using the common ancestor.
+
+---
+
+## Execution Engine Changes
+
+### Current flow (iteration 3)
+
+For each layer: extract diff for whole files → apply → commit.
+
+### New flow (iteration 4)
+
+For each layer:
+1. Checkout parent branch
+2. Create layer branch
+3. **Whole files**: same as before — `git diff base...source -- file1 file2` → apply
+4. **Partial files**: for each partial file:
+   a. Get full diff: `git diff base...source -- <file>`
+   b. Parse into `FileDiff`
+   c. Filter to only this layer's hunk indices
+   d. Apply filtered patch via `git apply --3way`
+5. Stage and commit
+
+The key insight: `git apply --3way` resolves against the merge base, so applying subset hunks to a branch that may already have other hunks from a previous layer works correctly — the hunks operate on independent regions of the file.
+
+### Tree identity check
+
+Unchanged — `git diff source_branch last_layer_branch` must still be empty. This validates that the hunk-level split is lossless.
+
+---
+
+## Validation Changes
+
+### Phase 1 validation (relaxed)
+
+Replaces `ValidatePlan` with `ValidatePhase1`:
+
+1. **Coverage**: every changed file appears in at least one layer
+2. **No extras**: no file that isn't in the diff
+3. **Non-empty layers**: every layer has at least one file
+4. **Valid names**: kebab-case
+
+Note: duplicates are no longer errors — they signal shared files that need Phase 2.
+
+### Phase 2 validation (new)
+
+`ValidateHunkAssignment(response, sharedFiles, hunkCounts)`:
+
+1. **Completeness**: every hunk of every shared file is assigned
+2. **No duplicates**: no hunk assigned to multiple layers
+3. **Valid layers**: each hunk assigned to a layer that listed the file
+4. **Valid indices**: all hunk indices are within range
+
+### Final plan validation (post-merge) *(deferred to iteration 5)*
+
+`ValidateFinalPlan` is not yet implemented. The tree identity check at execution time (`git diff source last_layer` must be empty) catches any issues with malformed merged plans. Explicit pre-execution validation would provide clearer error messages and avoid unnecessary branch creation.
+
+---
+
+## User-Facing Output
+
+### Plan display (updated)
+
+```
+Split plan for my-feature (base: main)
+──────────────────────────────────────────────────
+
+  Layer 1: db-schema (2 files, +320 lines)
+    Add users table with migration
+    Shared: internal/models/user.go (hunks 0, 2)
+
+  Layer 2: api-handlers (3 files, +480 lines)
+    REST endpoints for user management
+    Shared: internal/models/user.go (hunks 1, 3)
+
+  Total: 4 files across 2 layers (1 file split at hunk level)
+──────────────────────────────────────────────────
+```
+
+Shared files are shown with their hunk indices so the user can verify the assignment.
+
+---
+
+## File Structure
+
+### New files
+
+- `internal/split/hunk.go` — `Hunk`, `FileDiff`, `ParseDiff`, `FilterHunks`
+- `internal/split/hunk_test.go` — unit tests for hunk parsing/filtering
+
+### Modified files
+
+- `internal/split/plan.go` — add `PartialFile` struct, `HunkAssignmentResponse` structs, `ValidatePhase1`, `ValidateHunkAssignment`, `ValidateFinalPlan`; update `ParsePlan` for backward compat
+- `internal/split/plan_test.go` — new tests for Phase 1 validation, hunk assignment validation, final validation
+- `internal/split/ai.go` — add `BuildHunkPrompt`, update `Analyze` for two-phase flow
+- `internal/split/ai_test.go` — tests for hunk prompt construction
+- `internal/split/execute.go` — update `Execute` to handle `PartialFiles`
+- `internal/split/execute_test.go` — test with shared files and hunk-level split
+- `cmd/split.go` — update `displaySplitPlan` to show shared file info
+
+---
+
+## Error Handling
+
+### Phase 2 specific errors
+
+| Condition | Error |
+|-----------|-------|
+| Hunk index out of range | `"hunk %d for %s is out of range (0-%d)"` |
+| Hunk assigned to wrong layer | `"hunk %d for %s assigned to %q which didn't list the file"` |
+| Missing hunk assignment | `"hunk %d for %s is not assigned to any layer"` |
+| Duplicate hunk assignment | `"hunk %d for %s assigned to both %q and %q"` |
+| Hunk patch apply failure | `"cannot apply hunks for %s in layer %s: %w"` |
+
+### Retry behavior
+
+Phase 2 retries independently from Phase 1, using the same session (so Claude has full context). Up to 3 retries on validation failure, same as Phase 1.
+
+---
+
+## Testing Strategy
+
+### internal/split/hunk_test.go — Unit tests (no git)
+
+- Parse single-file diff into hunks
+- Parse multi-file diff
+- Parse diff with no hunks (empty)
+- Filter specific hunks
+- Filter all hunks (whole file)
+- Reconstruct valid patch from filtered hunks
+
+### internal/split/plan_test.go — Extended validation tests
+
+- Phase 1 validation: shared files are OK (not errors)
+- Phase 1 validation: files still must be in the diff
+- Hunk assignment validation: all hunks assigned → pass
+- Hunk assignment validation: missing hunk → error
+- Hunk assignment validation: duplicate hunk → error
+- Hunk assignment validation: wrong layer → error
+- Final plan validation with partial files
+
+### internal/split/ai_test.go — Hunk prompt tests
+
+- Hunk prompt includes numbered hunks
+- Hunk prompt includes layer names
+- Hunk assignment response parsing
+
+### internal/split/execute_test.go — Hunk execution tests
+
+- Split with shared file: 2 layers, 1 file split across them
+- Tree identity holds after hunk-level split
+- Mixed plan: some whole files, some partial files
+
+---
+
+## Known Limitations
+
+- **Overlapping context lines**: If two hunks are very close together, git may merge their context lines, making them one hunk. This is inherent to unified diff format and means fine-grained splitting has limits.
+- **Binary files**: Always assigned as whole files. Hunk-level splitting only applies to text diffs.
+- **Rename detection**: `git diff` may report a file as renamed. Renames go as whole files to one layer.
+
+---
+
+## Future Work (iteration 5+)
+
+- **Plan editing UX**: open plan in `$EDITOR` before execution
+- **YAML plan import**: `sdf split --plan <file>` to skip AI and use a user-provided plan
+- **`--refine` flag**: resume Claude session to adjust the plan interactively
+- **Save plans to disk**: persist YAML plan to `.sdf/split-plans/<stack-name>.yaml`

--- a/docs/plans/2026-02-23-split-hunk-level-impl.md
+++ b/docs/plans/2026-02-23-split-hunk-level-impl.md
@@ -1,0 +1,1514 @@
+# Hunk-Level Decomposition Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extend `sdf split` to split individual files across layers at the diff hunk level via a two-phase Claude analysis.
+
+**Architecture:** Phase 1 groups files into layers (relaxing the one-file-per-layer constraint). Phase 2 runs only for "shared files" (files in >1 layer) — sdf parses their diffs into numbered hunks and asks Claude to assign each hunk. The execution engine applies filtered patches per layer.
+
+**Tech Stack:** Go 1.24, `gopkg.in/yaml.v3`, Claude CLI (streaming JSON), git diff/apply
+
+**Design doc:** `docs/plans/2026-02-23-split-hunk-level-design.md`
+
+---
+
+### Task 1: Hunk Parsing — ParseDiff, FilterHunks, FormatNumberedHunks
+
+**Files:**
+- Create: `internal/split/hunk.go`
+- Create: `internal/split/hunk_test.go`
+
+**Step 1: Write failing tests in `internal/split/hunk_test.go`**
+
+```go
+package split
+
+import (
+	"strings"
+	"testing"
+)
+
+const testDiffTwoHunks = `diff --git a/user.go b/user.go
+index abc123..def456 100644
+--- a/user.go
++++ b/user.go
+@@ -1,5 +1,6 @@
+ package models
+
+ type User struct {
++	Email string
+ 	Name  string
+ }
+@@ -10,3 +11,7 @@ func (u *User) String() string {
+ 	return u.Name
+ }
++
++func (u *User) Validate() error {
++	return nil
++}
+`
+
+const testDiffTwoFiles = `diff --git a/one.go b/one.go
+index aaa..bbb 100644
+--- a/one.go
++++ b/one.go
+@@ -1,3 +1,4 @@
+ package main
++import "fmt"
+ func main() {}
+diff --git a/two.go b/two.go
+index ccc..ddd 100644
+--- a/two.go
++++ b/two.go
+@@ -1,2 +1,3 @@
+ package main
++func helper() {}
+`
+
+func TestParseDiff_SingleFileTwoHunks(t *testing.T) {
+	files := ParseDiff(testDiffTwoHunks)
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+	fd := files[0]
+	if fd.Path != "user.go" {
+		t.Errorf("path: got %q, want %q", fd.Path, "user.go")
+	}
+	if len(fd.Hunks) != 2 {
+		t.Fatalf("expected 2 hunks, got %d", len(fd.Hunks))
+	}
+	if !strings.HasPrefix(fd.Hunks[0].Header, "@@ -1,5 +1,6") {
+		t.Errorf("hunk 0 header: %q", fd.Hunks[0].Header)
+	}
+	if !strings.HasPrefix(fd.Hunks[1].Header, "@@ -10,3 +11,7") {
+		t.Errorf("hunk 1 header: %q", fd.Hunks[1].Header)
+	}
+	if !strings.Contains(fd.Hunks[0].Body, "Email") {
+		t.Error("hunk 0 body should contain Email")
+	}
+	if !strings.Contains(fd.Hunks[1].Body, "Validate") {
+		t.Error("hunk 1 body should contain Validate")
+	}
+}
+
+func TestParseDiff_TwoFiles(t *testing.T) {
+	files := ParseDiff(testDiffTwoFiles)
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(files))
+	}
+	if files[0].Path != "one.go" {
+		t.Errorf("file 0 path: %q", files[0].Path)
+	}
+	if files[1].Path != "two.go" {
+		t.Errorf("file 1 path: %q", files[1].Path)
+	}
+	if len(files[0].Hunks) != 1 {
+		t.Errorf("file 0 hunks: got %d, want 1", len(files[0].Hunks))
+	}
+	if len(files[1].Hunks) != 1 {
+		t.Errorf("file 1 hunks: got %d, want 1", len(files[1].Hunks))
+	}
+}
+
+func TestParseDiff_Empty(t *testing.T) {
+	files := ParseDiff("")
+	if len(files) != 0 {
+		t.Errorf("expected 0 files for empty diff, got %d", len(files))
+	}
+}
+
+func TestFilterHunks_SelectOne(t *testing.T) {
+	files := ParseDiff(testDiffTwoHunks)
+	fd := files[0]
+
+	// Select only hunk 1 (the Validate function)
+	patch := FilterHunks(fd, []int{1})
+
+	if !strings.Contains(patch, "diff --git") {
+		t.Error("patch should have file header")
+	}
+	if !strings.Contains(patch, "Validate") {
+		t.Error("patch should contain hunk 1 content")
+	}
+	if strings.Contains(patch, "Email") {
+		t.Error("patch should NOT contain hunk 0 content")
+	}
+}
+
+func TestFilterHunks_SelectAll(t *testing.T) {
+	files := ParseDiff(testDiffTwoHunks)
+	fd := files[0]
+
+	all := FilterHunks(fd, []int{0, 1})
+	// Should contain both hunks
+	if !strings.Contains(all, "Email") {
+		t.Error("all-hunks patch should contain hunk 0")
+	}
+	if !strings.Contains(all, "Validate") {
+		t.Error("all-hunks patch should contain hunk 1")
+	}
+}
+
+func TestFormatNumberedHunks(t *testing.T) {
+	files := ParseDiff(testDiffTwoHunks)
+	fd := files[0]
+
+	formatted := FormatNumberedHunks(fd)
+	if !strings.Contains(formatted, "Hunk 0:") {
+		t.Error("should contain Hunk 0 label")
+	}
+	if !strings.Contains(formatted, "Hunk 1:") {
+		t.Error("should contain Hunk 1 label")
+	}
+	if !strings.Contains(formatted, "Email") {
+		t.Error("should contain hunk 0 content")
+	}
+	if !strings.Contains(formatted, "Validate") {
+		t.Error("should contain hunk 1 content")
+	}
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/split/ -run TestParseDiff -v && go test ./internal/split/ -run TestFilterHunks -v && go test ./internal/split/ -run TestFormatNumberedHunks -v`
+Expected: FAIL — functions not defined
+
+**Step 3: Implement `internal/split/hunk.go`**
+
+```go
+package split
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Hunk represents a single diff hunk within a file.
+type Hunk struct {
+	Header string // the @@ line (with trailing newline)
+	Body   string // lines after the header, up to next hunk or file
+}
+
+// FileDiff represents all hunks for a single file in a unified diff.
+type FileDiff struct {
+	Header string // diff --git, index, ---, +++ lines (with newlines)
+	Path   string // file path extracted from diff --git header
+	Hunks  []Hunk
+}
+
+// ParseDiff splits a unified diff string into per-file sections with numbered hunks.
+func ParseDiff(diff string) []FileDiff {
+	if diff == "" {
+		return nil
+	}
+
+	lines := strings.Split(diff, "\n")
+	// Remove trailing empty string from Split if diff ends with newline
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	var result []FileDiff
+	var current *FileDiff
+	var currentHunk *Hunk
+
+	flush := func() {
+		if currentHunk != nil && current != nil {
+			current.Hunks = append(current.Hunks, *currentHunk)
+			currentHunk = nil
+		}
+		if current != nil {
+			result = append(result, *current)
+			current = nil
+		}
+	}
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "diff --git ") {
+			flush()
+			current = &FileDiff{Header: line + "\n"}
+			parts := strings.SplitN(line, " ", 4)
+			if len(parts) >= 3 {
+				current.Path = strings.TrimPrefix(parts[2], "a/")
+			}
+			continue
+		}
+
+		if strings.HasPrefix(line, "@@") && current != nil {
+			if currentHunk != nil {
+				current.Hunks = append(current.Hunks, *currentHunk)
+			}
+			currentHunk = &Hunk{Header: line + "\n"}
+			continue
+		}
+
+		if currentHunk != nil {
+			currentHunk.Body += line + "\n"
+		} else if current != nil {
+			current.Header += line + "\n"
+		}
+	}
+
+	flush()
+	return result
+}
+
+// FilterHunks reconstructs a valid patch containing only the specified hunks
+// from a FileDiff. The returned string is suitable for git apply.
+func FilterHunks(fd FileDiff, indices []int) string {
+	var b strings.Builder
+	b.WriteString(fd.Header)
+	for _, idx := range indices {
+		if idx >= 0 && idx < len(fd.Hunks) {
+			b.WriteString(fd.Hunks[idx].Header)
+			b.WriteString(fd.Hunks[idx].Body)
+		}
+	}
+	return b.String()
+}
+
+// FormatNumberedHunks formats a file's hunks with numbered labels,
+// suitable for including in the hunk assignment prompt.
+func FormatNumberedHunks(fd FileDiff) string {
+	var b strings.Builder
+	for i, h := range fd.Hunks {
+		fmt.Fprintf(&b, "Hunk %d:\n", i)
+		b.WriteString(h.Header)
+		b.WriteString(h.Body)
+	}
+	return b.String()
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/split/ -run "TestParseDiff|TestFilterHunks|TestFormatNumberedHunks" -v`
+Expected: PASS (all 6 tests)
+
+**Step 5: Commit**
+
+```bash
+git add internal/split/hunk.go internal/split/hunk_test.go
+git commit -m "feat(split): add hunk parsing — ParseDiff, FilterHunks, FormatNumberedHunks"
+```
+
+---
+
+### Task 2: Plan Types Extension — PartialFile, HunkAssignment, Helpers
+
+**Files:**
+- Modify: `internal/split/plan.go`
+- Modify: `internal/split/plan_test.go`
+
+**Step 1: Add new types and helpers to `internal/split/plan.go`**
+
+Add after the `Layer` struct (after line 23):
+
+```go
+// PartialFile represents a file that is split across layers at hunk level.
+// Only the specified hunk indices belong to this layer.
+type PartialFile struct {
+	Path  string `yaml:"path"`
+	Hunks []int  `yaml:"hunks"`
+}
+
+// HunkAssignmentResponse is the Phase 2 response from Claude.
+type HunkAssignmentResponse struct {
+	HunkAssignments []FileHunkAssignment `yaml:"hunk_assignments"`
+}
+
+// FileHunkAssignment maps hunks of a single file to layers.
+type FileHunkAssignment struct {
+	File        string           `yaml:"file"`
+	Assignments []HunkToLayer    `yaml:"assignments"`
+}
+
+// HunkToLayer assigns a single hunk index to a layer name.
+type HunkToLayer struct {
+	Hunk  int    `yaml:"hunk"`
+	Layer string `yaml:"layer"`
+}
+```
+
+Update the `Layer` struct to add `PartialFiles`:
+
+```go
+type Layer struct {
+	Name         string        `yaml:"name"`
+	Description  string        `yaml:"description"`
+	Files        []string      `yaml:"files"`
+	PartialFiles []PartialFile `yaml:"partial_files,omitempty"`
+}
+```
+
+Add helper methods:
+
+```go
+// AllFilePaths returns all file paths in the layer (both whole and partial).
+func (l Layer) AllFilePaths() []string {
+	result := make([]string, 0, len(l.Files)+len(l.PartialFiles))
+	result = append(result, l.Files...)
+	for _, pf := range l.PartialFiles {
+		result = append(result, pf.Path)
+	}
+	return result
+}
+
+// SharedFiles detects files that appear in multiple layers.
+// Returns a map of file path → list of layer names that include it.
+func SharedFiles(plan *Plan) map[string][]string {
+	counts := make(map[string][]string)
+	for _, layer := range plan.Layers {
+		for _, f := range layer.Files {
+			counts[f] = append(counts[f], layer.Name)
+		}
+	}
+	shared := make(map[string][]string)
+	for f, layers := range counts {
+		if len(layers) > 1 {
+			shared[f] = layers
+		}
+	}
+	return shared
+}
+```
+
+**Step 2: Add tests for helpers to `internal/split/plan_test.go`**
+
+Append these tests:
+
+```go
+func TestAllFilePaths(t *testing.T) {
+	layer := Layer{
+		Name:  "test",
+		Files: []string{"a.go", "b.go"},
+		PartialFiles: []PartialFile{
+			{Path: "shared.go", Hunks: []int{0, 2}},
+		},
+	}
+	paths := layer.AllFilePaths()
+	if len(paths) != 3 {
+		t.Fatalf("expected 3 paths, got %d", len(paths))
+	}
+	if paths[2] != "shared.go" {
+		t.Errorf("expected shared.go at index 2, got %q", paths[2])
+	}
+}
+
+func TestSharedFiles_NoneShared(t *testing.T) {
+	plan := &Plan{
+		Layers: []Layer{
+			{Name: "a", Files: []string{"one.go"}},
+			{Name: "b", Files: []string{"two.go"}},
+		},
+	}
+	shared := SharedFiles(plan)
+	if len(shared) != 0 {
+		t.Errorf("expected no shared files, got %v", shared)
+	}
+}
+
+func TestSharedFiles_OneShared(t *testing.T) {
+	plan := &Plan{
+		Layers: []Layer{
+			{Name: "db", Files: []string{"shared.go", "a.go"}},
+			{Name: "api", Files: []string{"shared.go", "b.go"}},
+		},
+	}
+	shared := SharedFiles(plan)
+	if len(shared) != 1 {
+		t.Fatalf("expected 1 shared file, got %d", len(shared))
+	}
+	layers, ok := shared["shared.go"]
+	if !ok {
+		t.Fatal("shared.go not found")
+	}
+	if len(layers) != 2 {
+		t.Errorf("expected 2 layers, got %d", len(layers))
+	}
+}
+```
+
+**Step 3: Run tests**
+
+Run: `go test ./internal/split/ -run "TestAllFilePaths|TestSharedFiles" -v`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add internal/split/plan.go internal/split/plan_test.go
+git commit -m "feat(split): add PartialFile type, SharedFiles detection, AllFilePaths helper"
+```
+
+---
+
+### Task 3: New Validation Functions
+
+**Files:**
+- Modify: `internal/split/plan.go`
+- Modify: `internal/split/plan_test.go`
+
+**Step 1: Write failing tests in `internal/split/plan_test.go`**
+
+Append:
+
+```go
+func TestValidatePhase1_AllowsSharedFiles(t *testing.T) {
+	plan := &Plan{
+		Layers: []Layer{
+			{Name: "db", Description: "schema", Files: []string{"shared.go", "a.go"}},
+			{Name: "api", Description: "endpoints", Files: []string{"shared.go", "b.go"}},
+		},
+	}
+	changedFiles := []string{"shared.go", "a.go", "b.go"}
+
+	errs := ValidatePhase1(plan, changedFiles)
+	if len(errs) != 0 {
+		t.Errorf("Phase 1 should allow shared files, got errors: %v", errs)
+	}
+}
+
+func TestValidatePhase1_StillCatchesMissing(t *testing.T) {
+	plan := &Plan{
+		Layers: []Layer{
+			{Name: "db", Description: "schema", Files: []string{"a.go"}},
+		},
+	}
+	changedFiles := []string{"a.go", "missing.go"}
+
+	errs := ValidatePhase1(plan, changedFiles)
+	if len(errs) == 0 {
+		t.Fatal("should catch missing file")
+	}
+}
+
+func TestValidatePhase1_CatchesExtras(t *testing.T) {
+	plan := &Plan{
+		Layers: []Layer{
+			{Name: "db", Description: "schema", Files: []string{"a.go", "extra.go"}},
+		},
+	}
+	changedFiles := []string{"a.go"}
+
+	errs := ValidatePhase1(plan, changedFiles)
+	if len(errs) == 0 {
+		t.Fatal("should catch extra file")
+	}
+}
+
+func TestValidateHunkAssignment_Valid(t *testing.T) {
+	resp := &HunkAssignmentResponse{
+		HunkAssignments: []FileHunkAssignment{
+			{
+				File: "shared.go",
+				Assignments: []HunkToLayer{
+					{Hunk: 0, Layer: "db"},
+					{Hunk: 1, Layer: "api"},
+				},
+			},
+		},
+	}
+	shared := map[string][]string{"shared.go": {"db", "api"}}
+	hunkCounts := map[string]int{"shared.go": 2}
+
+	errs := ValidateHunkAssignment(resp, shared, hunkCounts)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got: %v", errs)
+	}
+}
+
+func TestValidateHunkAssignment_MissingHunk(t *testing.T) {
+	resp := &HunkAssignmentResponse{
+		HunkAssignments: []FileHunkAssignment{
+			{
+				File: "shared.go",
+				Assignments: []HunkToLayer{
+					{Hunk: 0, Layer: "db"},
+					// Hunk 1 is missing
+				},
+			},
+		},
+	}
+	shared := map[string][]string{"shared.go": {"db", "api"}}
+	hunkCounts := map[string]int{"shared.go": 2}
+
+	errs := ValidateHunkAssignment(resp, shared, hunkCounts)
+	if len(errs) == 0 {
+		t.Fatal("should catch missing hunk")
+	}
+}
+
+func TestValidateHunkAssignment_DuplicateHunk(t *testing.T) {
+	resp := &HunkAssignmentResponse{
+		HunkAssignments: []FileHunkAssignment{
+			{
+				File: "shared.go",
+				Assignments: []HunkToLayer{
+					{Hunk: 0, Layer: "db"},
+					{Hunk: 0, Layer: "api"},
+					{Hunk: 1, Layer: "api"},
+				},
+			},
+		},
+	}
+	shared := map[string][]string{"shared.go": {"db", "api"}}
+	hunkCounts := map[string]int{"shared.go": 2}
+
+	errs := ValidateHunkAssignment(resp, shared, hunkCounts)
+	if len(errs) == 0 {
+		t.Fatal("should catch duplicate hunk")
+	}
+}
+
+func TestValidateHunkAssignment_WrongLayer(t *testing.T) {
+	resp := &HunkAssignmentResponse{
+		HunkAssignments: []FileHunkAssignment{
+			{
+				File: "shared.go",
+				Assignments: []HunkToLayer{
+					{Hunk: 0, Layer: "db"},
+					{Hunk: 1, Layer: "unknown"},
+				},
+			},
+		},
+	}
+	shared := map[string][]string{"shared.go": {"db", "api"}}
+	hunkCounts := map[string]int{"shared.go": 2}
+
+	errs := ValidateHunkAssignment(resp, shared, hunkCounts)
+	if len(errs) == 0 {
+		t.Fatal("should catch wrong layer")
+	}
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/split/ -run "TestValidatePhase1|TestValidateHunkAssignment" -v`
+Expected: FAIL — functions not defined
+
+**Step 3: Implement validation functions in `internal/split/plan.go`**
+
+Add after `ValidatePlan`:
+
+```go
+// ValidatePhase1 validates a Phase 1 plan (files may appear in multiple layers).
+// This is a relaxed version of ValidatePlan — duplicates are allowed.
+func ValidatePhase1(plan *Plan, changedFiles []string) []error {
+	var errs []error
+
+	changedSet := make(map[string]bool, len(changedFiles))
+	for _, f := range changedFiles {
+		changedSet[f] = true
+	}
+
+	assignedFiles := make(map[string]bool)
+
+	for _, layer := range plan.Layers {
+		if len(layer.Files) == 0 {
+			errs = append(errs, fmt.Errorf("layer %q has no files", layer.Name))
+		}
+		if !validName.MatchString(layer.Name) {
+			errs = append(errs, fmt.Errorf("layer name %q is not valid kebab-case", layer.Name))
+		}
+		for _, f := range layer.Files {
+			assignedFiles[f] = true
+			if !changedSet[f] {
+				errs = append(errs, fmt.Errorf("file %q in layer %q is not in the source branch diff", f, layer.Name))
+			}
+		}
+	}
+
+	// Completeness — every changed file must appear in at least one layer
+	for _, f := range changedFiles {
+		if !assignedFiles[f] {
+			errs = append(errs, fmt.Errorf("file %q is not assigned to any layer", f))
+		}
+	}
+
+	return errs
+}
+
+// ValidateHunkAssignment checks Phase 2 hunk assignments.
+// shared maps file path → list of layer names that listed the file.
+// hunkCounts maps file path → total number of hunks in the file's diff.
+func ValidateHunkAssignment(resp *HunkAssignmentResponse, shared map[string][]string, hunkCounts map[string]int) []error {
+	var errs []error
+
+	// Build set of valid layers per file
+	validLayers := make(map[string]map[string]bool)
+	for file, layers := range shared {
+		validLayers[file] = make(map[string]bool)
+		for _, l := range layers {
+			validLayers[file][l] = true
+		}
+	}
+
+	// Track which hunks have been assigned
+	assigned := make(map[string]map[int]string) // file → hunk → layer
+
+	for _, fa := range resp.HunkAssignments {
+		if _, ok := shared[fa.File]; !ok {
+			errs = append(errs, fmt.Errorf("file %q is not a shared file", fa.File))
+			continue
+		}
+		if assigned[fa.File] == nil {
+			assigned[fa.File] = make(map[int]string)
+		}
+		maxHunk := hunkCounts[fa.File]
+		for _, a := range fa.Assignments {
+			// Valid index
+			if a.Hunk < 0 || a.Hunk >= maxHunk {
+				errs = append(errs, fmt.Errorf("hunk %d for %s is out of range (0-%d)", a.Hunk, fa.File, maxHunk-1))
+				continue
+			}
+			// Valid layer
+			if !validLayers[fa.File][a.Layer] {
+				errs = append(errs, fmt.Errorf("hunk %d for %s assigned to %q which didn't list the file", a.Hunk, fa.File, a.Layer))
+				continue
+			}
+			// No duplicates
+			if prev, ok := assigned[fa.File][a.Hunk]; ok {
+				errs = append(errs, fmt.Errorf("hunk %d for %s assigned to both %q and %q", a.Hunk, fa.File, prev, a.Layer))
+				continue
+			}
+			assigned[fa.File][a.Hunk] = a.Layer
+		}
+	}
+
+	// Completeness — every hunk must be assigned
+	for file, count := range hunkCounts {
+		for i := 0; i < count; i++ {
+			if _, ok := assigned[file][i]; !ok {
+				errs = append(errs, fmt.Errorf("hunk %d for %s is not assigned to any layer", i, file))
+			}
+		}
+	}
+
+	return errs
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/split/ -run "TestValidatePhase1|TestValidateHunkAssignment" -v`
+Expected: PASS (all 7 tests)
+
+**Step 5: Run ALL split tests to verify no regressions**
+
+Run: `go test ./internal/split/ -v -count=1`
+Expected: ALL existing tests still pass
+
+**Step 6: Commit**
+
+```bash
+git add internal/split/plan.go internal/split/plan_test.go
+git commit -m "feat(split): add ValidatePhase1 and ValidateHunkAssignment"
+```
+
+---
+
+### Task 4: AI Prompt Updates — BuildHunkPrompt, ParseHunkAssignment, MergePlan
+
+**Files:**
+- Modify: `internal/split/ai.go`
+- Modify: `internal/split/ai_test.go`
+
+**Step 1: Write failing tests in `internal/split/ai_test.go`**
+
+Append:
+
+```go
+func TestBuildPrompt_AllowsSharedFiles(t *testing.T) {
+	prompt := BuildPrompt("feature/big-change", "main")
+
+	// Should mention that files may appear in multiple layers
+	if !strings.Contains(prompt, "multiple layers") {
+		t.Error("prompt should mention files can appear in multiple layers")
+	}
+}
+
+func TestBuildHunkPrompt(t *testing.T) {
+	sharedFiles := map[string][]string{
+		"user.go": {"db", "api"},
+	}
+	files := []FileDiff{
+		{
+			Path:   "user.go",
+			Header: "diff --git a/user.go b/user.go\n",
+			Hunks: []Hunk{
+				{Header: "@@ -1,5 +1,6 @@\n", Body: " context\n+Email\n"},
+				{Header: "@@ -10,3 +11,5 @@\n", Body: " context\n+Validate\n"},
+			},
+		},
+	}
+
+	prompt := BuildHunkPrompt(sharedFiles, files)
+
+	if !strings.Contains(prompt, "user.go") {
+		t.Error("prompt should contain file path")
+	}
+	if !strings.Contains(prompt, "Hunk 0:") {
+		t.Error("prompt should have numbered hunks")
+	}
+	if !strings.Contains(prompt, "Hunk 1:") {
+		t.Error("prompt should have hunk 1")
+	}
+	if !strings.Contains(prompt, "db") && !strings.Contains(prompt, "api") {
+		t.Error("prompt should mention layer names")
+	}
+	if !strings.Contains(prompt, "hunk_assignments") {
+		t.Error("prompt should show expected YAML format")
+	}
+}
+
+func TestParseHunkAssignment(t *testing.T) {
+	text := `Here are the assignments:
+` + "```yaml" + `
+hunk_assignments:
+  - file: user.go
+    assignments:
+      - hunk: 0
+        layer: db
+      - hunk: 1
+        layer: api
+` + "```"
+
+	resp, err := ParseHunkAssignment(text)
+	if err != nil {
+		t.Fatalf("ParseHunkAssignment: %v", err)
+	}
+	if len(resp.HunkAssignments) != 1 {
+		t.Fatalf("expected 1 file assignment, got %d", len(resp.HunkAssignments))
+	}
+	if resp.HunkAssignments[0].File != "user.go" {
+		t.Errorf("file: got %q", resp.HunkAssignments[0].File)
+	}
+	if len(resp.HunkAssignments[0].Assignments) != 2 {
+		t.Fatalf("expected 2 hunk assignments, got %d", len(resp.HunkAssignments[0].Assignments))
+	}
+}
+
+func TestMergePlan(t *testing.T) {
+	plan := &Plan{
+		Layers: []Layer{
+			{Name: "db", Description: "schema", Files: []string{"shared.go", "a.go"}},
+			{Name: "api", Description: "endpoints", Files: []string{"shared.go", "b.go"}},
+		},
+	}
+	resp := &HunkAssignmentResponse{
+		HunkAssignments: []FileHunkAssignment{
+			{
+				File: "shared.go",
+				Assignments: []HunkToLayer{
+					{Hunk: 0, Layer: "db"},
+					{Hunk: 1, Layer: "api"},
+				},
+			},
+		},
+	}
+
+	merged := MergePlan(plan, resp)
+
+	// Layer "db" should have a.go as whole file and shared.go as partial
+	if len(merged.Layers[0].Files) != 1 || merged.Layers[0].Files[0] != "a.go" {
+		t.Errorf("db layer files: %v", merged.Layers[0].Files)
+	}
+	if len(merged.Layers[0].PartialFiles) != 1 {
+		t.Fatalf("db layer partial files: %v", merged.Layers[0].PartialFiles)
+	}
+	if merged.Layers[0].PartialFiles[0].Path != "shared.go" {
+		t.Errorf("db partial path: %q", merged.Layers[0].PartialFiles[0].Path)
+	}
+	if len(merged.Layers[0].PartialFiles[0].Hunks) != 1 || merged.Layers[0].PartialFiles[0].Hunks[0] != 0 {
+		t.Errorf("db partial hunks: %v", merged.Layers[0].PartialFiles[0].Hunks)
+	}
+
+	// Layer "api" should have b.go as whole file and shared.go hunk 1
+	if len(merged.Layers[1].Files) != 1 || merged.Layers[1].Files[0] != "b.go" {
+		t.Errorf("api layer files: %v", merged.Layers[1].Files)
+	}
+	if len(merged.Layers[1].PartialFiles) != 1 {
+		t.Fatalf("api layer partial files: %v", merged.Layers[1].PartialFiles)
+	}
+	if merged.Layers[1].PartialFiles[0].Hunks[0] != 1 {
+		t.Errorf("api partial hunks: %v", merged.Layers[1].PartialFiles[0].Hunks)
+	}
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/split/ -run "TestBuildHunkPrompt|TestParseHunkAssignment|TestMergePlan" -v`
+Expected: FAIL — functions not defined
+
+**Step 3: Update `BuildPrompt` in `internal/split/ai.go`**
+
+Replace the two rules about file assignment (lines 35-40 in the prompt string):
+
+Old:
+```
+- Every changed file must appear in exactly one layer
+...
+- A file can only belong to one layer. If a file has changes for multiple concerns, put it in the earliest layer that needs it
+```
+
+New:
+```
+- Every changed file must appear in at least one layer
+- A file MAY appear in multiple layers if its changes clearly serve different concerns.
+  When this happens, we'll assign individual hunks in a follow-up step.
+- If all of a file's changes belong to one concern, list it in only one layer
+```
+
+**Step 4: Add `BuildHunkPrompt`, `ParseHunkAssignment`, `MergePlan` to `internal/split/ai.go`**
+
+```go
+// BuildHunkPrompt constructs the Phase 2 prompt for hunk assignment.
+// sharedFiles maps file path → layer names that listed it.
+// fileDiffs contains the parsed diffs for shared files.
+func BuildHunkPrompt(sharedFiles map[string][]string, fileDiffs []FileDiff) string {
+	var b strings.Builder
+	b.WriteString("Some files in your plan appear in multiple layers. Assign each hunk to exactly one layer.\n\n")
+
+	for _, fd := range fileDiffs {
+		layers, ok := sharedFiles[fd.Path]
+		if !ok {
+			continue
+		}
+		fmt.Fprintf(&b, "## %s\n", fd.Path)
+		fmt.Fprintf(&b, "Layers: %s\n\n", strings.Join(layers, ", "))
+		b.WriteString(FormatNumberedHunks(fd))
+		b.WriteString("---\n\n")
+	}
+
+	b.WriteString("Return ONLY this YAML (wrapped in ```yaml fences):\n\n")
+	b.WriteString("```yaml\nhunk_assignments:\n  - file: <filepath>\n    assignments:\n      - hunk: 0\n        layer: <layer-name>\n      - hunk: 1\n        layer: <layer-name>\n```")
+
+	return b.String()
+}
+
+// ParseHunkAssignment extracts and parses a HunkAssignmentResponse from Claude's response.
+func ParseHunkAssignment(text string) (*HunkAssignmentResponse, error) {
+	yamlStr := extractYAML(text)
+	var resp HunkAssignmentResponse
+	if err := yaml.Unmarshal([]byte(yamlStr), &resp); err != nil {
+		return nil, fmt.Errorf("cannot parse hunk assignment YAML: %w", err)
+	}
+	if len(resp.HunkAssignments) == 0 {
+		return nil, fmt.Errorf("no hunk assignments in response")
+	}
+	return &resp, nil
+}
+
+// MergePlan combines a Phase 1 plan with Phase 2 hunk assignments into a final plan.
+// Shared files are moved from Files to PartialFiles with their assigned hunk indices.
+func MergePlan(plan *Plan, resp *HunkAssignmentResponse) *Plan {
+	// Build lookup: file → layer → hunk indices
+	layerHunks := make(map[string]map[string][]int) // file → layer → hunks
+	for _, fa := range resp.HunkAssignments {
+		if layerHunks[fa.File] == nil {
+			layerHunks[fa.File] = make(map[string][]int)
+		}
+		for _, a := range fa.Assignments {
+			layerHunks[fa.File][a.Layer] = append(layerHunks[fa.File][a.Layer], a.Hunk)
+		}
+	}
+
+	// Build set of shared file paths
+	sharedSet := make(map[string]bool)
+	for file := range layerHunks {
+		sharedSet[file] = true
+	}
+
+	merged := &Plan{Layers: make([]Layer, len(plan.Layers))}
+
+	for i, layer := range plan.Layers {
+		merged.Layers[i] = Layer{
+			Name:        layer.Name,
+			Description: layer.Description,
+		}
+
+		// Split files into whole vs partial
+		for _, f := range layer.Files {
+			if sharedSet[f] {
+				if hunks, ok := layerHunks[f][layer.Name]; ok {
+					merged.Layers[i].PartialFiles = append(merged.Layers[i].PartialFiles,
+						PartialFile{Path: f, Hunks: hunks})
+				}
+			} else {
+				merged.Layers[i].Files = append(merged.Layers[i].Files, f)
+			}
+		}
+	}
+
+	return merged
+}
+```
+
+Note: Add `"gopkg.in/yaml.v3"` to ai.go imports if not already present (it's needed for `ParseHunkAssignment`). The existing import is in plan.go, so ai.go needs its own.
+
+**Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/split/ -run "TestBuildPrompt_AllowsSharedFiles|TestBuildHunkPrompt|TestParseHunkAssignment|TestMergePlan" -v`
+Expected: PASS (all 4 new tests + existing TestBuildPrompt still passes)
+
+**Step 6: Run ALL split tests**
+
+Run: `go test ./internal/split/ -v -count=1`
+Expected: ALL tests pass
+
+**Step 7: Commit**
+
+```bash
+git add internal/split/ai.go internal/split/ai_test.go
+git commit -m "feat(split): add BuildHunkPrompt, ParseHunkAssignment, MergePlan for Phase 2"
+```
+
+---
+
+### Task 5: Two-Phase Analyze Flow
+
+**Files:**
+- Modify: `internal/split/ai.go`
+
+This task updates the `Analyze` function to support two-phase analysis. Phase 2 is triggered when shared files are detected after Phase 1.
+
+**Step 1: Rewrite `Analyze` in `internal/split/ai.go`**
+
+Replace the entire `Analyze` function with:
+
+```go
+// Analyze invokes Claude to analyze a branch and produce a split plan.
+// Phase 1: file-level grouping (files may appear in multiple layers).
+// Phase 2: if shared files exist, assign individual hunks to layers.
+// Returns the validated plan with session ID.
+func Analyze(fromBranch, base string, display io.Writer) (*AnalysisResult, error) {
+	changedFiles, err := gitpkg.DiffNameOnly(base, fromBranch)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list changed files: %w", err)
+	}
+
+	// --- Phase 1: file-level grouping ---
+	prompt := BuildPrompt(fromBranch, base)
+	name := "split-analysis"
+
+	sr, err := claudepkg.RunPromptStreaming(name, prompt, display)
+	if err != nil {
+		return nil, fmt.Errorf("claude analysis failed: %w", err)
+	}
+
+	sessionID := sr.SessionID
+	plan, err := parseAndValidatePhase1(sr.Result, changedFiles, sessionID, name, display)
+	if err != nil {
+		return nil, err
+	}
+
+	// --- Check for shared files ---
+	shared := SharedFiles(plan)
+	if len(shared) == 0 {
+		// No shared files — plan is complete (backward compatible with iteration 3)
+		return &AnalysisResult{Plan: plan, SessionID: sessionID}, nil
+	}
+
+	// --- Phase 2: hunk assignment ---
+	fmt.Fprintf(display, "\n%d file(s) appear in multiple layers — assigning hunks...\n", len(shared))
+
+	fileDiffs, hunkCounts, err := parseSharedFileDiffs(base, fromBranch, shared)
+	if err != nil {
+		return nil, err
+	}
+
+	hunkPrompt := BuildHunkPrompt(shared, fileDiffs)
+	sr, err = claudepkg.RunPromptStreamingResume(name, sessionID, hunkPrompt, display)
+	if err != nil {
+		return nil, fmt.Errorf("claude hunk assignment failed: %w", err)
+	}
+
+	resp, err := parseAndValidatePhase2(sr.Result, shared, hunkCounts, sessionID, name, display)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := MergePlan(plan, resp)
+	return &AnalysisResult{Plan: merged, SessionID: sessionID}, nil
+}
+
+// parseAndValidatePhase1 parses and validates Phase 1 with retries.
+func parseAndValidatePhase1(result string, changedFiles []string, sessionID, name string, display io.Writer) (*Plan, error) {
+	sr := claudepkg.StreamResult{Result: result, SessionID: sessionID}
+
+	for attempt := 0; attempt <= MaxRetries; attempt++ {
+		plan, parseErr := ParsePlan(sr.Result)
+		if parseErr != nil {
+			if attempt == MaxRetries {
+				return nil, fmt.Errorf("claude returned invalid plan after %d attempts: %w", MaxRetries+1, parseErr)
+			}
+			retryPrompt := fmt.Sprintf("Your response could not be parsed: %s\n\nPlease return a valid YAML plan.", parseErr.Error())
+			fmt.Fprintf(display, "\n⚠ Parse error, retrying (%d/%d)...\n", attempt+1, MaxRetries)
+			var err error
+			sr, err = claudepkg.RunPromptStreamingResume(name, sessionID, retryPrompt, display)
+			if err != nil {
+				return nil, fmt.Errorf("claude retry failed: %w", err)
+			}
+			continue
+		}
+
+		validationErrs := ValidatePhase1(plan, changedFiles)
+		if len(validationErrs) == 0 {
+			return plan, nil
+		}
+
+		if attempt == MaxRetries {
+			var errMsgs []string
+			for _, e := range validationErrs {
+				errMsgs = append(errMsgs, e.Error())
+			}
+			return nil, fmt.Errorf("plan validation failed after %d attempts:\n  %s",
+				MaxRetries+1, strings.Join(errMsgs, "\n  "))
+		}
+
+		retryPrompt := BuildRetryPrompt(validationErrs)
+		fmt.Fprintf(display, "\n⚠ Validation failed, retrying (%d/%d)...\n", attempt+1, MaxRetries)
+		var err error
+		sr, err = claudepkg.RunPromptStreamingResume(name, sessionID, retryPrompt, display)
+		if err != nil {
+			return nil, fmt.Errorf("claude retry failed: %w", err)
+		}
+	}
+
+	return nil, fmt.Errorf("analysis failed")
+}
+
+// parseSharedFileDiffs extracts and parses diffs for shared files.
+func parseSharedFileDiffs(base, source string, shared map[string][]string) ([]FileDiff, map[string]int, error) {
+	var sharedPaths []string
+	for f := range shared {
+		sharedPaths = append(sharedPaths, f)
+	}
+
+	diff, err := gitpkg.DiffFiles(base, source, sharedPaths)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot extract diff for shared files: %w", err)
+	}
+
+	allFileDiffs := ParseDiff(diff)
+
+	// Filter to only shared files and build hunk counts
+	var fileDiffs []FileDiff
+	hunkCounts := make(map[string]int)
+	for _, fd := range allFileDiffs {
+		if _, ok := shared[fd.Path]; ok {
+			fileDiffs = append(fileDiffs, fd)
+			hunkCounts[fd.Path] = len(fd.Hunks)
+		}
+	}
+
+	return fileDiffs, hunkCounts, nil
+}
+
+// parseAndValidatePhase2 parses and validates Phase 2 hunk assignments with retries.
+func parseAndValidatePhase2(result string, shared map[string][]string, hunkCounts map[string]int, sessionID, name string, display io.Writer) (*HunkAssignmentResponse, error) {
+	sr := claudepkg.StreamResult{Result: result, SessionID: sessionID}
+
+	for attempt := 0; attempt <= MaxRetries; attempt++ {
+		resp, parseErr := ParseHunkAssignment(sr.Result)
+		if parseErr != nil {
+			if attempt == MaxRetries {
+				return nil, fmt.Errorf("claude returned invalid hunk assignment after %d attempts: %w", MaxRetries+1, parseErr)
+			}
+			retryPrompt := fmt.Sprintf("Your response could not be parsed: %s\n\nPlease return valid YAML hunk assignments.", parseErr.Error())
+			fmt.Fprintf(display, "\n⚠ Parse error, retrying (%d/%d)...\n", attempt+1, MaxRetries)
+			var err error
+			sr, err = claudepkg.RunPromptStreamingResume(name, sessionID, retryPrompt, display)
+			if err != nil {
+				return nil, fmt.Errorf("claude retry failed: %w", err)
+			}
+			continue
+		}
+
+		validationErrs := ValidateHunkAssignment(resp, shared, hunkCounts)
+		if len(validationErrs) == 0 {
+			return resp, nil
+		}
+
+		if attempt == MaxRetries {
+			var errMsgs []string
+			for _, e := range validationErrs {
+				errMsgs = append(errMsgs, e.Error())
+			}
+			return nil, fmt.Errorf("hunk assignment validation failed after %d attempts:\n  %s",
+				MaxRetries+1, strings.Join(errMsgs, "\n  "))
+		}
+
+		retryPrompt := ValidationSummary(validationErrs)
+		fmt.Fprintf(display, "\n⚠ Hunk assignment validation failed, retrying (%d/%d)...\n", attempt+1, MaxRetries)
+		var err error
+		sr, err = claudepkg.RunPromptStreamingResume(name, sessionID, retryPrompt, display)
+		if err != nil {
+			return nil, fmt.Errorf("claude retry failed: %w", err)
+		}
+	}
+
+	return nil, fmt.Errorf("hunk assignment failed")
+}
+```
+
+**Step 2: Verify the build compiles**
+
+Run: `go build ./internal/split/`
+Expected: Success
+
+**Step 3: Run ALL split tests (no new tests needed — Analyze is tested via integration)**
+
+Run: `go test ./internal/split/ -v -count=1`
+Expected: ALL tests pass
+
+**Step 4: Commit**
+
+```bash
+git add internal/split/ai.go
+git commit -m "feat(split): update Analyze for two-phase flow with hunk assignment"
+```
+
+---
+
+### Task 6: Execute with PartialFiles
+
+**Files:**
+- Modify: `internal/split/execute.go`
+- Modify: `internal/split/execute_test.go`
+
+**Step 1: Write failing test in `internal/split/execute_test.go`**
+
+Add a test repo helper and test that exercises hunk-level splitting:
+
+```go
+// testRepoForHunks creates a temp repo where one file has two independent
+// regions of change, suitable for hunk-level splitting.
+func testRepoForHunks(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	origDir, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(origDir) })
+	os.Chdir(dir)
+
+	git := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s: %s", strings.Join(args, " "), out)
+		}
+	}
+
+	write := func(name, content string) {
+		t.Helper()
+		full := filepath.Join(dir, name)
+		os.MkdirAll(filepath.Dir(full), 0755)
+		os.WriteFile(full, []byte(content), 0644)
+	}
+
+	git("init", "-b", "main")
+	git("config", "user.email", "test@test.com")
+	git("config", "user.name", "Test")
+	git("config", "commit.gpgsign", "false")
+
+	// Create a file with two functions (enough content for 2 hunks)
+	write("shared.go", `package main
+
+func Alpha() string {
+	return "alpha"
+}
+
+// separator to ensure two hunks
+
+func Beta() string {
+	return "beta"
+}
+`)
+	write("only-a.go", "package main\n")
+	write("only-b.go", "package main\n")
+	git("add", ".")
+	git("commit", "-m", "initial")
+
+	git("checkout", "-b", "feature")
+
+	// Modify two separate regions of shared.go + modify only-a.go and only-b.go
+	write("shared.go", `package main
+
+func Alpha() string {
+	return "alpha-modified"
+}
+
+// separator to ensure two hunks
+
+func Beta() string {
+	return "beta-modified"
+}
+`)
+	write("only-a.go", "package main\nfunc A() {}\n")
+	write("only-b.go", "package main\nfunc B() {}\n")
+	git("add", ".")
+	git("commit", "-m", "modify all")
+
+	return dir
+}
+
+func TestExecute_WithPartialFiles(t *testing.T) {
+	dir := testRepoForHunks(t)
+
+	// First, parse the diff to know hunk indices
+	diff, err := gitpkg.DiffFiles("main", "feature", []string{"shared.go"})
+	if err != nil {
+		t.Fatalf("DiffFiles: %v", err)
+	}
+	fileDiffs := ParseDiff(diff)
+	if len(fileDiffs) != 1 {
+		t.Fatalf("expected 1 file diff, got %d", len(fileDiffs))
+	}
+	if len(fileDiffs[0].Hunks) < 2 {
+		t.Fatalf("expected at least 2 hunks, got %d", len(fileDiffs[0].Hunks))
+	}
+
+	plan := &Plan{
+		Layers: []Layer{
+			{
+				Name:        "layer-a",
+				Description: "Alpha changes",
+				Files:       []string{"only-a.go"},
+				PartialFiles: []PartialFile{
+					{Path: "shared.go", Hunks: []int{0}},
+				},
+			},
+			{
+				Name:        "layer-b",
+				Description: "Beta changes",
+				Files:       []string{"only-b.go"},
+				PartialFiles: []PartialFile{
+					{Path: "shared.go", Hunks: []int{1}},
+				},
+			},
+		},
+	}
+
+	branches, err := Execute(plan, "hunk-stack", "main", "feature", dir)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if len(branches) != 2 {
+		t.Fatalf("expected 2 branches, got %d", len(branches))
+	}
+
+	// Tree identity: last branch should match feature
+	lastBranch := branches[len(branches)-1]
+	treeErr := ValidateTree("feature", lastBranch)
+	if treeErr != nil {
+		diffOut, _ := gitpkg.DiffFull("feature", lastBranch)
+		t.Fatalf("tree identity failed: %v\ndiff:\n%s", treeErr, diffOut)
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/split/ -run TestExecute_WithPartialFiles -v`
+Expected: FAIL (Execute doesn't handle PartialFiles yet)
+
+**Step 3: Update `Execute` in `internal/split/execute.go`**
+
+Update the layer loop inside `Execute` to handle both whole files and partial files. Replace the section from `// Extract diff for this layer's files` through `// Stage and commit` (lines 50-72) with:
+
+```go
+		// Build the combined patch for this layer
+		var patchParts []string
+
+		// Whole files — extract their full diff
+		if len(layer.Files) > 0 {
+			wholePatch, err := gitpkg.DiffFiles(base, source, layer.Files)
+			if err != nil {
+				return createdBranches, fmt.Errorf("cannot extract diff for %s: %w", layer.Name, err)
+			}
+			if wholePatch != "" {
+				patchParts = append(patchParts, wholePatch)
+			}
+		}
+
+		// Partial files — extract and filter hunks
+		for _, pf := range layer.PartialFiles {
+			fileDiff, err := gitpkg.DiffFiles(base, source, []string{pf.Path})
+			if err != nil {
+				return createdBranches, fmt.Errorf("cannot extract diff for %s in %s: %w", pf.Path, layer.Name, err)
+			}
+			parsed := ParseDiff(fileDiff)
+			if len(parsed) == 0 {
+				return createdBranches, fmt.Errorf("no diff found for partial file %s in layer %s", pf.Path, layer.Name)
+			}
+			filtered := FilterHunks(parsed[0], pf.Hunks)
+			if filtered != "" {
+				patchParts = append(patchParts, filtered)
+			}
+		}
+
+		if len(patchParts) == 0 {
+			return createdBranches, fmt.Errorf("empty diff for layer %s — no changes to apply", layer.Name)
+		}
+
+		patch := strings.Join(patchParts, "")
+
+		// Apply the patch
+		if err := gitpkg.ApplyPatch(patch); err != nil {
+			return createdBranches, fmt.Errorf("apply failed for %s: %w", layer.Name, err)
+		}
+
+		// Stage and commit all files (whole + partial)
+		allFiles := layer.AllFilePaths()
+		if err := gitpkg.Add(allFiles...); err != nil {
+			return createdBranches, fmt.Errorf("cannot stage files for %s: %w", layer.Name, err)
+		}
+
+		if err := gitpkg.Commit(layer.Description); err != nil {
+			return createdBranches, fmt.Errorf("cannot commit %s: %w", layer.Name, err)
+		}
+```
+
+Add `"strings"` to the import list in execute.go.
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/split/ -run TestExecute_WithPartialFiles -v`
+Expected: PASS
+
+**Step 5: Run ALL execute tests + full split tests**
+
+Run: `go test ./internal/split/ -v -count=1`
+Expected: ALL tests pass (existing tests still work — they only use `Files`, no `PartialFiles`)
+
+**Step 6: Commit**
+
+```bash
+git add internal/split/execute.go internal/split/execute_test.go
+git commit -m "feat(split): Execute handles PartialFiles with hunk-filtered patches"
+```
+
+---
+
+### Task 7: Display Update + Integration Verification
+
+**Files:**
+- Modify: `cmd/split.go`
+
+**Step 1: Update `displaySplitPlan` in `cmd/split.go`**
+
+Replace the `displaySplitPlan` function (lines 247-273) with:
+
+```go
+func displaySplitPlan(plan *splitpkg.Plan, stackName, base, source string) {
+	fmt.Printf("\nSplit plan for %s (base: %s)\n", ui.Branch(stackName), ui.Branch(base))
+	fmt.Println(strings.Repeat("─", 50))
+
+	totalFiles := 0
+	totalPartial := 0
+	for i, layer := range plan.Layers {
+		wholeCount := len(layer.Files)
+		partialCount := len(layer.PartialFiles)
+		fileCount := wholeCount + partialCount
+		totalFiles += fileCount
+		totalPartial += partialCount
+
+		// Try to get line stats for whole files
+		lineInfo := ""
+		allPaths := layer.AllFilePaths()
+		if len(allPaths) > 0 {
+			diff, err := gitpkg.DiffFiles(base, source, allPaths)
+			if err == nil {
+				adds, dels := countDiffLines(diff)
+				if adds > 0 || dels > 0 {
+					lineInfo = fmt.Sprintf(", +%d -%d", adds, dels)
+				}
+			}
+		}
+
+		fmt.Printf("\n  Layer %d: %s (%d files%s)\n",
+			i+1, ui.Bold.Render(layer.Name), fileCount, lineInfo)
+		fmt.Printf("    %s\n", layer.Description)
+
+		// Show shared files
+		for _, pf := range layer.PartialFiles {
+			fmt.Printf("    Shared: %s (hunks %s)\n", pf.Path, formatHunkIndices(pf.Hunks))
+		}
+	}
+
+	summary := fmt.Sprintf("  Total: %d files across %d layers", totalFiles, len(plan.Layers))
+	if totalPartial > 0 {
+		// Count unique partial file paths
+		seen := make(map[string]bool)
+		for _, layer := range plan.Layers {
+			for _, pf := range layer.PartialFiles {
+				seen[pf.Path] = true
+			}
+		}
+		summary += fmt.Sprintf(" (%d file(s) split at hunk level)", len(seen))
+	}
+	fmt.Printf("\n%s\n\n", summary)
+}
+
+// formatHunkIndices formats a slice of ints as a comma-separated string.
+func formatHunkIndices(hunks []int) string {
+	parts := make([]string, len(hunks))
+	for i, h := range hunks {
+		parts[i] = fmt.Sprintf("%d", h)
+	}
+	return strings.Join(parts, ", ")
+}
+```
+
+Note: the line stats now use `AllFilePaths()` which includes partial file paths. This gives an approximate line count (it includes all hunks of partial files, not just the assigned ones). This is acceptable for display — exact per-hunk counting can be added later.
+
+**Step 2: Build everything**
+
+Run: `go build ./...`
+Expected: Success
+
+**Step 3: Run vet**
+
+Run: `go vet ./...`
+Expected: Clean
+
+**Step 4: Run ALL tests**
+
+Run: `go test ./... -count=1`
+Expected: ALL tests pass
+
+**Step 5: Verify the command help**
+
+Run: `go run . split --help`
+Expected: Shows same help as before (no CLI changes)
+
+**Step 6: Commit**
+
+```bash
+git add cmd/split.go
+git commit -m "feat(split): update displaySplitPlan for hunk-level shared files"
+```
+
+---
+
+### Summary of changes
+
+| File | Change |
+|------|--------|
+| `internal/split/hunk.go` | **New** — Hunk, FileDiff, ParseDiff, FilterHunks, FormatNumberedHunks |
+| `internal/split/hunk_test.go` | **New** — 6 tests |
+| `internal/split/plan.go` | **Modified** — PartialFile, HunkAssignment types, AllFilePaths, SharedFiles, ValidatePhase1, ValidateHunkAssignment |
+| `internal/split/plan_test.go` | **Modified** — 10 new tests |
+| `internal/split/ai.go` | **Modified** — Two-phase Analyze, BuildHunkPrompt, ParseHunkAssignment, MergePlan |
+| `internal/split/ai_test.go` | **Modified** — 5 new tests |
+| `internal/split/execute.go` | **Modified** — PartialFiles support in Execute |
+| `internal/split/execute_test.go` | **Modified** — 1 new hunk-level test |
+| `cmd/split.go` | **Modified** — displaySplitPlan shows shared files |

--- a/docs/plans/2026-02-23-split-refine-persist-design.md
+++ b/docs/plans/2026-02-23-split-refine-persist-design.md
@@ -1,0 +1,215 @@
+# sdf split — Plan Refinement & Persistence (Iteration 5)
+
+## Summary
+
+Replace the Y/n confirmation prompt with a three-choice menu: Execute, Refine, Abort. "Refine" spawns an interactive Claude session (`claude --resume`) so the user can adjust the plan conversationally. After the session, sdf re-extracts the updated plan and loops back.
+
+Additionally, persist the plan to disk as YAML during the analysis-to-execution window. Delete it after successful execution.
+
+---
+
+## Three-Choice Prompt
+
+After displaying the plan, show:
+
+```
+? What would you like to do?
+  > Execute this split
+    Refine plan (opens Claude session)
+    Abort
+```
+
+Uses existing `ui.Select`. The `-y` flag skips this and goes straight to execute.
+
+---
+
+## Refine Flow
+
+When "Refine" is chosen:
+
+1. Spawn `claude --resume <session_id> <initial_prompt>` as an interactive terminal process (not `-p` mode)
+2. The initial prompt:
+   - Summarizes the current plan (layers, files, descriptions)
+   - Reminds Claude of the YAML output format
+   - Asks the user what they'd like to change
+3. User interacts with Claude directly in their terminal
+4. When the interactive session exits, sdf re-extracts the plan:
+   - Resume the same session with `-p`: `claude --resume <session_id> -p "Return the current split plan as YAML"`
+   - Parse and validate the response
+5. Display the updated plan, loop back to the 3-choice menu
+
+### Initial prompt for interactive session
+
+```
+The user wants to refine the split plan. Here's the current plan:
+
+<plan summary: layers with names, descriptions, files, partial files>
+
+Ask the user what they'd like to change. When they're satisfied, they can
+exit this session (Ctrl+C or /exit) and sdf will re-read the updated plan.
+
+Remember: every changed file must appear in at least one layer, use kebab-case
+layer names, and return YAML in the same format when asked.
+```
+
+### Re-extraction prompt (after interactive session)
+
+```
+Return the current split plan as YAML (wrapped in ```yaml fences).
+Use the exact same format:
+
+```yaml
+layers:
+  - name: <kebab-case-name>
+    description: "<one-line summary>"
+    files:
+      - <path/to/file>
+```
+
+Include any changes discussed in the refinement session.
+```
+
+---
+
+## Plan Persistence
+
+### Save location
+
+`.sdf/split-plans/<stack-name>.yaml`
+
+### Lifecycle
+
+1. **Save**: immediately after analysis completes (before the 3-choice prompt)
+2. **Update**: after each refinement loop (overwrite with updated plan)
+3. **Delete**: after successful split execution (tree identity verified)
+4. **Survive abort**: if user aborts, plan stays on disk for reference
+
+### Format
+
+Standard YAML serialization of the `Plan` struct — same format Claude produces. Includes `partial_files` when present.
+
+### Directory
+
+`.sdf/split-plans/` created alongside `.sdf/stacks/` in the `.sdf/` tree (gitignored).
+
+---
+
+## Refine Loop
+
+```
+Analyze → Save plan → Display → Choose
+  ├─ Execute → run → delete plan on success
+  ├─ Refine → interactive claude → re-extract → re-validate → Save → Display → Choose (loop)
+  └─ Abort → plan stays on disk
+```
+
+---
+
+## Command Interface Changes
+
+No new flags. Existing flags unchanged:
+
+```
+sdf split --from <branch> --stack <name>              # 3-choice prompt
+sdf split --from <branch> --stack <name> -y           # skip prompt, execute
+sdf split --from <branch> --stack <name> --dry-run    # show plan only, no prompt
+```
+
+---
+
+## Code Changes
+
+### cmd/split.go
+
+- Replace `ui.Confirm("Execute this split?")` with `ui.Select` offering three choices
+- Add refinement loop: call `refine()` → re-extract → re-validate → redisplay → loop
+- Save plan to disk after analysis and after each refinement
+- Delete plan file after successful execution
+
+### internal/split/plan.go
+
+- Add `SavePlan(path string, plan *Plan) error` — marshal to YAML, write to file
+- Add `PlanPath(root, stackName string) string` — returns `.sdf/split-plans/<name>.yaml`
+- Add `DeletePlan(path string) error` — remove plan file (ignore not-exist)
+
+### internal/claude/claude.go
+
+- Add `RunInteractiveResume(sessionID, prompt string) error` — spawns `claude --resume <id> <prompt>` with stdin/stdout/stderr connected to the terminal
+
+### internal/split/ai.go
+
+- Add `BuildRefinePrompt(plan *Plan) string` — builds the initial prompt for the interactive session
+- Add `BuildReExtractPrompt() string` — builds the prompt to re-extract the plan after refinement
+- Add `ReExtractPlan(sessionID, name string, display io.Writer) (*Plan, string, error)` — resumes session in `-p` mode, parses plan
+
+---
+
+## Error Handling
+
+| Condition | Behavior |
+|-----------|----------|
+| Interactive `claude --resume` exits non-zero | Warning, loop back with original plan |
+| Re-extraction fails to parse | Retry once, then fall back to original plan with warning |
+| Re-extracted plan fails validation | Show errors, loop back with original plan |
+| Plan file write failure | Non-fatal warning, execution proceeds |
+| Plan file delete failure | Non-fatal warning |
+
+---
+
+## User-Facing Output
+
+### Three-choice prompt
+
+```
+? What would you like to do?
+  > Execute this split
+    Refine plan (opens Claude session)
+    Abort
+```
+
+### Refinement
+
+```
+Opening Claude session for plan refinement...
+(Exit with Ctrl+C or /exit when done)
+
+[interactive Claude session runs here]
+
+Re-reading plan from Claude session...
+```
+
+Then redisplays the updated plan and shows the 3-choice prompt again.
+
+### Plan persistence
+
+```
+  Plan saved to .sdf/split-plans/my-feature.yaml
+```
+
+(Shown once after initial analysis, and again after each refinement.)
+
+---
+
+## Testing Strategy
+
+### cmd/split.go — Integration tests
+
+- Plan file created after analysis
+- Plan file deleted after successful execution
+- Plan file survives abort
+
+### internal/split/plan_test.go — Unit tests
+
+- SavePlan writes valid YAML
+- SavePlan round-trips through ParsePlan
+- DeletePlan removes file
+- DeletePlan on non-existent file is not an error
+
+### internal/split/ai_test.go — Unit tests
+
+- BuildRefinePrompt includes layer names and files
+- BuildReExtractPrompt returns expected format
+
+### internal/claude/claude.go — Manual testing only
+
+- RunInteractiveResume spawns a terminal process (cannot be unit tested)

--- a/docs/plans/2026-02-23-split-refine-persist-impl.md
+++ b/docs/plans/2026-02-23-split-refine-persist-impl.md
@@ -1,0 +1,636 @@
+# sdf split — Plan Refinement & Persistence Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace Y/n confirmation with Execute/Refine/Abort menu, persist plans to disk, and enable interactive plan refinement via Claude session.
+
+**Architecture:** Add plan serialization to `internal/split/plan.go`, interactive Claude session to `internal/claude/claude.go`, refine/re-extract logic to `internal/split/ai.go`, and wire the 3-choice loop in `cmd/split.go`.
+
+**Tech Stack:** Go 1.24, gopkg.in/yaml.v3, charmbracelet/huh (ui.Select), Claude CLI (`claude --resume`)
+
+---
+
+### Task 1: Plan Persistence — SavePlan, PlanPath, DeletePlan
+
+Add functions to serialize a Plan to YAML, compute the save path, and clean up after execution.
+
+**Files:**
+- Modify: `internal/split/plan.go`
+- Modify: `internal/split/plan_test.go`
+
+**Step 1: Write the failing tests**
+
+Add to `internal/split/plan_test.go`:
+
+```go
+func TestSavePlan_WritesValidYAML(t *testing.T) {
+	plan := &Plan{
+		Layers: []Layer{
+			{Name: "db", Description: "schema", Files: []string{"a.go", "b.go"}},
+			{Name: "api", Description: "endpoints", Files: []string{"c.go"},
+				PartialFiles: []PartialFile{{Path: "shared.go", Hunks: []int{0, 2}}}},
+		},
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plan.yaml")
+
+	if err := SavePlan(path, plan); err != nil {
+		t.Fatalf("SavePlan: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	// Round-trip: parse back
+	got, err := ParsePlan(string(data))
+	if err != nil {
+		t.Fatalf("ParsePlan round-trip: %v", err)
+	}
+	if len(got.Layers) != 2 {
+		t.Fatalf("expected 2 layers, got %d", len(got.Layers))
+	}
+	if got.Layers[0].Name != "db" {
+		t.Errorf("layer 0 name: got %q, want %q", got.Layers[0].Name, "db")
+	}
+	if len(got.Layers[1].PartialFiles) != 1 {
+		t.Errorf("layer 1 partial files: got %d, want 1", len(got.Layers[1].PartialFiles))
+	}
+	if got.Layers[1].PartialFiles[0].Path != "shared.go" {
+		t.Errorf("partial file path: got %q, want %q", got.Layers[1].PartialFiles[0].Path, "shared.go")
+	}
+}
+
+func TestPlanPath(t *testing.T) {
+	path := PlanPath("/repo", "my-feature")
+	want := filepath.Join("/repo", ".sdf", "split-plans", "my-feature.yaml")
+	if path != want {
+		t.Errorf("PlanPath: got %q, want %q", path, want)
+	}
+}
+
+func TestDeletePlan(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plan.yaml")
+	os.WriteFile(path, []byte("test"), 0644)
+
+	if err := DeletePlan(path); err != nil {
+		t.Fatalf("DeletePlan existing: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("file should be deleted")
+	}
+
+	// Deleting non-existent file should not error
+	if err := DeletePlan(path); err != nil {
+		t.Errorf("DeletePlan non-existent: %v", err)
+	}
+}
+```
+
+Add imports to the test file: `"os"`, `"path/filepath"`.
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/split/ -run 'TestSavePlan|TestPlanPath|TestDeletePlan' -v`
+Expected: FAIL (functions undefined)
+
+**Step 3: Implement**
+
+Add to `internal/split/plan.go`:
+
+```go
+// SplitPlansDir is the subdirectory for persisted split plans.
+const SplitPlansDir = "split-plans"
+
+// PlanPath returns the file path for a stack's split plan.
+func PlanPath(root, stackName string) string {
+	return filepath.Join(root, stack.SDFDir, SplitPlansDir, stackName+".yaml")
+}
+
+// SavePlan serializes a Plan to YAML and writes it to path.
+// Creates parent directories if needed.
+func SavePlan(path string, plan *Plan) error {
+	data, err := yaml.Marshal(plan)
+	if err != nil {
+		return fmt.Errorf("cannot marshal plan: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("cannot create plan directory: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("cannot write plan: %w", err)
+	}
+	return nil
+}
+
+// DeletePlan removes a plan file. Returns nil if the file doesn't exist.
+func DeletePlan(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("cannot delete plan: %w", err)
+	}
+	return nil
+}
+```
+
+Add imports: `"os"`, `"path/filepath"`, and `"github.com/pavelpascari/sdf/internal/stack"`.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/split/ -run 'TestSavePlan|TestPlanPath|TestDeletePlan' -v`
+Expected: PASS
+
+**Step 5: Run full test suite**
+
+Run: `go build ./... && go vet ./... && go test ./internal/split/ -count=1`
+Expected: All pass
+
+**Step 6: Commit**
+
+```bash
+git add internal/split/plan.go internal/split/plan_test.go
+git commit -m "feat(split): add SavePlan, PlanPath, DeletePlan for plan persistence"
+```
+
+---
+
+### Task 2: Interactive Claude Resume
+
+Add a function to spawn `claude --resume <id>` as an interactive terminal process with an initial prompt.
+
+**Files:**
+- Modify: `internal/claude/claude.go`
+
+**Step 1: Implement**
+
+This function spawns an interactive process with stdin/stdout/stderr attached to the terminal. It cannot be unit tested — it's verified manually and via integration tests.
+
+Add to `internal/claude/claude.go`:
+
+```go
+// RunInteractiveResume spawns an interactive Claude session that resumes
+// a previous conversation. The initialPrompt is passed as the positional
+// argument so Claude starts with context. Returns nil when the user exits.
+func RunInteractiveResume(sessionID, initialPrompt string) error {
+	args := []string{"--resume", sessionID, initialPrompt}
+	cmd := exec.Command(Binary, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+```
+
+**Step 2: Build to verify compilation**
+
+Run: `go build ./...`
+Expected: Clean build
+
+**Step 3: Commit**
+
+```bash
+git add internal/claude/claude.go
+git commit -m "feat(claude): add RunInteractiveResume for interactive session resumption"
+```
+
+---
+
+### Task 3: Refine and Re-Extract Prompts
+
+Add prompt builders for the interactive refinement session and the follow-up plan re-extraction.
+
+**Files:**
+- Modify: `internal/split/ai.go`
+- Modify: `internal/split/ai_test.go`
+
+**Step 1: Write the failing tests**
+
+Add to `internal/split/ai_test.go`:
+
+```go
+func TestBuildRefinePrompt(t *testing.T) {
+	plan := &Plan{
+		Layers: []Layer{
+			{Name: "db", Description: "Add schema", Files: []string{"a.go", "b.go"}},
+			{Name: "api", Description: "REST endpoints", Files: []string{"c.go"},
+				PartialFiles: []PartialFile{{Path: "shared.go", Hunks: []int{1, 3}}}},
+		},
+	}
+
+	prompt := BuildRefinePrompt(plan)
+
+	if !strings.Contains(prompt, "db") {
+		t.Error("prompt should contain layer name 'db'")
+	}
+	if !strings.Contains(prompt, "api") {
+		t.Error("prompt should contain layer name 'api'")
+	}
+	if !strings.Contains(prompt, "Add schema") {
+		t.Error("prompt should contain layer description")
+	}
+	if !strings.Contains(prompt, "a.go") {
+		t.Error("prompt should contain file names")
+	}
+	if !strings.Contains(prompt, "shared.go") {
+		t.Error("prompt should contain partial file names")
+	}
+	if !strings.Contains(prompt, "refine") || !strings.Contains(prompt, "change") {
+		t.Error("prompt should ask user what to change")
+	}
+}
+
+func TestBuildReExtractPrompt(t *testing.T) {
+	prompt := BuildReExtractPrompt()
+
+	if !strings.Contains(prompt, "layers:") {
+		t.Error("prompt should show expected YAML format")
+	}
+	if !strings.Contains(prompt, "yaml") {
+		t.Error("prompt should mention YAML")
+	}
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/split/ -run 'TestBuildRefinePrompt|TestBuildReExtractPrompt' -v`
+Expected: FAIL (functions undefined)
+
+**Step 3: Implement**
+
+Add to `internal/split/ai.go`:
+
+```go
+// BuildRefinePrompt constructs the initial prompt for an interactive
+// Claude session where the user can refine the split plan.
+func BuildRefinePrompt(plan *Plan) string {
+	var b strings.Builder
+	b.WriteString("The user wants to refine the split plan. Here's the current plan:\n\n")
+
+	for i, layer := range plan.Layers {
+		fmt.Fprintf(&b, "Layer %d: %s\n", i+1, layer.Name)
+		fmt.Fprintf(&b, "  Description: %s\n", layer.Description)
+		for _, f := range layer.Files {
+			fmt.Fprintf(&b, "  - %s\n", f)
+		}
+		for _, pf := range layer.PartialFiles {
+			fmt.Fprintf(&b, "  - %s (hunks %v)\n", pf.Path, pf.Hunks)
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("Ask the user what they'd like to change. When they're satisfied, they can\n")
+	b.WriteString("exit this session (Ctrl+C or /exit) and sdf will re-read the updated plan.\n\n")
+	b.WriteString("Remember: every changed file must appear in at least one layer, use kebab-case\n")
+	b.WriteString("layer names, and return YAML in the same format when asked.\n")
+
+	return b.String()
+}
+
+// BuildReExtractPrompt constructs the prompt to re-extract the plan
+// after an interactive refinement session.
+func BuildReExtractPrompt() string {
+	return `Return the current split plan as YAML (wrapped in ` + "```" + `yaml fences).
+Use the exact same format:
+
+` + "```" + `yaml
+layers:
+  - name: <kebab-case-name>
+    description: "<one-line summary>"
+    files:
+      - <path/to/file>
+` + "```" + `
+
+Include any changes discussed in the refinement session.`
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/split/ -run 'TestBuildRefinePrompt|TestBuildReExtractPrompt' -v`
+Expected: PASS
+
+**Step 5: Run full test suite**
+
+Run: `go build ./... && go vet ./... && go test ./internal/split/ -count=1`
+Expected: All pass
+
+**Step 6: Commit**
+
+```bash
+git add internal/split/ai.go internal/split/ai_test.go
+git commit -m "feat(split): add BuildRefinePrompt and BuildReExtractPrompt"
+```
+
+---
+
+### Task 4: ReExtractPlan Function
+
+Add a function that resumes the Claude session in `-p` mode, parses the plan from the response, and validates it.
+
+**Files:**
+- Modify: `internal/split/ai.go`
+- Modify: `internal/split/ai_test.go`
+
+**Step 1: Write the failing test**
+
+Add to `internal/split/ai_test.go`:
+
+```go
+func TestBuildReExtractPrompt_ContainsFormat(t *testing.T) {
+	prompt := BuildReExtractPrompt()
+	if !strings.Contains(prompt, "name:") {
+		t.Error("re-extract prompt should contain name field")
+	}
+	if !strings.Contains(prompt, "description:") {
+		t.Error("re-extract prompt should contain description field")
+	}
+	if !strings.Contains(prompt, "files:") {
+		t.Error("re-extract prompt should contain files field")
+	}
+}
+```
+
+Note: `ReExtractPlan` itself calls Claude (external process) so it cannot be unit tested. We test the prompt construction and rely on integration testing for the full flow.
+
+**Step 2: Implement**
+
+Add to `internal/split/ai.go`:
+
+```go
+// ReExtractPlan resumes a Claude session in print mode to re-extract
+// the plan after an interactive refinement. Returns the parsed plan.
+// changedFiles is used for Phase 1 validation of the re-extracted plan.
+func ReExtractPlan(sessionID, name string, changedFiles []string, display io.Writer) (*Plan, error) {
+	prompt := BuildReExtractPrompt()
+	sr, err := claudepkg.RunPromptStreamingResume(name, sessionID, prompt, display)
+	if err != nil {
+		return nil, fmt.Errorf("plan re-extraction failed: %w", err)
+	}
+
+	plan, err := ParsePlan(sr.Result)
+	if err != nil {
+		// Retry once
+		retryPrompt := fmt.Sprintf("Could not parse your response: %s\n\nPlease return ONLY the YAML plan.", err.Error())
+		sr, err = claudepkg.RunPromptStreamingResume(name, sessionID, retryPrompt, display)
+		if err != nil {
+			return nil, fmt.Errorf("plan re-extraction retry failed: %w", err)
+		}
+		plan, err = ParsePlan(sr.Result)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse re-extracted plan: %w", err)
+		}
+	}
+
+	validationErrs := ValidatePhase1(plan, changedFiles)
+	if len(validationErrs) > 0 {
+		var msgs []string
+		for _, e := range validationErrs {
+			msgs = append(msgs, e.Error())
+		}
+		return nil, fmt.Errorf("re-extracted plan has validation errors:\n  %s", strings.Join(msgs, "\n  "))
+	}
+
+	return plan, nil
+}
+```
+
+**Step 3: Run tests**
+
+Run: `go build ./... && go vet ./... && go test ./internal/split/ -count=1`
+Expected: All pass
+
+**Step 4: Commit**
+
+```bash
+git add internal/split/ai.go internal/split/ai_test.go
+git commit -m "feat(split): add ReExtractPlan for post-refinement plan extraction"
+```
+
+---
+
+### Task 5: Wire the 3-Choice Loop in cmd/split.go
+
+Replace the Y/n confirmation with Execute/Refine/Abort, add plan persistence, and wire the refinement loop.
+
+**Files:**
+- Modify: `cmd/split.go`
+
+**Context:** The current confirmation code is at lines 140-146 in `cmd/split.go`:
+
+```go
+// --- Confirm ---
+if !yes {
+    if !ui.Confirm("Execute this split?") {
+        fmt.Println("Aborted.")
+        return nil
+    }
+}
+```
+
+Replace this entire section with the 3-choice loop. Also add plan save after analysis and plan delete after successful execution.
+
+**Step 1: Implement the changes**
+
+Add import for `"github.com/charmbracelet/huh"` at the top of `cmd/split.go`.
+
+Replace the confirmation section (lines 133-146) and add plan persistence. The new code:
+
+After the analysis result is obtained and the plan is displayed (around line 134), insert plan save:
+
+```go
+// --- Save plan to disk ---
+planPath := splitpkg.PlanPath(root, stackName)
+if err := splitpkg.SavePlan(planPath, result.Plan); err != nil {
+    fmt.Fprintf(os.Stderr, "  %s could not save plan: %v\n", ui.SymWarn, err)
+} else {
+    fmt.Printf("  Plan saved to %s\n", planPath)
+}
+```
+
+Replace the confirmation block with the 3-choice loop:
+
+```go
+if dryRun {
+    return nil
+}
+
+// --- Choose action ---
+plan := result.Plan
+sessionID := result.SessionID
+
+if !yes {
+    for {
+        choice := ui.Select("What would you like to do?", []huh.Option[string]{
+            huh.NewOption("Execute this split", "execute"),
+            huh.NewOption("Refine plan (opens Claude session)", "refine"),
+            huh.NewOption("Abort", "abort"),
+        })
+
+        switch choice {
+        case "execute":
+            goto execute
+        case "refine":
+            if sessionID == "" {
+                fmt.Println("No Claude session available for refinement.")
+                continue
+            }
+
+            fmt.Println("\nOpening Claude session for plan refinement...")
+            fmt.Println("(Exit with Ctrl+C or /exit when done)\n")
+
+            refinePrompt := splitpkg.BuildRefinePrompt(plan)
+            if err := claudepkg.RunInteractiveResume(sessionID, refinePrompt); err != nil {
+                fmt.Fprintf(os.Stderr, "\n%s Claude session exited with error: %v\n", ui.SymWarn, err)
+                fmt.Println("Continuing with the previous plan.\n")
+                displaySplitPlan(plan, stackName, base, fromBranch)
+                continue
+            }
+
+            fmt.Println("\nRe-reading plan from Claude session...")
+            changedFiles, _ := gitpkg.DiffNameOnly(base, fromBranch)
+            newPlan, err := splitpkg.ReExtractPlan(sessionID, "split-analysis", changedFiles, os.Stdout)
+            if err != nil {
+                fmt.Fprintf(os.Stderr, "\n%s Could not re-extract plan: %v\n", ui.SymWarn, err)
+                fmt.Println("Continuing with the previous plan.\n")
+                displaySplitPlan(plan, stackName, base, fromBranch)
+                continue
+            }
+
+            plan = newPlan
+            // Check for shared files in the refined plan
+            shared := splitpkg.SharedFiles(plan)
+            if len(shared) > 0 {
+                fmt.Printf("\n%d file(s) appear in multiple layers — assigning hunks...\n", len(shared))
+                fileDiffs, hunkCounts, err := splitpkg.ParseSharedFileDiffs(base, fromBranch, shared)
+                if err != nil {
+                    fmt.Fprintf(os.Stderr, "\n%s Could not parse shared file diffs: %v\n", ui.SymWarn, err)
+                    fmt.Println("Continuing with the previous plan.\n")
+                    plan = result.Plan
+                    displaySplitPlan(plan, stackName, base, fromBranch)
+                    continue
+                }
+
+                hunkPrompt := splitpkg.BuildHunkPrompt(shared, fileDiffs)
+                sr, err := claudepkg.RunPromptStreamingResume("split-analysis", sessionID, hunkPrompt, os.Stdout)
+                if err != nil {
+                    fmt.Fprintf(os.Stderr, "\n%s Hunk assignment failed: %v\n", ui.SymWarn, err)
+                    fmt.Println("Continuing with the previous plan.\n")
+                    plan = result.Plan
+                    displaySplitPlan(plan, stackName, base, fromBranch)
+                    continue
+                }
+
+                resp, err := splitpkg.ParseHunkAssignment(sr.Result)
+                if err != nil {
+                    fmt.Fprintf(os.Stderr, "\n%s Could not parse hunk assignments: %v\n", ui.SymWarn, err)
+                    fmt.Println("Continuing with the previous plan.\n")
+                    plan = result.Plan
+                    displaySplitPlan(plan, stackName, base, fromBranch)
+                    continue
+                }
+
+                validationErrs := splitpkg.ValidateHunkAssignment(resp, shared, hunkCounts)
+                if len(validationErrs) > 0 {
+                    fmt.Fprintf(os.Stderr, "\n%s Hunk assignment validation failed\n", ui.SymWarn)
+                    fmt.Println("Continuing with the previous plan.\n")
+                    plan = result.Plan
+                    displaySplitPlan(plan, stackName, base, fromBranch)
+                    continue
+                }
+
+                plan = splitpkg.MergePlan(plan, resp)
+            }
+
+            result.Plan = plan
+
+            fmt.Println()
+            displaySplitPlan(plan, stackName, base, fromBranch)
+
+            // Update saved plan
+            if err := splitpkg.SavePlan(planPath, plan); err != nil {
+                fmt.Fprintf(os.Stderr, "  %s could not save updated plan: %v\n", ui.SymWarn, err)
+            }
+
+            continue
+        default:
+            // abort or empty (user cancelled)
+            fmt.Println("Aborted.")
+            return nil
+        }
+    }
+}
+execute:
+```
+
+After successful tree identity verification (around current line 171), add plan cleanup:
+
+```go
+// --- Delete plan file (split succeeded) ---
+splitpkg.DeletePlan(planPath)
+```
+
+**Important:** The `parseSharedFileDiffs` function in `ai.go` is currently unexported. We need to export it as `ParseSharedFileDiffs` for use from `cmd/split.go`.
+
+**Step 2: Export parseSharedFileDiffs in ai.go**
+
+In `internal/split/ai.go`, rename `parseSharedFileDiffs` to `ParseSharedFileDiffs` (capitalize the P). Update the call in the `Analyze` function to use `ParseSharedFileDiffs`.
+
+**Step 3: Build and verify**
+
+Run: `go build ./...`
+Expected: Clean build
+
+**Step 4: Manual smoke test**
+
+The 3-choice loop involves interactive UI (`ui.Select`, `claude --resume`) which can't be unit tested easily. Verify manually:
+
+1. `go install ./...`
+2. Create a test repo with a feature branch
+3. `sdf split --from feature --stack test --dry-run` — should show plan without prompt
+4. `sdf split --from feature --stack test -y` — should skip prompt and execute
+5. `sdf split --from feature --stack test` — should show 3-choice menu
+
+**Step 5: Commit**
+
+```bash
+git add cmd/split.go internal/split/ai.go
+git commit -m "feat(split): add Execute/Refine/Abort menu with plan persistence"
+```
+
+---
+
+### Task 6: Verify Full Test Suite
+
+Run the complete test suite to ensure nothing is broken.
+
+**Step 1: Build, vet, test**
+
+Run: `go build ./... && go vet ./... && go test ./... -count=1`
+Expected: All pass
+
+**Step 2: Verify plan persistence paths**
+
+The `.sdf/split-plans/` directory uses `stack.SDFDir` constant for consistency. Verify this compiles and the path looks correct by checking the test output from Task 1.
+
+---
+
+## Context Notes
+
+**Key files you'll need to understand:**
+
+- `internal/split/plan.go` — Plan/Layer/PartialFile structs, validation functions, YAML parsing
+- `internal/split/ai.go` — Claude interaction: prompts, Analyze (2-phase), retry logic
+- `internal/claude/claude.go` — Claude CLI wrapper: `RunPromptStreaming`, `RunPromptStreamingResume`
+- `cmd/split.go` — Command orchestration: flags, preconditions, analysis, display, execute, push, PRs
+- `internal/ui/prompt.go` — `ui.Confirm` (being replaced), `ui.Select` (being used)
+- `internal/stack/stack.go` — `SDFDir` constant, `LocalState` with `SplitSessions`
+
+**Existing patterns to follow:**
+
+- Error handling: non-fatal warnings use `fmt.Fprintf(os.Stderr, "  %s ...\n", ui.SymWarn, ...)`, fatal errors return `fmt.Errorf(...)`
+- YAML: uses `gopkg.in/yaml.v3` throughout
+- Plan display: `displaySplitPlan(plan, stackName, base, source)` already handles partial files
+- Session persistence: `SplitSessions` map in `.sdf/local.json` stores `stackName → sessionID`


### PR DESCRIPTION
<!-- sdf:description -->
Adds design documents and implementation plans for two upcoming `sdf split` iterations. Iteration 4 introduces hunk-level decomposition, allowing individual diff hunks within a file to be assigned to different layers via a two-phase Claude analysis — solving the limitation where a file touching multiple concerns was forced into a single layer. Iteration 5 replaces the simple Y/n confirmation with an Execute/Refine/Abort menu, enabling interactive plan refinement through a resumed Claude session, and persists plans to disk as YAML between analysis and execution. Both documents include full data structures, validation rules, error handling, and task-by-task implementation plans with tests.
<!-- /sdf:description -->

Part of stack: **feature-split**

Split from `claude/sdf-pr-stacking-plan-taR5V` — PR 9 of 9

Base: `feature-split/8-split-command`

<!-- sdf:stack-nav -->
---
Stack: `feature-split`
1. https://github.com/pavelpascari/sdf/pull/57
2. https://github.com/pavelpascari/sdf/pull/58
3. https://github.com/pavelpascari/sdf/pull/59
4. https://github.com/pavelpascari/sdf/pull/60
5. https://github.com/pavelpascari/sdf/pull/61
6. https://github.com/pavelpascari/sdf/pull/62
7. https://github.com/pavelpascari/sdf/pull/63
8. https://github.com/pavelpascari/sdf/pull/64
9. https://github.com/pavelpascari/sdf/pull/65 ◀ this PR
<!-- /sdf:stack-nav -->