### PR TITLE
fix: pass prompt via stdin in streaming Claude invocations

### DIFF
--- a/cmd/ai_test.go
+++ b/cmd/ai_test.go
@@ -63,10 +63,8 @@ func TestAIIntro_InvokesClaude(t *testing.T) {
 		t.Errorf("expected --allowedTools Read in args")
 	}
 
-	// Verify the prompt contains SDF info
-	if !strings.Contains(args, "SDF") {
-		t.Errorf("expected prompt to mention SDF")
-	}
+	// Prompt content is verified in internal/ai/prompt_test.go.
+	// Here we only check that the CLI flags are correct.
 
 	// Verify output contains status messages
 	if !strings.Contains(output, "Skill created") {

--- a/internal/claude/claude.go
+++ b/internal/claude/claude.go
@@ -77,9 +77,9 @@ func RunPromptStreamingWithOpts(name, prompt string, display io.Writer, opts Pro
 	for _, tool := range opts.AllowedTools {
 		args = append(args, "--allowedTools", tool)
 	}
-	args = append(args, prompt)
 
 	cmd := exec.Command(Binary, args...)
+	cmd.Stdin = strings.NewReader(prompt)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return "", fmt.Errorf("claude %s: %w", name, err)
@@ -137,14 +137,17 @@ func RunPromptStreamingWithOpts(name, prompt string, display io.Writer, opts Pro
 		}
 	}
 
+	recordArgs := make([]string, len(args)+1)
+	copy(recordArgs, args)
+	recordArgs[len(args)] = prompt
 	exitCode := 0
 	if err := cmd.Wait(); err != nil {
 		exitCode = 1
-		recordRun(args, result, exitCode)
+		recordRun(recordArgs, result, exitCode)
 		return result, fmt.Errorf("claude %s: failed", name)
 	}
 
-	recordRun(args, result, exitCode)
+	recordRun(recordArgs, result, exitCode)
 	return strings.TrimSpace(result), nil
 }
 


### PR DESCRIPTION
## Summary

- Pipes the prompt via stdin instead of passing as a trailing CLI argument in `RunPromptStreamingWithOpts`
- Fixes `sdf ai intro` failing with "Input must be provided either through stdin or as a prompt argument when using --print"
- Updates test to not check for prompt content in CLI args (now on stdin); prompt content is tested separately in `internal/ai/prompt_test.go`

## Test plan

- [x] All tests pass
- [x] Linter clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)