### PR TITLE
fix: correct spelling of customized in comments

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -125,7 +125,7 @@ func runInitCore(stackName, base, branchFlag string, jsonFlag bool) (string, err
 	}
 
 	// Create default config file only if one doesn't already exist,
-	// so we never overwrite user-customised settings.
+	// so we never overwrite user-customized settings.
 	cfgPath := cfgpkg.RepoPath(root)
 	if _, statErr := os.Stat(cfgPath); os.IsNotExist(statErr) {
 		if err := cfgpkg.Save(cfgPath, cfgpkg.Defaults()); err != nil {

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -76,7 +76,7 @@ func RegisterStack(root, name string, ds stack.DiscoveredStack) error {
 	}
 
 	// Create default config (with inferred prefix) only if one doesn't
-	// already exist, so we never overwrite user-customised settings.
+	// already exist, so we never overwrite user-customized settings.
 	cfgPath := cfgpkg.RepoPath(root)
 	if _, statErr := os.Stat(cfgPath); os.IsNotExist(statErr) {
 		cfg := cfgpkg.Defaults()


### PR DESCRIPTION
## Summary
- Fix misspell lint error: `customised` → `customized` in `cmd/init.go` and `cmd/register.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)