### PR TITLE
Add execution duration tracking to spy recorder

### DIFF
--- a/internal/claude/claude.go
+++ b/internal/claude/claude.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 // Binary is the name (or path) of the claude executable.
@@ -36,14 +37,16 @@ func Version() (string, error) {
 // The sessionName is unused by the current CLI but kept for call-site clarity.
 func RunPrompt(sessionName, prompt string) (string, error) {
 	cmd := exec.Command(Binary, "-p", prompt)
+	start := time.Now()
 	out, err := cmd.CombinedOutput()
+	elapsed := time.Since(start)
 	output := strings.TrimSpace(string(out))
 
 	exitCode := 0
 	if err != nil {
 		exitCode = 1
 	}
-	recordRun([]string{"-p", prompt}, output, exitCode)
+	recordRun([]string{"-p", prompt}, output, exitCode, elapsed)
 
 	if err != nil {
 		return output, fmt.Errorf("claude %s: %s", sessionName, output)

--- a/internal/claude/record_noop.go
+++ b/internal/claude/record_noop.go
@@ -2,6 +2,8 @@
 
 package claude
 
+import "time"
+
 // recordRun is a no-op in production builds.
 // With -tags spyrecord, the real implementation records invocations.
-func recordRun(args []string, output string, exitCode int) {}
+func recordRun(args []string, output string, exitCode int, elapsed time.Duration) {}

--- a/internal/claude/record_spy.go
+++ b/internal/claude/record_spy.go
@@ -4,6 +4,7 @@ package claude
 
 import (
 	"os"
+	"time"
 
 	"github.com/pavelpascari/sdf/internal/spy"
 )
@@ -18,9 +19,9 @@ func init() {
 	}
 }
 
-func recordRun(args []string, output string, exitCode int) {
+func recordRun(args []string, output string, exitCode int, elapsed time.Duration) {
 	if spyRec != nil {
-		spyRec.Record(args, output, exitCode)
-		fullSpy.RecordAs("sdf", "claude", args, output, exitCode)
+		spyRec.Record(args, output, exitCode, elapsed)
+		fullSpy.RecordAs("sdf", "claude", args, output, exitCode, elapsed)
 	}
 }

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 // PRInfo represents pull request information from gh.
@@ -26,14 +27,16 @@ var Binary = "gh"
 // run executes a gh command and returns its trimmed stdout.
 func run(args ...string) (string, error) {
 	cmd := exec.Command(Binary, args...)
+	start := time.Now()
 	out, err := cmd.CombinedOutput()
+	elapsed := time.Since(start)
 	output := strings.TrimSpace(string(out))
 
 	exitCode := 0
 	if err != nil {
 		exitCode = 1
 	}
-	recordRun(args, output, exitCode)
+	recordRun(args, output, exitCode, elapsed)
 
 	if err != nil {
 		return output, fmt.Errorf("gh %s: %s", strings.Join(args, " "), output)

--- a/internal/gh/record_noop.go
+++ b/internal/gh/record_noop.go
@@ -2,6 +2,8 @@
 
 package gh
 
+import "time"
+
 // recordRun is a no-op in production builds.
 // With -tags spyrecord, the real implementation records invocations.
-func recordRun(args []string, output string, exitCode int) {}
+func recordRun(args []string, output string, exitCode int, elapsed time.Duration) {}

--- a/internal/gh/record_spy.go
+++ b/internal/gh/record_spy.go
@@ -4,6 +4,7 @@ package gh
 
 import (
 	"os"
+	"time"
 
 	"github.com/pavelpascari/sdf/internal/spy"
 )
@@ -18,9 +19,9 @@ func init() {
 	}
 }
 
-func recordRun(args []string, output string, exitCode int) {
+func recordRun(args []string, output string, exitCode int, elapsed time.Duration) {
 	if spyRec != nil {
-		spyRec.Record(args, output, exitCode)
-		fullSpy.RecordAs("sdf", "gh", args, output, exitCode)
+		spyRec.Record(args, output, exitCode, elapsed)
+		fullSpy.RecordAs("sdf", "gh", args, output, exitCode, elapsed)
 	}
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // Binary is the name (or path) of the git executable.
@@ -16,14 +17,16 @@ var Binary = "git"
 // run executes a git command and returns its trimmed stdout.
 func run(args ...string) (string, error) {
 	cmd := exec.Command(Binary, args...)
+	start := time.Now()
 	out, err := cmd.CombinedOutput()
+	elapsed := time.Since(start)
 	output := strings.TrimSpace(string(out))
 
 	exitCode := 0
 	if err != nil {
 		exitCode = 1
 	}
-	recordRun(args, output, exitCode)
+	recordRun(args, output, exitCode, elapsed)
 
 	if err != nil {
 		return output, fmt.Errorf("git %s: %s", strings.Join(args, " "), output)

--- a/internal/git/record_noop.go
+++ b/internal/git/record_noop.go
@@ -2,6 +2,8 @@
 
 package git
 
+import "time"
+
 // recordRun is a no-op in production builds.
 // With -tags spyrecord, the real implementation records invocations.
-func recordRun(args []string, output string, exitCode int) {}
+func recordRun(args []string, output string, exitCode int, elapsed time.Duration) {}

--- a/internal/git/record_spy.go
+++ b/internal/git/record_spy.go
@@ -4,6 +4,7 @@ package git
 
 import (
 	"os"
+	"time"
 
 	"github.com/pavelpascari/sdf/internal/spy"
 )
@@ -18,9 +19,9 @@ func init() {
 	}
 }
 
-func recordRun(args []string, output string, exitCode int) {
+func recordRun(args []string, output string, exitCode int, elapsed time.Duration) {
 	if spyRec != nil {
-		spyRec.Record(args, output, exitCode)
-		fullSpy.RecordAs("sdf", "git", args, output, exitCode)
+		spyRec.Record(args, output, exitCode, elapsed)
+		fullSpy.RecordAs("sdf", "git", args, output, exitCode, elapsed)
 	}
 }

--- a/internal/spy/spy.go
+++ b/internal/spy/spy.go
@@ -13,12 +13,13 @@ import (
 
 // Invocation records a single call to an external binary.
 type Invocation struct {
-	Actor     string   `json:"actor"`
-	Binary    string   `json:"binary"`
-	Args      []string `json:"args"`
-	Stdout    string   `json:"stdout"`
-	ExitCode  int      `json:"exit_code"`
-	Timestamp string   `json:"timestamp"`
+	Actor      string   `json:"actor"`
+	Binary     string   `json:"binary"`
+	Args       []string `json:"args"`
+	Stdout     string   `json:"stdout"`
+	ExitCode   int      `json:"exit_code"`
+	Timestamp  string   `json:"timestamp"`
+	DurationNs int64    `json:"duration_ns"`
 }
 
 // Recorder captures invocations to a JSONL file.
@@ -81,24 +82,25 @@ func (r *Recorder) Binary() string {
 
 // Record appends an invocation to the log. No-op on nil receiver.
 // Uses the recorder's name as actor and its binary as the tool.
-func (r *Recorder) Record(args []string, stdout string, exitCode int) {
-	r.RecordAs(r.name, r.binary, args, stdout, exitCode)
+func (r *Recorder) Record(args []string, stdout string, exitCode int, elapsed time.Duration) {
+	r.RecordAs(r.name, r.binary, args, stdout, exitCode, elapsed)
 }
 
 // RecordAs appends an invocation with explicit actor and binary names.
 // Use this for combined logs (e.g., full.jsonl) where one recorder captures
 // invocations from multiple tools and actors. No-op on nil receiver.
-func (r *Recorder) RecordAs(actor, binary string, args []string, stdout string, exitCode int) {
+func (r *Recorder) RecordAs(actor, binary string, args []string, stdout string, exitCode int, elapsed time.Duration) {
 	if r == nil {
 		return
 	}
 	inv := Invocation{
-		Actor:     actor,
-		Binary:    binary,
-		Args:      args,
-		Stdout:    stdout,
-		ExitCode:  exitCode,
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Actor:      actor,
+		Binary:     binary,
+		Args:       args,
+		Stdout:     stdout,
+		ExitCode:   exitCode,
+		Timestamp:  time.Now().UTC().Format(time.RFC3339Nano),
+		DurationNs: elapsed.Nanoseconds(),
 	}
 	data, err := json.Marshal(inv)
 	if err != nil {


### PR DESCRIPTION
## Summary
This change adds execution duration tracking to the spy recorder, capturing how long each external binary invocation takes. The duration is now recorded in nanoseconds and included in the invocation log.

## Key Changes
- Added `DurationNs` field to the `Invocation` struct to store execution time in nanoseconds
- Updated `Record()` and `RecordAs()` methods to accept an `elapsed time.Duration` parameter
- Changed timestamp format from `time.RFC3339` to `time.RFC3339Nano` for higher precision
- Modified all call sites in `claude`, `gh`, and `git` packages to measure and pass execution duration:
  - Added `start := time.Now()` before command execution
  - Calculated `elapsed := time.Since(start)` after command completion
  - Passed `elapsed` to `recordRun()` calls
- Updated both the spy recording implementations and no-op stubs to accept the new duration parameter

## Implementation Details
- Duration measurement wraps the `cmd.CombinedOutput()` call to capture actual execution time
- The duration is converted to nanoseconds via `elapsed.Nanoseconds()` for storage
- All three external tool packages (claude, gh, git) follow the same pattern for consistency
- The change is backward compatible at the API level since the spy recorder is internal

https://claude.ai/code/session_01TBHpEPkKbKNZndhZ5uSR5H