### PR TITLE
fix: prevent sdf init and register from overwriting existing config

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -124,17 +124,19 @@ func runInitCore(stackName, base, branchFlag string, jsonFlag bool) (string, err
 		return "", err
 	}
 
-	// Create default config file so it's discoverable
-	cfg := cfgpkg.Defaults()
+	// Create default config file only if one doesn't already exist,
+	// so we never overwrite user-customised settings.
 	cfgPath := cfgpkg.RepoPath(root)
-	if err := cfgpkg.Save(cfgPath, cfg); err != nil {
-		if !jsonFlag {
-			fmt.Fprintf(os.Stderr, "warning: could not create config: %v\n", err)
+	if _, statErr := os.Stat(cfgPath); os.IsNotExist(statErr) {
+		if err := cfgpkg.Save(cfgPath, cfgpkg.Defaults()); err != nil {
+			if !jsonFlag {
+				fmt.Fprintf(os.Stderr, "warning: could not create config: %v\n", err)
+			}
 		}
 	}
 
-	// Load the config (may already exist with custom settings)
-	cfg, err = cfgpkg.Load(root)
+	// Load the config (merges global + repo, applies defaults for unset fields)
+	cfg, err := cfgpkg.Load(root)
 	if err != nil {
 		cfg = cfgpkg.Defaults()
 	}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -184,6 +184,67 @@ func TestInit_JSONOutputWithCustomBranch(t *testing.T) {
 	}
 }
 
+func TestInit_PreservesExistingConfig(t *testing.T) {
+	dir := initTestRepo(t)
+
+	// Pre-create .sdf directory and a custom config before running init.
+	sdfDir := filepath.Join(dir, ".sdf")
+	if err := os.MkdirAll(sdfDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	customCfg := `{
+  "branch_prefix": {
+    "enabled": false,
+    "scope": "custom",
+    "separator": "-"
+  }
+}
+`
+	cfgPath := filepath.Join(sdfDir, "config.json")
+	if err := os.WriteFile(cfgPath, []byte(customCfg), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run init via runInitCore directly (avoids cobra flag state leaking
+	// between tests via the global rootCmd).
+	if _, err := runInitCore("my-feature", "main", "", false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read back the config and verify it was preserved.
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("cannot read config after init: %v", err)
+	}
+
+	var got struct {
+		BranchPrefix struct {
+			Enabled   *bool  `json:"enabled"`
+			Scope     string `json:"scope"`
+			Separator string `json:"separator"`
+		} `json:"branch_prefix"`
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("cannot parse config after init: %v", err)
+	}
+
+	if got.BranchPrefix.Enabled == nil || *got.BranchPrefix.Enabled != false {
+		t.Error("expected enabled=false to be preserved, got overwritten")
+	}
+	if got.BranchPrefix.Scope != "custom" {
+		t.Errorf("expected scope 'custom' to be preserved, got %q", got.BranchPrefix.Scope)
+	}
+	if got.BranchPrefix.Separator != "-" {
+		t.Errorf("expected separator '-' to be preserved, got %q", got.BranchPrefix.Separator)
+	}
+
+	// With prefix disabled, branch name should be bare (no prefix applied).
+	branch := currentBranch(t, dir)
+	if branch != "my-feature" {
+		t.Errorf("expected bare branch 'my-feature' (prefix disabled), got %s", branch)
+	}
+}
+
 func TestInit_JSONOutputNotPushed(t *testing.T) {
 	// Test repo has no origin, so pushed should be false
 	initTestRepo(t)

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -75,14 +75,18 @@ func RegisterStack(root, name string, ds stack.DiscoveredStack) error {
 		return err
 	}
 
-	// Infer prefix config from registered branch names
-	cfg := cfgpkg.Defaults()
-	if prefix, sep := inferBranchPrefix(nodes, name); prefix != "" {
-		cfg.BranchPrefix.Scope = prefix
-		cfg.BranchPrefix.Separator = sep
-	}
-	if err := cfgpkg.Save(cfgpkg.RepoPath(root), cfg); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: could not create config: %v\n", err)
+	// Create default config (with inferred prefix) only if one doesn't
+	// already exist, so we never overwrite user-customised settings.
+	cfgPath := cfgpkg.RepoPath(root)
+	if _, statErr := os.Stat(cfgPath); os.IsNotExist(statErr) {
+		cfg := cfgpkg.Defaults()
+		if prefix, sep := inferBranchPrefix(nodes, name); prefix != "" {
+			cfg.BranchPrefix.Scope = prefix
+			cfg.BranchPrefix.Separator = sep
+		}
+		if err := cfgpkg.Save(cfgPath, cfg); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not create config: %v\n", err)
+		}
 	}
 
 	fmt.Printf("\nRegistered stack %q with %d branches (base: %s)\n\n", name, len(nodes), ui.Branch(ds.Base))

--- a/cmd/register_test.go
+++ b/cmd/register_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -285,6 +286,77 @@ func TestRegisterStack_ParentBranchRelationships(t *testing.T) {
 	}
 	if parent := s.ParentBranch("feat/ui"); parent != "feat/api" {
 		t.Errorf("parent of feat/ui should be 'feat/api', got %q", parent)
+	}
+}
+
+func TestRegisterStack_PreservesExistingConfig(t *testing.T) {
+	dir, _ := registerTestRepo(t)
+
+	// Pre-create .sdf directory and a custom config before registering.
+	sdfDir := filepath.Join(dir, ".sdf")
+	if err := os.MkdirAll(sdfDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	customCfg := `{
+  "branch_prefix": {
+    "enabled": false,
+    "scope": "custom",
+    "separator": "-"
+  },
+  "pr_title": {
+    "conventional_commits": true
+  }
+}
+`
+	cfgPath := filepath.Join(sdfDir, "config.json")
+	if err := os.WriteFile(cfgPath, []byte(customCfg), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ds := stack.DiscoveredStack{
+		Base: "main",
+		Chains: []stack.PRRecord{
+			{Number: 10, HeadRefName: "feat/schema", BaseRefName: "main"},
+			{Number: 11, HeadRefName: "feat/api", BaseRefName: "feat/schema"},
+		},
+	}
+
+	if err := RegisterStack(dir, "feat", ds); err != nil {
+		t.Fatalf("RegisterStack failed: %v", err)
+	}
+
+	// Read back the config and verify it was preserved.
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("cannot read config after register: %v", err)
+	}
+
+	type cfgShape struct {
+		BranchPrefix struct {
+			Enabled   *bool  `json:"enabled"`
+			Scope     string `json:"scope"`
+			Separator string `json:"separator"`
+		} `json:"branch_prefix"`
+		PRTitle struct {
+			ConventionalCommits *bool `json:"conventional_commits"`
+		} `json:"pr_title"`
+	}
+	var got cfgShape
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("cannot parse config after register: %v", err)
+	}
+
+	if got.BranchPrefix.Enabled == nil || *got.BranchPrefix.Enabled != false {
+		t.Error("expected enabled=false to be preserved")
+	}
+	if got.BranchPrefix.Scope != "custom" {
+		t.Errorf("expected scope 'custom' to be preserved, got %q", got.BranchPrefix.Scope)
+	}
+	if got.BranchPrefix.Separator != "-" {
+		t.Errorf("expected separator '-' to be preserved, got %q", got.BranchPrefix.Separator)
+	}
+	if got.PRTitle.ConventionalCommits == nil || !*got.PRTitle.ConventionalCommits {
+		t.Error("expected conventional_commits=true to be preserved")
 	}
 }
 


### PR DESCRIPTION
Both `sdf init` and `sdf register` (now `sdf fetch`) unconditionally
saved a default config to `.sdf/config.json`, wiping out any
user-customised settings (branch prefix, separator, PR title rules,
etc.). Now the default config is only written when no config file
exists yet, preserving existing configuration.

https://claude.ai/code/session_01P5BZLwacXBVY84KtDWABVc