### PR TITLE
docs: add render package research, design, and implementation plan

### DIFF
--- a/docs/plans/2026-02-27-advanced-rendering.md
+++ b/docs/plans/2026-02-27-advanced-rendering.md
@@ -1,0 +1,732 @@
+# Designing a JSONL-Driven Terminal Renderer for Parallel Go CLI Tasks
+
+## Executive summary
+
+A robust way to render concurrent task progress “in place” in a terminal is to treat all task updates as an event stream (JSONL/NDJSON) and to centralise *all* terminal writes in a single renderer loop. JSON Lines is explicitly designed for “one record at a time” processing and works well for streaming between cooperating processes and log files. citeturn2search0turn2search5
+
+The recommended architecture is:
+
+- **Workers produce structured events** (`task.start`, `task.progress`, `task.log`, `task.end`, …) instead of printing to the terminal.
+- **A message router** assigns a global sequence, optionally persists every event to a JSONL log, applies backpressure/coalescing for high-rate updates, and forwards state changes to the renderer.
+- **A renderer is the sole writer to the terminal**, updating fixed “task rows” (or blocks) at a controlled refresh cadence using ANSI/VT control sequences such as cursor positioning (CUP) and erasing (EL/ED), optionally inside the alternate screen buffer to avoid polluting scrollback. citeturn10view0turn10view2turn3search3
+
+Key protocol choices:
+
+- Use **newline-delimited JSON** with a versioned envelope and RFC 3339 timestamps; JSON strings must escape control characters U+0000..U+001F, which includes LF (U+000A), making `\n`-delimited framing safe in practice. citeturn2search0turn15view0turn3search1
+- Prefer **renderer-managed layout** (semantic “slots”/regions) over producer-specified absolute coordinates; absolute CUP coordinates are 1-based and fragile under resize/scroll. citeturn10view0turn11view0turn3search3
+- For Unicode alignment, compute display width using a wcwidth-style model; East Asian Width and ambiguous-width handling are key pitfalls, and libraries like `go-runewidth` and terminal frameworks like `tcell` provide pragmatic solutions. citeturn4search0turn4search1turn4search34turn13view0
+
+## Problem framing and design goals
+
+The core requirements imply three separations of concern:
+
+- **Task execution vs. presentation:** tasks run in parallel and may finish out of order; the UI must remain responsive even if tasks are slow or chatty.
+- **Structured stream vs. terminal control:** your JSONL stream should be a faithful record of what happened (suitable for replay/debugging), while the renderer is free to compress/coalesce updates for smooth terminal output.
+- **Terminal UI vs. non-interactive output:** if stdout/stderr is not a terminal, emitting JSONL directly is often preferable to ANSI control sequences; Go provides `IsTerminal` to detect this. citeturn11view0
+
+Two rendering modes are typically useful:
+
+- **Full-screen (alternate screen buffer):** safest positioning model; avoids mixing with shell scrollback; common in TUIs. The xterm family defines `CSI ? 1049 h/l` for entering/leaving the alternate screen buffer. citeturn3search3turn3search11
+- **Inline (“sticky” status region):** preserves scrollback and allows interleaved log lines above a fixed progress area; feasible but requires careful cursor/line insertion handling and is more terminal-dependent.
+
+Because terminal support varies across platforms, especially on Windows, rely on the de facto VT/xterm subset and be explicit about enabling VT processing in the Windows console host (`ENABLE_VIRTUAL_TERMINAL_PROCESSING`). citeturn12view0turn12view1
+
+## Library and tooling landscape comparison
+
+The design you choose depends on whether you want to build a minimal renderer (ANSI sequences + your own diffing) or adopt a TUI framework that already provides buffering, resize handling, input events, and Unicode correctness.
+
+| Library / tool | Language | Rendering model | Strengths | Weaknesses / risks | Suitability for JSONL-driven multi-task progress |
+|---|---:|---|---|---|---|
+| Bubble Tea (framework by entity["company","Charmbracelet","tui tools company"]) | Go | Elm-style TUI loop; supports alt screen and cursor control via commands / options | High-level architecture; built-in terminal control primitives such as entering alt screen and cursor hide/show; good ecosystem for styling and widgets citeturn0search14turn5search4 | Heavier abstraction if you only need “fixed rows”; event ordering and state updates must stay fast (general TUI concern) citeturn5search4 | Strong choice if you want full-screen UI with input handling; JSONL can be your internal event stream feeding the model |
+| tcell | Go | Cell-based screen abstraction; manages Unicode width/combining; simulation screen for tests | Low-level but powerful; explicitly supports wide/combining characters and has a `SimulationScreen` for automated tests citeturn13view0 | You build your own layout/widgets; steeper learning curve than high-level frameworks citeturn13view0 | Excellent if you want deterministic diffing and correctness, and you’re comfortable building a renderer around a screen buffer |
+| gocui | Go | View/window abstraction with a main loop; supports updating via `Gui.Update` | Simple “views” concept; documentation notes layout runs per event; community patterns for updating via `Gui.Update` citeturn1search7turn1search16 | More limited widget ecosystem; less focus on sophisticated diffing/Unicode than tcell-style approaches citeturn1search7turn13view0 | Good for quick multi-pane CLIs; JSONL events can map naturally to “append to view” and “update status view” |
+| termui | Go | Widget/dashboard library (built on termbox-go) | Dashboard-oriented widgets; “takes over your terminal display” model citeturn1search2turn1search6 | Documentation quality varies across versions; termbox lineage implies constraints vs. newer cell engines citeturn1search2turn1search22 | Reasonable if you want dashboards; less ideal for a replayable JSONL event protocol unless you architect it yourself |
+| Rich | Python | Live/progress refresh loop; updates at default refresh rates | Mature progress/live components; default refresh rates documented (Progress ~10 Hz; Live ~4 Hz) citeturn2search2turn2search6 | Python ecosystem; not directly reusable in Go | Useful as a reference point for refresh cadence and UX patterns for progress UIs |
+| Ratatui | Rust | Double buffer + diffing renderer | Explicitly documents using a double-buffer technique that renders diffs for performance citeturn2search15turn2search27 | Rust; different ecosystem | Excellent conceptual reference for implementing your own diff renderer in Go |
+| Ink | Node.js | React renderer; Flexbox via Yoga | Component model; uses Yoga for Flexbox layouts in terminal citeturn5search2turn5search22 | Node.js runtime; React model can be heavyweight | Conceptual reference if you want layout-by-constraints rather than manual coordinates |
+
+image_group{"layout":"carousel","aspect_ratio":"16:9","query":["Bubble Tea TUI example screenshot","tcell Go terminal UI screenshot","Python Rich progress bar screenshot","Ratatui terminal UI demo screenshot"],"num_per_query":1}
+
+## JSONL message schema design for task lifecycles, progress, outputs, and positioning
+
+### Framing and encoding requirements
+
+JSON Lines (newline-delimited JSON) is intended for streaming and logs, and NDJSON additionally specifies `application/x-ndjson` as a media type and recommends `.ndjson` for files. citeturn2search0turn2search5
+
+Framing with `\n` works because JSON strings must escape control characters U+0000..U+001F, which includes line feed; the RFC 8259 string definition explicitly calls out that control characters must be escaped. citeturn15view0turn3search0
+
+Timestamps should use RFC 3339 for interoperability. citeturn3search1
+
+### Schema approach
+
+A practical protocol uses:
+
+- **A stable envelope** with versioning, ordering, identity, and routing metadata.
+- **Typed payloads** per event type.
+- **A positioning model based on semantic regions/slots**, not raw terminal coordinates, with an escape hatch for absolute coordinates where necessary.
+
+Below are two compatible schema variants:
+
+- **Schema A (recommended):** a single envelope with `type` + `data`.
+- **Schema B (high-frequency optimisation):** compact progress messages that omit repeated metadata and rely on prior `task.start` context (useful if you emit thousands of progress events).
+
+#### Schema A: versioned event envelope (recommended)
+
+Field definitions (types are JSON types):
+
+- `v` (number, integer): protocol version, start at `1`.
+- `type` (string): event type, e.g. `task.start`.
+- `ts` (string): RFC 3339 timestamp.
+- `seq` (number, integer): monotonic per-run sequence assigned by the router (global ordering for replay).
+- `run` (object):
+  - `id` (string): run/session id (UUID/ULID/opaque).
+  - `pid` (number, integer, optional): process id if useful.
+- `task` (object, optional):
+  - `id` (string): stable task id.
+  - `name` (string, optional): human name shown in UI.
+  - `seq` (number, integer, optional): monotonic per-task event sequence (dedup/out-of-order handling).
+- `route` (object, optional):
+  - `priority` (string): `low|normal|high` (backpressure decisions).
+  - `channel` (string): `ui|log|stdout|stderr|debug`.
+- `layout` (object, optional): semantic positioning
+  - `region` (string): e.g. `tasks`, `log`, `header`.
+  - `slot` (string, optional): stable renderer-assigned slot id (e.g. `tasks/row/3`).
+  - `row` (number, integer, optional): 0-based row within region.
+  - `col` (number, integer, optional): 0-based col within region.
+- `data` (object): type-specific payload.
+
+Event types and payloads:
+
+- `run.start`: `{ "tool": "...", "args": [...], "capabilities": {...} }`
+- `task.start`: `{ "status": "running", "meta": {...} }`
+- `task.progress`: `{ "fraction": 0.0..1.0, "current": n, "total": n, "unit": "bytes|items|...", "message": "..." }`
+- `task.status`: `{ "status": "running|succeeded|failed|cancelled|skipped", "message": "..." }`
+- `task.log`: `{ "text": "...", "style": {... optional ...} }` (append-only semantics)
+- `task.output`: `{ "stream": "stdout|stderr", "chunk": "...", "encoding": "utf-8|base64", "eof": false }`
+- `task.end`: `{ "status": "...", "duration_ms": n, "result": {... optional ...} }`
+- `task.error`: `{ "message": "...", "kind": "...", "retryable": true/false, "cause": {... optional ...} }`
+- `layout.assign`: `{ "task_id": "...", "region": "tasks", "slot": "tasks/row/3" }` (renderer → producers, optional)
+- `renderer.notice`: `{ "dropped": n, "reason": "backpressure", "scope": "task|global" }` (diagnostics)
+
+**Examples (one JSON object per line):**
+
+```json
+{"v":1,"type":"run.start","ts":"2026-02-24T11:00:00.000Z","seq":1,"run":{"id":"01HT..."},"route":{"channel":"ui","priority":"high"},"data":{"tool":"mycli","args":["sync"],"capabilities":{"alt_screen":true,"unicode":true}}}
+{"v":1,"type":"task.start","ts":"2026-02-24T11:00:00.120Z","seq":2,"run":{"id":"01HT..."},"task":{"id":"t1","name":"Download index","seq":1},"route":{"channel":"ui","priority":"high"},"data":{"status":"running"}}
+{"v":1,"type":"task.progress","ts":"2026-02-24T11:00:01.050Z","seq":9,"run":{"id":"01HT..."},"task":{"id":"t1","seq":7},"route":{"channel":"ui","priority":"low"},"data":{"fraction":0.42,"current":420,"total":1000,"unit":"items","message":"Fetching…"}}
+{"v":1,"type":"task.log","ts":"2026-02-24T11:00:01.200Z","seq":10,"run":{"id":"01HT..."},"task":{"id":"t1","seq":8},"route":{"channel":"log","priority":"normal"},"data":{"text":"Resolved 18 endpoints"}}
+{"v":1,"type":"task.end","ts":"2026-02-24T11:00:03.940Z","seq":21,"run":{"id":"01HT..."},"task":{"id":"t1","seq":15},"route":{"channel":"ui","priority":"high"},"data":{"status":"succeeded","duration_ms":3820}}
+```
+
+#### Schema B: compact progress frames (optional)
+
+For high-frequency progress (e.g. 50–200 Hz from many tasks), a compact record can reduce overhead:
+
+- `p` (string): task id
+- `s` (number): per-task seq
+- `t` (string): RFC3339 timestamp (or omitted if router adds)
+- `f` (number): fraction
+- `m` (string): message
+
+Example:
+
+```json
+{"v":1,"type":"task.p","p":"t1","s":91,"t":"2026-02-24T11:00:01.050Z","f":0.42,"m":"Fetching…"}
+```
+
+The router can normalise this into Schema A for persistence/replay.
+
+### Ordering, deduplication, and backpressure semantics
+
+A JSONL stream across goroutines/processes is inherently concurrent: messages can arrive out of order relative to wall-clock time. A pragmatic approach is:
+
+- **Global ordering for replay:** assign `seq` centrally when the router accepts an event.
+- **Per-task ordering for state:** maintain `task.seq` and ignore stale updates (if `seq <= lastSeq` for that task).
+- **Backpressure policy:** treat progress as “latest wins” and allow coalescing/dropping under load, but never drop lifecycle edges (`task.start`, terminal `task.end`, `task.error`) or log/output records unless explicitly configured; if drops happen, emit `renderer.notice` counters for observability.
+
+This design keeps rendering smooth without losing semantic correctness.
+
+## Terminal layout and coordinate model
+
+### Terminal coordinate primitives
+
+If you implement a renderer directly on ANSI/VT control sequences, your coordinate baseline should reflect standards:
+
+- **CUP (Cursor Position)** in ECMA-48 moves the active presentation position to line `Pn1` and column `Pn2`, with default values 1; in practice this corresponds to the familiar `CSI row;col H` 1-based model. citeturn10view0
+- **EL (Erase in Line)** and **ED (Erase in Page/Display)** define the standard “clear” operations used to avoid leaving artefacts when lines shrink. citeturn10view1turn10view2
+- **IL/DL (Insert/Delete Line)** exist for in-terminal scrolling region manipulations and can support inline “sticky footer” UIs, but behaviour varies across consoles/emulators, and on Windows the console host documents equivalents for IL/DL/ED/EL in its VT sequence support. citeturn10view3turn10view4turn12view1
+
+On Windows, these sequences are processed only if VT mode is enabled via `SetConsoleMode` with `ENABLE_VIRTUAL_TERMINAL_PROCESSING`. citeturn12view0turn12view1
+
+### Renderer-managed regions and slots
+
+For “fixed positions”, avoid letting tasks dictate absolute terminal rows/cols. Instead:
+
+- Define a small set of **regions**: `header`, `tasks`, `log`, `footer`.
+- The renderer assigns each task a **slot** (typically one row in `tasks` or a small block for multi-line tasks).
+- Tasks reference their slot by id (`layout.slot`) or simply by `task.id` and let the renderer map `task.id → slot`.
+
+This makes resizing and reflow tractable because the renderer can recompute region geometry when terminal dimensions change.
+
+Terminal dimensions can be queried via `golang.org/x/term.GetSize`, which returns the visible width/height and explicitly excludes scrollback. citeturn11view0
+
+### Resizing and scrolling strategies
+
+A cross-platform strategy tends to combine:
+
+- **Resize detection:** on Unix-like systems, terminal emulators commonly notify running programs on resize (e.g. via `SIGWINCH`), and terminal tools such as xterm mention this behaviour. citeturn3search19  
+  In Go, you can also periodically re-check `term.GetSize` and treat changes as resize events. citeturn11view0
+- **Full-screen (recommended for fixed blocks):** use alternate screen buffer, render your own scrolling log pane inside the UI (ring buffer). The xterm control sequence documentation describes mode `1049` as “save cursor and use alternate screen buffer”. citeturn3search3turn3search11
+- **Inline mode (more complex):** keep a footer of N lines reserved for tasks; print log lines above it using IL (insert line) and careful cursor restoration. ECMA-48 defines IL/DL; Windows VT docs also define IL/DL semantics with scrolling margins caveats. citeturn10view4turn10view3turn12view1
+
+In practice, full-screen mode is easier to make correct across terminal types because *you own the whole viewport* while active.
+
+## Rendering engine design
+
+### Double-buffering and diffing model
+
+To reduce flicker and unnecessary output, a proven approach is **double-buffering**:
+
+1. Build a “desired frame” buffer from current task states and layout.
+2. Diff it against the previous frame.
+3. Emit only the changes.
+
+Ratatui explicitly notes that it uses a “double buffer technique that only renders diffs,” and this is a strong conceptual template for a Go renderer even if you don’t use Rust. citeturn2search15
+
+If you want a Go-native abstraction, `tcell` already provides a cell-based screen view and includes mechanisms like dirty tracking and test simulation; it also emphasises Unicode correctness (wide and combining characters). citeturn13view0
+
+### ANSI/VT sequences you will typically need
+
+A minimal diff renderer generally relies on:
+
+- `CUP` to move the cursor to a line/column. citeturn10view0turn12view1
+- `EL` to clear the remainder (or all) of a line when overwriting shorter content. citeturn10view2turn12view1
+- `ED` to clear the screen on full redraw / resize. citeturn10view1turn12view1
+- Cursor visibility (`CSI ? 25 l/h`) to hide cursor during rendering; the Windows console VT docs document the DECTCEM show/hide sequences and associate them with cursor visibility control. citeturn12view1turn4search3
+- Optional alternate screen enter/exit (`CSI ? 1049 h/l`). citeturn3search3turn3search11
+
+### Handling UTF-8 and variable-width characters
+
+Terminals measure width in *cells*, not bytes:
+
+- Unicode’s East Asian Width property formalises inherent character width categories used in many terminal-width calculations. citeturn4search0
+- POSIX `wcwidth` defines the idea of “number of column positions” required for a wide character, returning 0/1/2 (or -1 for non-printable). citeturn4search1turn4search29
+- In Go, `github.com/mattn/go-runewidth` provides `StringWidth` and locale-aware “East Asian” handling; its docs also expose ambiguous-width behaviours. citeturn4search34turn4search2turn4search18
+- `tcell` goes further: its `Put()` API takes a UTF-8 string, renders the first grapheme cluster, and returns the width displayed; it also warns about undefined behaviour if you overwrite adjacent cells incorrectly next to wide characters. citeturn13view0
+
+A rigorous renderer therefore needs:
+
+- A **cell-width truncation** function (truncate to N cells without splitting grapheme clusters where possible).
+- **Padding** to clear remnants when a line shrinks.
+- A policy for **ambiguous-width characters** (treat as 1 by default; optionally honour locale preferences).
+
+### Go code snippets
+
+#### JSONL event structs and encoder
+
+```go
+package ui
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"time"
+)
+
+type Event struct {
+	V     int       `json:"v"`
+	Type  string    `json:"type"`
+	TS    time.Time `json:"ts"`
+	Seq   uint64    `json:"seq"`
+	Run   RunRef    `json:"run"`
+	Task  *TaskRef  `json:"task,omitempty"`
+	Route *Route    `json:"route,omitempty"`
+	Layout *Layout  `json:"layout,omitempty"`
+	Data  any       `json:"data,omitempty"`
+}
+
+type RunRef struct {
+	ID  string `json:"id"`
+	PID int    `json:"pid,omitempty"`
+}
+
+type TaskRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
+	Seq  uint64 `json:"seq,omitempty"` // per-task ordering
+}
+
+type Route struct {
+	Channel  string `json:"channel,omitempty"`  // ui|log|stdout|stderr|debug
+	Priority string `json:"priority,omitempty"` // low|normal|high
+}
+
+type Layout struct {
+	Region string `json:"region,omitempty"` // tasks|log|header|footer
+	Slot   string `json:"slot,omitempty"`   // renderer-assigned slot id
+	Row    int    `json:"row,omitempty"`    // 0-based within region
+	Col    int    `json:"col,omitempty"`    // 0-based within region
+}
+
+// NewJSONLEncoder returns an encoder suitable for JSONL.
+// encoding/json.Encoder.Encode appends a newline automatically. (See docs.)
+func NewJSONLEncoder(w io.Writer) *json.Encoder {
+	bw := bufio.NewWriterSize(w, 64*1024)
+	enc := json.NewEncoder(bw)
+	enc.SetEscapeHTML(false)
+	// Caller should Flush bw on shutdown by wrapping w or returning both.
+	return enc
+}
+```
+
+Go’s `encoding/json.Encoder.Encode` explicitly writes a JSON value followed by a newline character, which makes it a natural fit for JSONL output, and `SetEscapeHTML(false)` disables the default escape of HTML-sensitive characters for readability. citeturn18search1turn19view0
+
+#### Terminal control helpers (ANSI/VT)
+
+```go
+package termui
+
+import (
+	"fmt"
+	"io"
+)
+
+const esc = "\x1b"
+
+// Cup moves the cursor to 1-based (row, col): CSI row;col H.
+func Cup(row, col int) string { return fmt.Sprintf("%s[%d;%dH", esc, row, col) }
+
+// El2 clears the entire current line: CSI 2 K.
+func El2() string { return esc + "[2K" }
+
+// Ed2 clears the entire screen (viewport): CSI 2 J.
+func Ed2() string { return esc + "[2J" }
+
+// HideCursor / ShowCursor use DECTCEM (commonly supported).
+func HideCursor() string { return esc + "[?25l" }
+func ShowCursor() string { return esc + "[?25h" }
+
+// Alt screen (xterm family).
+func EnterAltScreen() string { return esc + "[?1049h" }
+func ExitAltScreen() string  { return esc + "[?1049l" }
+
+func WriteSeq(w io.Writer, s string) error {
+	_, err := io.WriteString(w, s)
+	return err
+}
+```
+
+The underlying semantics of CUP/EL/ED are defined in standards (ECMA-48) and widely implemented subsets (Linux console and Windows VT mode). citeturn10view0turn10view1turn10view2turn0search7turn12view1  
+Alternate-screen mode `1049` is a documented xterm control sequence and is widely adopted in terminal emulators. citeturn3search3turn3search11  
+Cursor show/hide is documented under DECTCEM in the Windows console VT sequence guide. citeturn12view1
+
+#### Renderer loop with diff-by-line updates
+
+This is an intentionally minimal “line buffer” renderer (suitable when each task maps to one line). A production renderer typically adds styles, multi-line blocks, and log panes.
+
+```go
+package render
+
+import (
+	"context"
+	"io"
+	"strings"
+	"time"
+
+	"golang.org/x/term"
+
+	"github.com/mattn/go-runewidth"
+
+	"example.com/mycli/termui"
+)
+
+type Frame struct {
+	Lines []string // already laid out, one string per terminal row (0-based)
+}
+
+type Renderer struct {
+	Out io.Writer
+
+	prev Frame
+	width, height int
+
+	// If true, use alternate screen buffer.
+	AltScreen bool
+}
+
+func (r *Renderer) Init(ctx context.Context) error {
+	if r.AltScreen {
+		_ = termui.WriteSeq(r.Out, termui.EnterAltScreen())
+	}
+	_ = termui.WriteSeq(r.Out, termui.HideCursor())
+	_ = termui.WriteSeq(r.Out, termui.Ed2()+termui.Cup(1, 1))
+	return r.refreshSize()
+}
+
+func (r *Renderer) Close() {
+	_ = termui.WriteSeq(r.Out, termui.ShowCursor())
+	if r.AltScreen {
+		_ = termui.WriteSeq(r.Out, termui.ExitAltScreen())
+	}
+}
+
+func (r *Renderer) refreshSize() error {
+	w, h, err := term.GetSize(int(getFD(r.Out)))
+	if err != nil {
+		return err
+	}
+	r.width, r.height = w, h
+	return nil
+}
+
+// Flush diffs the new frame against the previous and updates changed lines.
+func (r *Renderer) Flush(next Frame) error {
+	// Ensure we only render within current terminal height.
+	maxLines := min(r.height, len(next.Lines))
+	for i := 0; i < maxLines; i++ {
+		if i < len(r.prev.Lines) && r.prev.Lines[i] == next.Lines[i] {
+			continue
+		}
+		line := fitToWidth(next.Lines[i], r.width)
+		row := i + 1 // CUP is 1-based
+		if err := termui.WriteSeq(r.Out, termui.Cup(row, 1)+termui.El2()+line); err != nil {
+			return err
+		}
+	}
+
+	r.prev = next
+	return nil
+}
+
+func fitToWidth(s string, w int) string {
+	if w <= 0 {
+		return ""
+	}
+	// Replace tabs defensively; tabs are terminal-dependent width.
+	s = strings.ReplaceAll(s, "\t", "    ")
+
+	if runewidth.StringWidth(s) <= w {
+		// Pad with spaces so shrinking lines don't leave remnants (also cleared by EL2).
+		return s
+	}
+	// Truncate to w cells:
+	var b strings.Builder
+	b.Grow(len(s))
+	width := 0
+	for _, r := range s {
+		cw := runewidth.RuneWidth(r)
+		if width+cw > w {
+			break
+		}
+		b.WriteRune(r)
+		width += cw
+	}
+	return b.String()
+}
+
+func min(a, b int) int { if a < b { return a }; return b }
+
+// getFD is left as an exercise: in practice you should track the fd explicitly
+// (e.g., os.Stdout.Fd()).
+func getFD(_ io.Writer) uintptr { return 1 }
+```
+
+This snippet relies on (a) CUP being 1-based and (b) line clearing via EL to prevent residue; those behaviours are standardised in ECMA-48 and widely documented by platform VT sequence references. citeturn10view0turn10view2turn12view1  
+The width-fitting logic uses wcwidth-style concepts; Unicode width modelling and ambiguous-width edge cases are well known, and `go-runewidth` exposes locale-sensitive checks that can affect alignment. citeturn4search0turn4search1turn4search34turn4search18  
+Terminal dimension querying uses `term.GetSize`. citeturn11view0
+
+## Go concurrency and synchronisation architecture
+
+### Recommended component model
+
+A concurrency architecture that scales and stays debuggable is:
+
+- A bounded **worker pool** (or `errgroup` fan-out) that runs tasks concurrently.
+- A per-task **Reporter** that emits events into a central **router** channel.
+- A **router** that assigns global `seq`, persists events to JSONL, and forwards them to the renderer after applying coalescing/backpressure policies.
+- A **renderer loop** that rebuilds a frame at a fixed cadence and diffs to the terminal.
+
+Go’s concurrency primitives naturally support pipelines and cancellation patterns; the Go blog’s “Pipelines and cancellation” article is a canonical reference for building streaming pipelines with clean failure handling. citeturn3search2  
+For structured cancellation, `context.WithCancel` derives a context whose Done channel closes when cancelled (or parent is cancelled). citeturn16search0  
+For parallel subtasks with error propagation and shared cancellation, `errgroup` is designed specifically for “groups of goroutines working on subtasks of a common task”. citeturn16search1turn16search5
+
+### Mermaid architecture diagram
+
+```mermaid
+flowchart LR
+  subgraph Exec[Task execution]
+    T1[Task goroutine 1]
+    T2[Task goroutine 2]
+    TN[Task goroutine N]
+  end
+
+  subgraph Bus[Event bus & routing]
+    RPT[Per-task Reporter]
+    Q[(Bounded channel)]
+    RT[Router\n- assign global seq\n- dedupe/coalesce\n- persistence]
+  end
+
+  subgraph UI[Presentation]
+    REN[Renderer\n- state store\n- layout\n- diff flush]
+    TERM[(Terminal)]
+  end
+
+  subgraph Persist[Observability]
+    LOG[(JSONL log file)]
+  end
+
+  T1 --> RPT
+  T2 --> RPT
+  TN --> RPT
+  RPT --> Q --> RT
+  RT --> REN --> TERM
+  RT --> LOG
+```
+
+### Message routing, backpressure, and deduplication tactics
+
+To keep the UI responsive under load:
+
+- **Single writer rule:** only the renderer writes to the terminal output stream. Worker goroutines must never write escape sequences, otherwise output interleaves and breaks cursor positioning.
+- **Separate high-rate vs. low-rate events:** progress updates should be coalesced (“latest wins”), while task lifecycle edges and logs should be preserved.
+- **Per-task seq for correctness:** if you accept out-of-order arrival, store `lastTaskSeq[taskID]`, ignoring older events.
+- **Explicit backpressure policy:** when the bus is full:
+  - drop/coalesce `task.progress`,
+  - block (or apply a larger buffer) for `task.log`, `task.output`, `task.end`,
+  - and emit `renderer.notice` counters so drops are visible rather than silent.
+
+### Synchronisation between renderer and workers
+
+Two common patterns for safe synchronisation:
+
+- **Channel-confinement:** all state mutation for rendering happens in the renderer goroutine; workers send immutable events. This naturally avoids locks in the hot rendering path.
+- **Atomic snapshot + tick:** workers update atomic “latest progress” values; renderer reads snapshots on a ticker. This reduces contention further but complicates replay/persistence because you need to decide which atomic transitions become durable events.
+
+A hybrid is often best: channel events for lifecycle/log/output (durable), and optional atomic fast-path for progress (ephemeral), with periodic “progress snapshots” emitted by the router into the JSONL log.
+
+### Go code snippet: worker pool + reporter
+
+```go
+package runner
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"example.com/mycli/ui"
+)
+
+type TaskFunc func(ctx context.Context, r *Reporter) error
+
+type TaskSpec struct {
+	ID   string
+	Name string
+	Fn   TaskFunc
+}
+
+type Reporter struct {
+	runID   string
+	taskID  string
+	taskSeq uint64
+
+	out chan<- ui.Event
+}
+
+func (r *Reporter) nextSeq() uint64 { return atomic.AddUint64(&r.taskSeq, 1) }
+
+func (r *Reporter) Start(name string) {
+	r.out <- ui.Event{
+		V:    1,
+		Type: "task.start",
+		TS:   time.Now().UTC(),
+		Run:  ui.RunRef{ID: r.runID},
+		Task: &ui.TaskRef{ID: r.taskID, Name: name, Seq: r.nextSeq()},
+		Route: &ui.Route{Channel: "ui", Priority: "high"},
+		Data: map[string]any{"status": "running"},
+	}
+}
+
+func (r *Reporter) Progress(fraction float64, msg string) {
+	// Non-blocking send: progress is "latest wins".
+	ev := ui.Event{
+		V:    1,
+		Type: "task.progress",
+		TS:   time.Now().UTC(),
+		Run:  ui.RunRef{ID: r.runID},
+		Task: &ui.TaskRef{ID: r.taskID, Seq: r.nextSeq()},
+		Route: &ui.Route{Channel: "ui", Priority: "low"},
+		Data: map[string]any{"fraction": fraction, "message": msg},
+	}
+	select {
+	case r.out <- ev:
+	default:
+		// dropped under backpressure; router may count drops
+	}
+}
+
+func (r *Reporter) LogLine(text string) {
+	// Blocking (or context-aware) send is usually acceptable for logs.
+	r.out <- ui.Event{
+		V:    1,
+		Type: "task.log",
+		TS:   time.Now().UTC(),
+		Run:  ui.RunRef{ID: r.runID},
+		Task: &ui.TaskRef{ID: r.taskID, Seq: r.nextSeq()},
+		Route: &ui.Route{Channel: "log", Priority: "normal"},
+		Data: map[string]any{"text": text},
+	}
+}
+
+func (r *Reporter) End(status string, errMsg string) {
+	data := map[string]any{"status": status}
+	if errMsg != "" {
+		data["message"] = errMsg
+	}
+	r.out <- ui.Event{
+		V:    1,
+		Type: "task.end",
+		TS:   time.Now().UTC(),
+		Run:  ui.RunRef{ID: r.runID},
+		Task: &ui.TaskRef{ID: r.taskID, Seq: r.nextSeq()},
+		Route: &ui.Route{Channel: "ui", Priority: "high"},
+		Data: data,
+	}
+}
+
+func Run(ctx context.Context, runID string, tasks []TaskSpec, maxParallel int, out chan<- ui.Event) error {
+	g, ctx := errgroup.WithContext(ctx)
+	sem := make(chan struct{}, maxParallel)
+
+	for _, t := range tasks {
+		t := t
+		g.Go(func() error {
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			defer func() { <-sem }()
+
+			rep := &Reporter{runID: runID, taskID: t.ID, out: out}
+			rep.Start(t.Name)
+
+			err := t.Fn(ctx, rep)
+			if err != nil {
+				rep.End("failed", err.Error())
+				return err
+			}
+			rep.End("succeeded", "")
+			return nil
+		})
+	}
+	return g.Wait()
+}
+```
+
+This uses `errgroup.WithContext` to couple cancellation and error propagation across concurrent tasks. citeturn16search1turn16search0
+
+### Mermaid message lifecycle flowchart
+
+```mermaid
+stateDiagram-v2
+  [*] --> Created: (task known / scheduled)
+  Created --> Running: task.start
+  Running --> Running: task.progress
+  Running --> Running: task.status
+  Running --> Running: task.log / task.output
+  Running --> Succeeded: task.end{status=succeeded}
+  Running --> Failed: task.error\nor task.end{status=failed}
+  Running --> Cancelled: task.end{status=cancelled}
+  Succeeded --> [*]
+  Failed --> [*]
+  Cancelled --> [*]
+```
+
+## Observability, resilience, performance, and testing
+
+### Persistence and replay of the JSONL stream
+
+A durable JSONL stream is valuable for:
+
+- debugging (replay a run and reproduce UI states),
+- post-run analysis (task durations, failure rates),
+- integration with external tooling.
+
+Implementation recommendations:
+
+- Persist the *router-normalised* event stream to a file (or stdout in non-TTY mode).
+- Use `encoding/json.Encoder` to emit one JSON value per line; it terminates each encoded value with a newline character, matching JSONL expectations. citeturn18search1turn2search0
+- Set `SetEscapeHTML(false)` to avoid escaping `<`, `>`, `&` unless you explicitly need HTML embedding safety. citeturn19view0
+- Wrap the file writer in `bufio.Writer` to reduce syscall overhead, but remember to flush at shutdown; `bufio` is explicitly designed to provide buffering for textual I/O. citeturn16search24turn16search20
+- Consider emitting a `run.start` header and `run.end` footer record to bound each session for downstream readers.
+
+### Error handling and recovery strategies
+
+A terminal renderer should treat “restore the terminal state” as a first-class reliability feature:
+
+- Always restore cursor visibility and exit alternate screen on shutdown, even on panic. Cursor visibility control is explicitly documented in VT sequence references. citeturn12view1turn3search3
+- If you use raw mode (for interactive input), capture the old terminal state and restore it on exit; `x/term.MakeRaw` and `Restore` exist for this purpose. citeturn11view0
+- Emit `task.error` or `task.end{status=failed}` consistently; avoid “silent failures” that only appear in stderr text, because structured events are what enables reliable concurrent rendering.
+
+Router-level robustness patterns:
+
+- If a worker panics, recover at the task boundary and emit `task.error` with a synthesised message; then propagate cancellation (via context) so the system approaches a consistent stopped state. Context cancellation semantics (Done channel closure) are the standard mechanism to signal shutdown across goroutines. citeturn16search0turn3search2
+
+### Performance considerations and benchmark targets
+
+Refresh cadence needs to balance smoothness with overhead:
+
+- Rich refreshes progress displays at **10 updates/second by default**, and live displays at **4 updates/second by default**, which are useful empirical baselines for “good enough” interactive output without saturating the terminal. citeturn2search2turn2search6
+- Diffing/double-buffering is the main lever to keep bandwidth low; Ratatui specifically calls out diffing to keep rendering fast. citeturn2search15
+
+Practical benchmark goals (recommended starting points, to be validated in your environment):
+
+- **Input-to-render latency:** aim for <100 ms perceived latency for UI updates; in practice, a 10–20 Hz render loop (50–100 ms tick) is often adequate for progress UIs, while 30 Hz gives a “snappier” feel at higher CPU/IO cost.
+- **Terminal write volume:** minimise total bytes written per frame; rewriting only changed lines and using EL to clear reduces bandwidth compared with full redraw.
+- **Router ingestion throughput:** sustain at least tens of thousands of events/minute without unbounded memory growth by coalescing progress updates and bounding channel buffers.
+
+What to benchmark:
+
+- Event ingestion rate (events/sec) into the router under load.
+- Renderer frame build time (ms) and flush time (ms).
+- Bytes written per second to the terminal in typical and worst cases.
+- Behaviour under resize storms and under “log spam”.
+
+### Testing strategies and edge cases
+
+A thorough test plan should combine state-level unit tests with end-to-end terminal simulations:
+
+- **Unit tests** (pure Go):  
+  - event ordering/dedup (per-task seq monotonicity),
+  - coalescing correctness (latest progress wins),
+  - layout reflow (stable slot assignment on resize),
+  - truncation/padding behaviour with wide/combining characters (ensure no leftover glyphs).
+
+- **Simulation-based tests:**  
+  `tcell` provides a `SimulationScreen` that supports event delivery and resizing and allows inspection of “physical” screen contents, enabling deterministic rendering tests without a real terminal. citeturn13view0
+
+- **End-to-end tests on a pseudo-terminal (pty):**  
+  run the renderer against a pty, trigger resizes, inject high-rate events, and assert no corrupted output (e.g. stray escape sequences, broken UTF-8).
+
+Edge cases to design for explicitly:
+
+- **Terminal resize during redraw:** ensure you detect size change and force a full redraw (clear + re-render) to avoid artefact accumulation.
+- **Lost progress events (intentional drops):** ensure lifecycle edges are not dropped; surface drops via counters (`renderer.notice`) so operators can tune buffers.
+- **Very long task names / messages:** truncation by cell width; avoid splitting multi-rune graphemes where you can (or accept a documented limitation).
+- **High-volume logs:** keep log display bounded (ring buffer) while persisting full logs to JSONL.
+- **Slow tasks and “quiet” periods:** render loop should not busy-wait; drive by tick or by “dirty” signals to avoid CPU burn.
+
+### Key primary references
+
+- Terminal control sequences and alternate screen buffer documentation: citeturn3search3turn3search11  
+- ECMA-48 definitions of CUP/ED/EL/IL/DL: citeturn10view0turn10view1turn10view2turn10view3turn10view4  
+- Windows console VT processing and cursor visibility: citeturn12view1turn12view0  
+- JSON string escaping rules (control characters): citeturn15view0  
+- JSON Lines / NDJSON framing: citeturn2search0turn2search5  
+- Go terminal sizing/raw mode: citeturn11view0  
+- Go concurrency primitives and cancellation patterns: citeturn3search2turn16search0turn16search1  
+- Unicode width modelling: citeturn4search0turn4search1turn4search34

--- a/docs/plans/2026-02-27-render-package-design.md
+++ b/docs/plans/2026-02-27-render-package-design.md
@@ -1,0 +1,406 @@
+# Design: `internal/render` Package
+
+Date: 2026-02-27
+Status: Approved
+Inputs: `2026-02-27-advanced-rendering.md`, `2026-02-27-rendering-alignment-analysis.md`, `2026-02-20-terminal-ui-design.md`
+
+## Overview
+
+A rendering and orchestration package for parallel CLI task execution. Commands define tasks, the bus runs them, and a pluggable renderer presents progress to the user.
+
+**Key principle:** JSONL is a serialization format for persistence and external output. In-process communication uses typed Go structs over channels.
+
+```
+                          In-process (Go structs over channels)
+                         ┌──────────────────────────────────────────────┐
+                         │                                              │
+  goroutine 1 ─→ Reporter ─→ chan Event ─→ Router ─→ Renderer ─→ terminal
+  goroutine 2 ─→ Reporter ─┘               │
+  goroutine N ─→ Reporter ─┘               │
+                                            │  side-effect (serialization)
+                                            └─→ json.Encoder ─→ .sdf/logs/*.jsonl
+```
+
+## Core Types
+
+### Event
+
+The unit of communication on the bus. A Go struct, never serialized in-process.
+
+```go
+type Event struct {
+    Type   string    // "task.start", "task.log", "task.end"
+    TS     time.Time
+    Seq    uint64    // global sequence, assigned by router
+    TaskID string
+    Data   any       // type-specific payload
+}
+```
+
+Event types:
+
+| Type | Data | Semantics |
+|---|---|---|
+| `task.start` | `{name: string}` | Task is running, renderer allocates a slot |
+| `task.log` | `{text: string}` | Status update — overwrites previous log in the slot |
+| `task.end` | `{status: string, message: string}` | Terminal state — slot shows final result |
+
+`task.progress` (fractional) is not needed initially. No sdf command has fractional progress. Can be added later without breaking changes.
+
+### Reporter
+
+Per-task handle. Commands call its methods instead of `fmt.Printf`. Wraps a `chan<- Event` with convenience methods.
+
+```go
+type Reporter struct {
+    bus     *Bus
+    taskID  string
+    taskSeq atomic.Uint64
+}
+
+func (r *Reporter) Start(name string)              // sends task.start
+func (r *Reporter) Log(text string)                 // sends task.log (overwrites previous)
+func (r *Reporter) End(status string, msg string)   // sends task.end
+func (r *Reporter) Pause()                          // tells renderer to clear progress area
+func (r *Reporter) Resume()                         // tells renderer to re-take terminal
+```
+
+Each `r.Log()` call replaces the slot's current status text. The renderer picks up the change on the next tick. Multiple `r.Log()` calls within a tick — only the last one is displayed.
+
+### TaskSpec
+
+Defines a unit of work for the bus.
+
+```go
+type TaskSpec struct {
+    ID   string
+    Name string
+    Fn   func(ctx context.Context, r *Reporter) error
+}
+```
+
+### Renderer Interface
+
+Pluggable output. Swapped based on `--json` flag / TTY detection.
+
+```go
+type Renderer interface {
+    Init(taskCount int)      // allocate slots
+    HandleEvent(Event)       // process an event
+    Flush()                  // called on tick (TTY) or no-op (JSON)
+    Pause()                  // clear progress area for interactive prompts
+    Resume()                 // re-take terminal control
+    Finish()                 // final cleanup
+}
+```
+
+## Bus
+
+The single entry point for commands. One bus per command invocation.
+
+```go
+type Bus struct {
+    renderer Renderer
+    logFile  *LogWriter     // JSONL persistence (always on)
+    seq      atomic.Uint64  // global sequence counter
+    events   chan Event      // bounded channel
+    tasks    []TaskSpec      // registered tasks
+}
+
+func NewBus(w io.Writer, opts Options) *Bus
+func (b *Bus) AddTask(task TaskSpec)
+func (b *Bus) Run(ctx context.Context, task TaskSpec) error     // single task, sequential
+func (b *Bus) RunBatch(ctx context.Context) error               // all added tasks, parallel
+func (b *Bus) Finish() error                                    // flush logs, finalize renderer
+```
+
+**`Run()`** — executes one task. Creates a Reporter, calls the task function, waits for completion. Used for sequential phases where order matters (e.g., rebase steps in sync).
+
+**`RunBatch()`** — launches all added tasks via `errgroup`, each with its own Reporter. The renderer displays results in insertion order. Used for parallel phases (e.g., PR content updates).
+
+**Router** — internal to the bus. A goroutine that reads from the `events` channel, assigns global `seq`, tees to the JSONL log writer, and forwards to the renderer via `HandleEvent()`. Commands never interact with the router directly.
+
+### Command Ownership
+
+The bus does not own the command flow. The command calls `Run()` and `RunBatch()` as needed, interleaving its own logic between calls:
+
+```go
+func RunSync(...) error {
+    // Sequential logic — no bus needed
+    git.FetchAll()
+    plan := computeSyncPlan(...)
+    if !ui.Confirm("Proceed?") { return nil }
+
+    bus := render.NewBus(os.Stdout, render.Options{LogDir: root + "/.sdf/logs"})
+
+    // Sequential rebase steps (future — use Run())
+    for _, step := range plan {
+        bus.Run(ctx, render.TaskSpec{
+            Name: fmt.Sprintf("rebase %s", step.Branch),
+            Fn: func(ctx context.Context, r *render.Reporter) error {
+                r.Log("rebasing...")
+                if err := git.RebaseOnto(...); err != nil {
+                    r.Pause()
+                    choice := ui.Select(...)  // huh prompt
+                    r.Resume()
+                    // handle choice...
+                }
+                return git.Push(...)
+            },
+        })
+    }
+
+    // Parallel PR content updates (first adoption target)
+    for _, j := range jobs {
+        bus.AddTask(render.TaskSpec{
+            Name: fmt.Sprintf("PR %s", ui.PR(j.node.PR)),
+            Fn: func(ctx context.Context, r *render.Reporter) error {
+                r.Log("updating title...")
+                // ... title logic ...
+                r.Log("generating description...")
+                // ... description logic ...
+                r.End("succeeded", "updated (title + description)")
+                return nil
+            },
+        })
+    }
+    bus.RunBatch(ctx)
+
+    return bus.Finish()
+}
+```
+
+## Renderers
+
+### TTYRenderer
+
+Two modes depending on how the bus is used:
+
+#### Batch Mode (`RunBatch`)
+
+Multi-line in-place block. Each task owns a persistent line that updates in place:
+
+```
+  PR #56: updating title...          ← slot 0, updates in-place
+  PR #57: reading commit content...  ← slot 1, updates in-place
+  PR #58: waiting...                 ← slot 2, updates in-place
+
+  ⠋ Updating PR content (0/3)       ← spinner, animates on tick
+```
+
+As tasks complete, their slots show final state:
+
+```
+  PR #56: ✓ unchanged                ← slot 0, done
+  PR #57: writing description...     ← slot 1, still updating
+  PR #58: ✓ updated (title)          ← slot 2, done
+
+  ⠋ Updating PR content (2/3)
+```
+
+All done:
+
+```
+  PR #56: ✓ unchanged
+  PR #57: ✓ updated (description)
+  PR #58: ✓ updated (title)
+
+  Updated content for 2/3 PRs.
+```
+
+Implementation:
+
+```go
+type TTYRenderer struct {
+    w        io.Writer
+    slots    []Slot
+    startRow int          // terminal row where block starts
+    spinner  int          // current spinner frame
+    ticker   *time.Ticker // 10 Hz render loop
+}
+
+type Slot struct {
+    Label  string // "PR #57"
+    Status string // current status, overwritten by task.log
+    Done   bool   // true after task.end
+    Final  string // final result line
+}
+```
+
+On each tick (100ms):
+1. For each slot: CUP to `startRow + i`, EL to clear, write `label: status`
+2. Move to spinner row, write spinner frame + completion counter
+3. ~10-20 lines of ANSI writes per frame — negligible cost
+
+Event handling:
+- `task.start` → allocate slot, set initial status
+- `task.log` → `slot.Status = text` (picked up on next tick)
+- `task.end` → `slot.Done = true`, `slot.Final = formatted result line`
+
+Pause/Resume:
+- `Pause()` → stop ticker, move cursor below block
+- `Resume()` → re-render all slots, restart ticker
+
+#### Sequential Mode (`Run`)
+
+Append-only, no cursor movement. Same as today's behavior:
+- `task.log` → prints a line
+- `task.end` → prints the final result line
+
+No block, no spinner. Used for sequential phases where tasks execute one at a time.
+
+### JSONRenderer
+
+Silently collects task outcomes. No terminal output.
+
+```go
+type JSONRenderer struct {
+    results []TaskResult
+}
+
+type TaskResult struct {
+    TaskID  string
+    Status  string
+    Message string
+    Data    any
+}
+
+func (r *JSONRenderer) Results() []TaskResult
+```
+
+- `HandleEvent` accumulates `task.end` events into `results`
+- All other events silently consumed
+- `Pause`/`Resume` are no-ops (no interactive prompts in JSON mode)
+- `Finish()` is a no-op — the command retrieves `Results()`, builds its own result struct, and prints
+
+The command owns both the result shape and the output:
+
+```go
+results := jsonRenderer.Results()
+summary := SyncResult{
+    Stack:      s.StackID,
+    PRsUpdated: countUpdated(results),
+    Tasks:      results,
+}
+json.NewEncoder(os.Stdout).Encode(summary)
+```
+
+## JSONL Log Writer
+
+A router side-effect, not a renderer. Always active regardless of output mode.
+
+```go
+type LogWriter struct {
+    enc  *json.Encoder // wraps bufio.Writer → file
+    path string
+}
+```
+
+- Router calls `logWriter.Write(event)` for every event
+- `json.Encoder.Encode()` appends a newline automatically (natural JSONL)
+- `SetEscapeHTML(false)` for readability
+- Buffered with `bufio.Writer`, flushed on `bus.Finish()`
+- Path: `.sdf/logs/YYYY-MM-DDTHH-MM-SS.jsonl`
+
+The JSONL log captures every event — start, log, end. Useful for debugging and test replay.
+
+```
+TTY mode:     Router → TTYRenderer → styled terminal
+                 └──→ .sdf/logs/run.jsonl
+
+--json mode:  Router → JSONRenderer (silent) → command prints result
+                 └──→ .sdf/logs/run.jsonl
+```
+
+## Package Layout
+
+```
+internal/render/
+  event.go       — Event struct, event type constants
+  reporter.go    — Reporter: Start/Log/End/Pause/Resume
+  bus.go         — Bus: NewBus/AddTask/Run/RunBatch/Finish, router goroutine
+  renderer.go    — Renderer interface definition
+  tty.go         — TTYRenderer: batch mode (multi-line block) + sequential mode
+  json.go        — JSONRenderer: collects task.end, exposes Results()
+  log.go         — LogWriter: JSONL persistence
+  ansi.go        — CUP, EL, HideCursor, ShowCursor helpers
+```
+
+7 files. No new dependencies — `encoding/json`, `sync`, `context`, `golang.org/x/sync/errgroup`, `charmbracelet/lipgloss`, `golang.org/x/term` are all already in `go.mod`.
+
+## First Consumer: sync.go
+
+Replace `orderedPrinter` in `updatePRContent()`.
+
+Before (today):
+```go
+printer := newOrderedPrinter(len(jobs), "Updating PR content...")
+var wg sync.WaitGroup
+for _, j := range jobs {
+    wg.Add(1)
+    go func(j contentJob) {
+        defer wg.Done()
+        // ... do work ...
+        printer.set(j.index, result)
+    }(j)
+}
+wg.Wait()
+printer.finish()
+```
+
+After:
+```go
+bus := render.NewBus(os.Stdout, render.Options{LogDir: root + "/.sdf/logs"})
+for _, j := range jobs {
+    j := j
+    bus.AddTask(render.TaskSpec{
+        ID:   fmt.Sprintf("pr-%d", j.node.PR),
+        Name: fmt.Sprintf("PR %s", ui.PR(j.node.PR)),
+        Fn: func(ctx context.Context, r *render.Reporter) error {
+            r.Log("updating title...")
+            // ... title logic ...
+            r.Log("generating description...")
+            // ... description logic ...
+            r.End("succeeded", "updated (title + description)")
+            return nil
+        },
+    })
+}
+bus.RunBatch(ctx)
+bus.Finish()
+```
+
+`orderedPrinter` struct and methods get deleted. `contentJob.index` becomes unnecessary.
+
+## Testing Strategy
+
+### Unit tests (no terminal)
+
+- `reporter_test.go` — sends correct events in order, per-task seq increments
+- `bus_test.go` — `Run` executes single task, `RunBatch` executes in parallel, errors propagate via errgroup, context cancellation works
+- `json_test.go` — accumulates task.end results, ignores other events
+- `log_test.go` — produces valid JSONL (one line per event, parseable)
+
+### TTY renderer tests
+
+- Output captured to `bytes.Buffer`
+- Assert CUP/EL sequences target correct rows
+- Slot updates: Log overwrites previous status, End finalizes
+- Ordering: out-of-order completions display in task-index order
+- Pause/Resume: progress area clears and re-renders
+
+### Integration test
+
+- After wiring into sync, existing sync tests validate end-to-end flow
+- One test that runs `updatePRContent` with fake `gh`/`claude` and asserts the JSONL log contains expected events
+
+## Deferred
+
+| Feature | Reason |
+|---|---|
+| `r.Progress(fraction)` | No sdf command has fractional progress yet |
+| Alt screen buffer | No full-screen commands planned |
+| Backpressure / coalescing | 2-10 parallel tasks won't saturate a channel |
+| Resize handling | Fixed block of N lines is small, unlikely to break |
+| Spinner customization | Default is fine |
+| Log pruning | `.sdf/logs/` cleanup can be added later |

--- a/docs/plans/2026-02-27-render-package-plan.md
+++ b/docs/plans/2026-02-27-render-package-plan.md
@@ -1,0 +1,1507 @@
+# `internal/render` Package Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a rendering and orchestration package that replaces `orderedPrinter` in `sync.go` with a pluggable event bus supporting parallel task execution, in-place terminal updates, JSON output, and JSONL log persistence.
+
+**Architecture:** Commands define tasks as `TaskSpec` structs. A `Bus` runs them (sequentially or in parallel via `errgroup`), routing typed `Event` structs through a channel to a `Renderer` interface. TTYRenderer draws a multi-line in-place block with spinner. JSONRenderer silently collects results. A LogWriter tees all events to `.sdf/logs/*.jsonl` as a side-effect.
+
+**Tech Stack:** Go stdlib (`encoding/json`, `sync/atomic`, `context`), `golang.org/x/sync/errgroup`, `mattn/go-isatty`, `charmbracelet/lipgloss` — all already in `go.mod`.
+
+**Design doc:** `docs/plans/2026-02-27-render-package-design.md`
+
+---
+
+### Task 1: Event Types and Constants
+
+**Files:**
+- Create: `internal/render/event.go`
+- Test: `internal/render/event_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+// internal/render/event_test.go
+package render
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewEvent_SetsFields(t *testing.T) {
+	ev := Event{
+		Type:   EventTaskStart,
+		TS:     time.Now(),
+		Seq:    1,
+		TaskID: "t1",
+		Data:   map[string]any{"name": "download"},
+	}
+	if ev.Type != "task.start" {
+		t.Fatalf("got type %q, want %q", ev.Type, "task.start")
+	}
+	if ev.TaskID != "t1" {
+		t.Fatalf("got task id %q, want %q", ev.TaskID, "t1")
+	}
+}
+
+func TestEventConstants(t *testing.T) {
+	if EventTaskStart != "task.start" {
+		t.Fatal("wrong constant")
+	}
+	if EventTaskLog != "task.log" {
+		t.Fatal("wrong constant")
+	}
+	if EventTaskEnd != "task.end" {
+		t.Fatal("wrong constant")
+	}
+	if EventPause != "renderer.pause" {
+		t.Fatal("wrong constant")
+	}
+	if EventResume != "renderer.resume" {
+		t.Fatal("wrong constant")
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/render/ -run TestNewEvent -v -count=1`
+Expected: FAIL — package does not exist
+
+**Step 3: Write minimal implementation**
+
+```go
+// internal/render/event.go
+package render
+
+import "time"
+
+const (
+	EventTaskStart = "task.start"
+	EventTaskLog   = "task.log"
+	EventTaskEnd   = "task.end"
+	EventPause     = "renderer.pause"
+	EventResume    = "renderer.resume"
+)
+
+type Event struct {
+	Type   string    `json:"type"`
+	TS     time.Time `json:"ts"`
+	Seq    uint64    `json:"seq"`
+	TaskID string    `json:"task_id"`
+	Data   any       `json:"data,omitempty"`
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/render/ -v -count=1`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/render/event.go internal/render/event_test.go
+git commit -m "feat(render): add Event struct and type constants"
+```
+
+---
+
+### Task 2: Reporter
+
+**Files:**
+- Create: `internal/render/reporter.go`
+- Test: `internal/render/reporter_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+// internal/render/reporter_test.go
+package render
+
+import (
+	"testing"
+	"time"
+)
+
+func TestReporter_Start(t *testing.T) {
+	ch := make(chan Event, 10)
+	r := &Reporter{taskID: "t1", events: ch}
+	r.Start("download")
+
+	ev := <-ch
+	if ev.Type != EventTaskStart {
+		t.Fatalf("got type %q, want %q", ev.Type, EventTaskStart)
+	}
+	if ev.TaskID != "t1" {
+		t.Fatalf("got task id %q, want %q", ev.TaskID, "t1")
+	}
+	data := ev.Data.(map[string]any)
+	if data["name"] != "download" {
+		t.Fatalf("got name %q, want %q", data["name"], "download")
+	}
+}
+
+func TestReporter_Log(t *testing.T) {
+	ch := make(chan Event, 10)
+	r := &Reporter{taskID: "t1", events: ch}
+	r.Log("fetching index...")
+
+	ev := <-ch
+	if ev.Type != EventTaskLog {
+		t.Fatalf("got type %q, want %q", ev.Type, EventTaskLog)
+	}
+	data := ev.Data.(map[string]any)
+	if data["text"] != "fetching index..." {
+		t.Fatalf("got text %q", data["text"])
+	}
+}
+
+func TestReporter_End(t *testing.T) {
+	ch := make(chan Event, 10)
+	r := &Reporter{taskID: "t1", events: ch}
+	r.End("succeeded", "updated (title)")
+
+	ev := <-ch
+	if ev.Type != EventTaskEnd {
+		t.Fatalf("got type %q, want %q", ev.Type, EventTaskEnd)
+	}
+	data := ev.Data.(map[string]any)
+	if data["status"] != "succeeded" {
+		t.Fatalf("got status %q", data["status"])
+	}
+	if data["message"] != "updated (title)" {
+		t.Fatalf("got message %q", data["message"])
+	}
+}
+
+func TestReporter_SeqIncrements(t *testing.T) {
+	ch := make(chan Event, 10)
+	r := &Reporter{taskID: "t1", events: ch}
+	r.Start("a")
+	r.Log("b")
+	r.End("succeeded", "c")
+
+	seqs := make([]uint64, 0, 3)
+	for range 3 {
+		ev := <-ch
+		seqs = append(seqs, ev.Seq)
+	}
+	// Seq is assigned by the router (0 here), but taskSeq should increment.
+	// Reporter doesn't set global Seq — that's the router's job.
+	// Just verify events arrive and are distinct timestamps.
+	if len(seqs) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(seqs))
+	}
+}
+
+func TestReporter_PauseResume(t *testing.T) {
+	ch := make(chan Event, 10)
+	r := &Reporter{taskID: "t1", events: ch}
+	r.Pause()
+	r.Resume()
+
+	ev1 := <-ch
+	if ev1.Type != EventPause {
+		t.Fatalf("got type %q, want %q", ev1.Type, EventPause)
+	}
+	ev2 := <-ch
+	if ev2.Type != EventResume {
+		t.Fatalf("got type %q, want %q", ev2.Type, EventResume)
+	}
+}
+
+func drainTimeout(ch <-chan Event, d time.Duration) (Event, bool) {
+	select {
+	case ev := <-ch:
+		return ev, true
+	case <-time.After(d):
+		return Event{}, false
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/render/ -run TestReporter -v -count=1`
+Expected: FAIL — `Reporter` not defined
+
+**Step 3: Write minimal implementation**
+
+```go
+// internal/render/reporter.go
+package render
+
+import "time"
+
+// Reporter is the per-task handle for emitting events.
+// Commands call its methods instead of fmt.Printf.
+type Reporter struct {
+	taskID string
+	events chan<- Event
+}
+
+func (r *Reporter) Start(name string) {
+	r.events <- Event{
+		Type:   EventTaskStart,
+		TS:     time.Now(),
+		TaskID: r.taskID,
+		Data:   map[string]any{"name": name},
+	}
+}
+
+func (r *Reporter) Log(text string) {
+	r.events <- Event{
+		Type:   EventTaskLog,
+		TS:     time.Now(),
+		TaskID: r.taskID,
+		Data:   map[string]any{"text": text},
+	}
+}
+
+func (r *Reporter) End(status, message string) {
+	r.events <- Event{
+		Type:   EventTaskEnd,
+		TS:     time.Now(),
+		TaskID: r.taskID,
+		Data:   map[string]any{"status": status, "message": message},
+	}
+}
+
+func (r *Reporter) Pause() {
+	r.events <- Event{
+		Type:   EventPause,
+		TS:     time.Now(),
+		TaskID: r.taskID,
+	}
+}
+
+func (r *Reporter) Resume() {
+	r.events <- Event{
+		Type:   EventResume,
+		TS:     time.Now(),
+		TaskID: r.taskID,
+	}
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/render/ -run TestReporter -v -count=1`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/render/reporter.go internal/render/reporter_test.go
+git commit -m "feat(render): add Reporter with Start/Log/End/Pause/Resume"
+```
+
+---
+
+### Task 3: Renderer Interface and JSONRenderer
+
+**Files:**
+- Create: `internal/render/renderer.go`
+- Create: `internal/render/json.go`
+- Test: `internal/render/json_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+// internal/render/json_test.go
+package render
+
+import "testing"
+
+func TestJSONRenderer_CollectsEndEvents(t *testing.T) {
+	r := &JSONRenderer{}
+	r.Init(3)
+
+	r.HandleEvent(Event{Type: EventTaskStart, TaskID: "t1", Data: map[string]any{"name": "PR #1"}})
+	r.HandleEvent(Event{Type: EventTaskLog, TaskID: "t1", Data: map[string]any{"text": "working..."}})
+	r.HandleEvent(Event{Type: EventTaskEnd, TaskID: "t1", Data: map[string]any{"status": "succeeded", "message": "updated"}})
+	r.HandleEvent(Event{Type: EventTaskEnd, TaskID: "t2", Data: map[string]any{"status": "succeeded", "message": "unchanged"}})
+
+	results := r.Results()
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+	if results[0].TaskID != "t1" {
+		t.Fatalf("got task id %q, want %q", results[0].TaskID, "t1")
+	}
+	if results[0].Status != "succeeded" {
+		t.Fatalf("got status %q", results[0].Status)
+	}
+	if results[0].Message != "updated" {
+		t.Fatalf("got message %q", results[0].Message)
+	}
+}
+
+func TestJSONRenderer_IgnoresNonEndEvents(t *testing.T) {
+	r := &JSONRenderer{}
+	r.Init(2)
+
+	r.HandleEvent(Event{Type: EventTaskStart, TaskID: "t1"})
+	r.HandleEvent(Event{Type: EventTaskLog, TaskID: "t1"})
+	r.HandleEvent(Event{Type: EventPause, TaskID: "t1"})
+	r.HandleEvent(Event{Type: EventResume, TaskID: "t1"})
+
+	if len(r.Results()) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(r.Results()))
+	}
+}
+
+func TestJSONRenderer_PauseResumeAreNoOps(t *testing.T) {
+	r := &JSONRenderer{}
+	r.Init(1)
+	// These must not panic.
+	r.Pause()
+	r.Resume()
+	r.Flush()
+	r.Finish()
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/render/ -run TestJSONRenderer -v -count=1`
+Expected: FAIL — `JSONRenderer` not defined
+
+**Step 3: Write minimal implementation**
+
+```go
+// internal/render/renderer.go
+package render
+
+// Renderer is the pluggable output interface.
+// Swapped based on --json flag / TTY detection.
+type Renderer interface {
+	Init(taskCount int)
+	HandleEvent(Event)
+	Flush()
+	Pause()
+	Resume()
+	Finish()
+}
+```
+
+```go
+// internal/render/json.go
+package render
+
+// TaskResult holds the outcome of a single task, extracted from task.end events.
+type TaskResult struct {
+	TaskID  string
+	Status  string
+	Message string
+}
+
+// JSONRenderer silently collects task outcomes for --json output.
+// The command retrieves Results(), builds its own result struct, and prints.
+type JSONRenderer struct {
+	results []TaskResult
+}
+
+func (r *JSONRenderer) Init(taskCount int) {
+	r.results = make([]TaskResult, 0, taskCount)
+}
+
+func (r *JSONRenderer) HandleEvent(ev Event) {
+	if ev.Type != EventTaskEnd {
+		return
+	}
+	data, _ := ev.Data.(map[string]any)
+	status, _ := data["status"].(string)
+	message, _ := data["message"].(string)
+	r.results = append(r.results, TaskResult{
+		TaskID:  ev.TaskID,
+		Status:  status,
+		Message: message,
+	})
+}
+
+func (r *JSONRenderer) Flush()  {}
+func (r *JSONRenderer) Pause()  {}
+func (r *JSONRenderer) Resume() {}
+func (r *JSONRenderer) Finish() {}
+
+// Results returns the collected task outcomes.
+func (r *JSONRenderer) Results() []TaskResult {
+	return r.results
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/render/ -run TestJSONRenderer -v -count=1`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/render/renderer.go internal/render/json.go internal/render/json_test.go
+git commit -m "feat(render): add Renderer interface and JSONRenderer"
+```
+
+---
+
+### Task 4: JSONL LogWriter
+
+**Files:**
+- Create: `internal/render/log.go`
+- Test: `internal/render/log_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+// internal/render/log_test.go
+package render
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLogWriter_WritesJSONL(t *testing.T) {
+	var buf bytes.Buffer
+	lw := NewLogWriter(&buf)
+
+	lw.Write(Event{Type: EventTaskStart, TS: time.Now(), TaskID: "t1", Data: map[string]any{"name": "task1"}})
+	lw.Write(Event{Type: EventTaskLog, TS: time.Now(), TaskID: "t1", Data: map[string]any{"text": "working"}})
+	lw.Write(Event{Type: EventTaskEnd, TS: time.Now(), TaskID: "t1", Data: map[string]any{"status": "succeeded"}})
+	lw.Flush()
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("got %d lines, want 3:\n%s", len(lines), buf.String())
+	}
+
+	// Each line must be valid JSON.
+	for i, line := range lines {
+		var ev Event
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("line %d not valid JSON: %v\nline: %s", i, err, line)
+		}
+	}
+}
+
+func TestLogWriter_PreservesEventFields(t *testing.T) {
+	var buf bytes.Buffer
+	lw := NewLogWriter(&buf)
+
+	ts := time.Date(2026, 2, 27, 10, 0, 0, 0, time.UTC)
+	lw.Write(Event{Type: EventTaskStart, TS: ts, Seq: 42, TaskID: "abc"})
+	lw.Flush()
+
+	var parsed map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed["type"] != "task.start" {
+		t.Fatalf("got type %v", parsed["type"])
+	}
+	if parsed["task_id"] != "abc" {
+		t.Fatalf("got task_id %v", parsed["task_id"])
+	}
+	if parsed["seq"].(float64) != 42 {
+		t.Fatalf("got seq %v", parsed["seq"])
+	}
+}
+
+func TestLogWriter_NoHTMLEscaping(t *testing.T) {
+	var buf bytes.Buffer
+	lw := NewLogWriter(&buf)
+	lw.Write(Event{Type: EventTaskLog, TS: time.Now(), TaskID: "t1", Data: map[string]any{"text": "a < b & c > d"}})
+	lw.Flush()
+
+	// encoding/json with SetEscapeHTML(false) should NOT escape <, >, &
+	if strings.Contains(buf.String(), `\u003c`) {
+		t.Fatal("HTML escaping should be disabled")
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/render/ -run TestLogWriter -v -count=1`
+Expected: FAIL — `NewLogWriter` not defined
+
+**Step 3: Write minimal implementation**
+
+```go
+// internal/render/log.go
+package render
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+)
+
+// LogWriter serializes events to JSONL format.
+// This is a router side-effect for persistence — not a renderer.
+type LogWriter struct {
+	bw  *bufio.Writer
+	enc *json.Encoder
+}
+
+// NewLogWriter creates a LogWriter that writes JSONL to w.
+func NewLogWriter(w io.Writer) *LogWriter {
+	bw := bufio.NewWriterSize(w, 64*1024)
+	enc := json.NewEncoder(bw)
+	enc.SetEscapeHTML(false)
+	return &LogWriter{bw: bw, enc: enc}
+}
+
+// Write serializes a single event as one JSON line.
+func (l *LogWriter) Write(ev Event) error {
+	return l.enc.Encode(ev)
+}
+
+// Flush flushes the buffered writer.
+func (l *LogWriter) Flush() error {
+	return l.bw.Flush()
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/render/ -run TestLogWriter -v -count=1`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/render/log.go internal/render/log_test.go
+git commit -m "feat(render): add JSONL LogWriter for event persistence"
+```
+
+---
+
+### Task 5: ANSI Helpers
+
+**Files:**
+- Create: `internal/render/ansi.go`
+- Test: `internal/render/ansi_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+// internal/render/ansi_test.go
+package render
+
+import "testing"
+
+func TestCup(t *testing.T) {
+	// CUP is 1-based: CSI row;col H
+	got := Cup(3, 1)
+	want := "\x1b[3;1H"
+	if got != want {
+		t.Fatalf("Cup(3,1) = %q, want %q", got, want)
+	}
+}
+
+func TestEl(t *testing.T) {
+	got := El()
+	want := "\x1b[2K"
+	if got != want {
+		t.Fatalf("El() = %q, want %q", got, want)
+	}
+}
+
+func TestHideCursor(t *testing.T) {
+	got := HideCursor()
+	want := "\x1b[?25l"
+	if got != want {
+		t.Fatalf("HideCursor() = %q, want %q", got, want)
+	}
+}
+
+func TestShowCursor(t *testing.T) {
+	got := ShowCursor()
+	want := "\x1b[?25h"
+	if got != want {
+		t.Fatalf("ShowCursor() = %q, want %q", got, want)
+	}
+}
+
+func TestCursorUp(t *testing.T) {
+	got := CursorUp(5)
+	want := "\x1b[5A"
+	if got != want {
+		t.Fatalf("CursorUp(5) = %q, want %q", got, want)
+	}
+}
+
+func TestCursorDown(t *testing.T) {
+	got := CursorDown(2)
+	want := "\x1b[2B"
+	if got != want {
+		t.Fatalf("CursorDown(2) = %q, want %q", got, want)
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/render/ -run TestCup -v -count=1`
+Expected: FAIL — `Cup` not defined
+
+**Step 3: Write minimal implementation**
+
+```go
+// internal/render/ansi.go
+package render
+
+import "fmt"
+
+const esc = "\x1b"
+
+// Cup moves cursor to 1-based (row, col).
+func Cup(row, col int) string { return fmt.Sprintf("%s[%d;%dH", esc, row, col) }
+
+// El clears the entire current line (EL 2).
+func El() string { return esc + "[2K" }
+
+// HideCursor hides the terminal cursor (DECTCEM).
+func HideCursor() string { return esc + "[?25l" }
+
+// ShowCursor shows the terminal cursor (DECTCEM).
+func ShowCursor() string { return esc + "[?25h" }
+
+// CursorUp moves cursor up n lines.
+func CursorUp(n int) string { return fmt.Sprintf("%s[%dA", esc, n) }
+
+// CursorDown moves cursor down n lines.
+func CursorDown(n int) string { return fmt.Sprintf("%s[%dB", esc, n) }
+
+// CarriageReturn moves cursor to column 1 of current line.
+func CarriageReturn() string { return "\r" }
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/render/ -run "TestCup|TestEl|TestHide|TestShow|TestCursor" -v -count=1`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/render/ansi.go internal/render/ansi_test.go
+git commit -m "feat(render): add ANSI terminal control helpers"
+```
+
+---
+
+### Task 6: TTYRenderer
+
+**Files:**
+- Create: `internal/render/tty.go`
+- Test: `internal/render/tty_test.go`
+
+This is the most complex component. The TTY renderer has two modes:
+- **Batch mode**: multi-line in-place block with spinner (used by `RunBatch`)
+- **Sequential mode**: append-only, one line at a time (used by `Run`)
+
+**Step 1: Write the failing tests**
+
+```go
+// internal/render/tty_test.go
+package render
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestTTYRenderer_BatchMode_ShowsSlots(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTTYRenderer(&buf)
+	r.Init(2)
+
+	r.HandleEvent(Event{Type: EventTaskStart, TaskID: "t0", Data: map[string]any{"name": "PR #1"}})
+	r.HandleEvent(Event{Type: EventTaskStart, TaskID: "t1", Data: map[string]any{"name": "PR #2"}})
+	r.HandleEvent(Event{Type: EventTaskLog, TaskID: "t0", Data: map[string]any{"text": "updating title..."}})
+	r.Flush()
+
+	out := buf.String()
+	if !strings.Contains(out, "PR #1") {
+		t.Fatalf("expected PR #1 in output:\n%s", out)
+	}
+	if !strings.Contains(out, "updating title...") {
+		t.Fatalf("expected 'updating title...' in output:\n%s", out)
+	}
+	if !strings.Contains(out, "PR #2") {
+		t.Fatalf("expected PR #2 in output:\n%s", out)
+	}
+}
+
+func TestTTYRenderer_BatchMode_EndFinalizes(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTTYRenderer(&buf)
+	r.Init(2)
+
+	r.HandleEvent(Event{Type: EventTaskStart, TaskID: "t0", Data: map[string]any{"name": "PR #1"}})
+	r.HandleEvent(Event{Type: EventTaskStart, TaskID: "t1", Data: map[string]any{"name": "PR #2"}})
+	r.HandleEvent(Event{Type: EventTaskEnd, TaskID: "t0", Data: map[string]any{"status": "succeeded", "message": "unchanged"}})
+	r.Flush()
+
+	out := buf.String()
+	if !strings.Contains(out, "unchanged") {
+		t.Fatalf("expected 'unchanged' in output:\n%s", out)
+	}
+}
+
+func TestTTYRenderer_BatchMode_SpinnerLine(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTTYRenderer(&buf)
+	r.Init(2)
+
+	r.HandleEvent(Event{Type: EventTaskStart, TaskID: "t0", Data: map[string]any{"name": "PR #1"}})
+	r.HandleEvent(Event{Type: EventTaskStart, TaskID: "t1", Data: map[string]any{"name": "PR #2"}})
+	r.HandleEvent(Event{Type: EventTaskEnd, TaskID: "t0", Data: map[string]any{"status": "succeeded", "message": "done"}})
+	r.Flush()
+
+	out := buf.String()
+	// Spinner line should show completion counter
+	if !strings.Contains(out, "1/2") {
+		t.Fatalf("expected completion counter '1/2' in output:\n%s", out)
+	}
+}
+
+func TestTTYRenderer_SequentialMode_AppendsLines(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTTYRenderer(&buf)
+	// Init with 0 means sequential mode — no batch block
+	r.Init(0)
+
+	r.HandleEvent(Event{Type: EventTaskLog, TaskID: "t0", Data: map[string]any{"text": "rebasing..."}})
+	r.HandleEvent(Event{Type: EventTaskEnd, TaskID: "t0", Data: map[string]any{"status": "succeeded", "message": "rebased and pushed"}})
+
+	out := buf.String()
+	if !strings.Contains(out, "rebasing...") {
+		t.Fatalf("expected 'rebasing...' in output:\n%s", out)
+	}
+	if !strings.Contains(out, "rebased and pushed") {
+		t.Fatalf("expected 'rebased and pushed' in output:\n%s", out)
+	}
+}
+
+func TestTTYRenderer_PauseResume(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTTYRenderer(&buf)
+	r.Init(2)
+
+	r.HandleEvent(Event{Type: EventTaskStart, TaskID: "t0", Data: map[string]any{"name": "PR #1"}})
+	r.Flush()
+	buf.Reset()
+
+	// Pause should emit show-cursor (restores terminal for prompts)
+	r.Pause()
+	out := buf.String()
+	if !strings.Contains(out, ShowCursor()) {
+		t.Fatalf("expected ShowCursor in pause output:\n%q", out)
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/render/ -run TestTTYRenderer -v -count=1`
+Expected: FAIL — `NewTTYRenderer` not defined
+
+**Step 3: Write implementation**
+
+```go
+// internal/render/tty.go
+package render
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+)
+
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+type slot struct {
+	label  string // task name, e.g. "PR #57"
+	status string // current status from task.log
+	done   bool
+	final  string // final line from task.end
+}
+
+// TTYRenderer renders task progress to a terminal.
+// Batch mode (Init with n>0): multi-line in-place block with spinner.
+// Sequential mode (Init with n=0): append-only, no cursor movement.
+type TTYRenderer struct {
+	mu           sync.Mutex
+	w            io.Writer
+	slots        []slot
+	taskIndex    map[string]int // taskID → slot index
+	completed    int
+	spinnerFrame int
+	batchMode    bool
+	paused       bool
+	label        string
+}
+
+func NewTTYRenderer(w io.Writer) *TTYRenderer {
+	return &TTYRenderer{
+		w:         w,
+		taskIndex: make(map[string]int),
+		label:     "Running tasks",
+	}
+}
+
+func (r *TTYRenderer) Init(taskCount int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.batchMode = taskCount > 0
+	r.slots = make([]slot, 0, taskCount)
+	r.taskIndex = make(map[string]int, taskCount)
+	r.completed = 0
+	if r.batchMode {
+		fmt.Fprint(r.w, HideCursor())
+	}
+}
+
+func (r *TTYRenderer) HandleEvent(ev Event) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	switch ev.Type {
+	case EventTaskStart:
+		data, _ := ev.Data.(map[string]any)
+		name, _ := data["name"].(string)
+		idx := len(r.slots)
+		r.slots = append(r.slots, slot{label: name, status: "starting..."})
+		r.taskIndex[ev.TaskID] = idx
+
+	case EventTaskLog:
+		idx, ok := r.taskIndex[ev.TaskID]
+		if !ok {
+			return
+		}
+		data, _ := ev.Data.(map[string]any)
+		text, _ := data["text"].(string)
+		r.slots[idx].status = text
+		if !r.batchMode {
+			fmt.Fprintf(r.w, "  %s\n", text)
+		}
+
+	case EventTaskEnd:
+		idx, ok := r.taskIndex[ev.TaskID]
+		if !ok {
+			return
+		}
+		data, _ := ev.Data.(map[string]any)
+		status, _ := data["status"].(string)
+		message, _ := data["message"].(string)
+		r.slots[idx].done = true
+		r.slots[idx].final = formatFinal(status, message)
+		r.completed++
+		if !r.batchMode {
+			fmt.Fprintf(r.w, "  %s\n", r.slots[idx].final)
+		}
+
+	case EventPause:
+		r.paused = true
+
+	case EventResume:
+		r.paused = false
+	}
+}
+
+func (r *TTYRenderer) Flush() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if !r.batchMode || r.paused {
+		return
+	}
+	r.renderBlock()
+}
+
+func (r *TTYRenderer) Pause() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.paused = true
+	// Move cursor below the block and show cursor for prompt interaction.
+	if r.batchMode {
+		fmt.Fprint(r.w, ShowCursor())
+	}
+}
+
+func (r *TTYRenderer) Resume() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.paused = false
+	if r.batchMode {
+		fmt.Fprint(r.w, HideCursor())
+	}
+}
+
+func (r *TTYRenderer) Finish() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.batchMode {
+		r.renderBlock()
+		fmt.Fprint(r.w, ShowCursor())
+	}
+}
+
+// renderBlock redraws all slots and the spinner line.
+// Called with r.mu held.
+func (r *TTYRenderer) renderBlock() {
+	var b strings.Builder
+
+	// Move cursor to start of block.
+	// We re-render from current position using \r + cursor up.
+	totalLines := len(r.slots) + 2 // slots + blank + spinner
+	b.WriteString(fmt.Sprintf("\r%s", CursorUp(totalLines)))
+
+	for _, s := range r.slots {
+		b.WriteString(El())
+		if s.done {
+			b.WriteString(fmt.Sprintf("  %s\n", s.final))
+		} else {
+			b.WriteString(fmt.Sprintf("  %s: %s\n", s.label, s.status))
+		}
+	}
+
+	// Blank line + spinner
+	b.WriteString(El())
+	b.WriteString("\n")
+	b.WriteString(El())
+	frame := spinnerFrames[r.spinnerFrame%len(spinnerFrames)]
+	b.WriteString(fmt.Sprintf("  %s %s (%d/%d)\n", frame, r.label, r.completed, len(r.slots)))
+	r.spinnerFrame++
+
+	fmt.Fprint(r.w, b.String())
+}
+
+func formatFinal(status, message string) string {
+	// The command can pass pre-formatted messages using ui.SymOK etc.
+	// If not pre-formatted, add a simple prefix.
+	if message == "" {
+		message = status
+	}
+	return message
+}
+```
+
+**Note:** The initial Flush implementation uses cursor-up from current position. The `Init` in batch mode must print enough newlines to "allocate" the block space. Add this to `Init`:
+
+After `fmt.Fprint(r.w, HideCursor())` in Init, add:
+```go
+// Allocate space for the block: slots + blank + spinner.
+for range taskCount + 2 {
+    fmt.Fprintln(r.w)
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/render/ -run TestTTYRenderer -v -count=1`
+Expected: PASS
+
+Iterate on the implementation if tests fail. The key behaviors:
+- Batch mode: CursorUp to start of block, rewrite each line with EL, spinner at bottom
+- Sequential mode: plain `fmt.Fprintf` append-only
+- Pause: show cursor, stop rendering
+- Resume: hide cursor, resume rendering
+
+**Step 5: Commit**
+
+```bash
+git add internal/render/tty.go internal/render/tty_test.go
+git commit -m "feat(render): add TTYRenderer with batch and sequential modes"
+```
+
+---
+
+### Task 7: Bus (Orchestrator)
+
+**Files:**
+- Create: `internal/render/bus.go`
+- Test: `internal/render/bus_test.go`
+
+**Step 1: Write the failing tests**
+
+```go
+// internal/render/bus_test.go
+package render
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestBus_RunBatch_ExecutesAllTasks(t *testing.T) {
+	var buf bytes.Buffer
+	bus := NewBus(&buf, Options{})
+
+	var count atomic.Int32
+	for i := range 3 {
+		id := fmt.Sprintf("t%d", i)
+		bus.AddTask(TaskSpec{
+			ID:   id,
+			Name: fmt.Sprintf("task %d", i),
+			Fn: func(ctx context.Context, r *Reporter) error {
+				count.Add(1)
+				r.End("succeeded", "done")
+				return nil
+			},
+		})
+	}
+
+	err := bus.RunBatch(context.Background())
+	if err != nil {
+		t.Fatalf("RunBatch failed: %v", err)
+	}
+	bus.Finish()
+
+	if count.Load() != 3 {
+		t.Fatalf("expected 3 tasks executed, got %d", count.Load())
+	}
+}
+
+func TestBus_RunBatch_PropagatesError(t *testing.T) {
+	var buf bytes.Buffer
+	bus := NewBus(&buf, Options{})
+
+	bus.AddTask(TaskSpec{
+		ID: "t0", Name: "fail",
+		Fn: func(ctx context.Context, r *Reporter) error {
+			r.End("failed", "boom")
+			return errors.New("boom")
+		},
+	})
+
+	err := bus.RunBatch(context.Background())
+	if err == nil {
+		t.Fatal("expected error from RunBatch")
+	}
+	bus.Finish()
+}
+
+func TestBus_Run_ExecutesSingleTask(t *testing.T) {
+	var buf bytes.Buffer
+	bus := NewBus(&buf, Options{})
+
+	executed := false
+	err := bus.Run(context.Background(), TaskSpec{
+		ID: "t0", Name: "single",
+		Fn: func(ctx context.Context, r *Reporter) error {
+			executed = true
+			r.Log("working...")
+			r.End("succeeded", "done")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	bus.Finish()
+
+	if !executed {
+		t.Fatal("task was not executed")
+	}
+}
+
+func TestBus_RunBatch_CancelsOnContext(t *testing.T) {
+	var buf bytes.Buffer
+	bus := NewBus(&buf, Options{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	bus.AddTask(TaskSpec{
+		ID: "t0", Name: "blocker",
+		Fn: func(ctx context.Context, r *Reporter) error {
+			cancel() // cancel immediately
+			<-ctx.Done()
+			r.End("cancelled", "cancelled")
+			return ctx.Err()
+		},
+	})
+
+	err := bus.RunBatch(ctx)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	bus.Finish()
+}
+
+func TestBus_LogWriter_ProducesJSONL(t *testing.T) {
+	var logBuf bytes.Buffer
+	var termBuf bytes.Buffer
+	bus := NewBus(&termBuf, Options{LogWriter: NewLogWriter(&logBuf)})
+
+	bus.AddTask(TaskSpec{
+		ID: "t0", Name: "test",
+		Fn: func(ctx context.Context, r *Reporter) error {
+			r.Log("hello")
+			r.End("succeeded", "done")
+			return nil
+		},
+	})
+
+	bus.RunBatch(context.Background())
+	bus.Finish()
+
+	// Log should contain JSONL lines.
+	lines := strings.Split(strings.TrimSpace(logBuf.String()), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 JSONL lines, got %d:\n%s", len(lines), logBuf.String())
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/render/ -run TestBus -v -count=1`
+Expected: FAIL — `NewBus` not defined
+
+**Step 3: Write implementation**
+
+```go
+// internal/render/bus.go
+package render
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// Options configures the Bus.
+type Options struct {
+	Renderer  Renderer   // nil = auto-detect (TTY → TTYRenderer, else JSONRenderer)
+	LogWriter *LogWriter // nil = no logging
+	Label     string     // spinner label, default "Running tasks"
+}
+
+// TaskSpec defines a unit of work for the bus.
+type TaskSpec struct {
+	ID   string
+	Name string
+	Fn   func(ctx context.Context, r *Reporter) error
+}
+
+// Bus orchestrates task execution and rendering.
+// One bus per command invocation.
+type Bus struct {
+	renderer Renderer
+	log      *LogWriter
+	events   chan Event
+	tasks    []TaskSpec
+	seq      atomic.Uint64
+	done     chan struct{} // signals router goroutine to stop
+}
+
+// NewBus creates a Bus with the given output writer and options.
+func NewBus(w io.Writer, opts Options) *Bus {
+	renderer := opts.Renderer
+	if renderer == nil {
+		renderer = NewTTYRenderer(w)
+	}
+
+	b := &Bus{
+		renderer: renderer,
+		log:      opts.LogWriter,
+		events:   make(chan Event, 256),
+		done:     make(chan struct{}),
+	}
+
+	// Start the router goroutine.
+	go b.router()
+	return b
+}
+
+// AddTask registers a task for the next RunBatch call.
+func (b *Bus) AddTask(task TaskSpec) {
+	b.tasks = append(b.tasks, task)
+}
+
+// Run executes a single task synchronously (sequential mode).
+func (b *Bus) Run(ctx context.Context, task TaskSpec) error {
+	b.renderer.Init(0) // sequential mode
+	rep := &Reporter{taskID: task.ID, events: b.events}
+	rep.Start(task.Name)
+	err := task.Fn(ctx, rep)
+	if err != nil {
+		rep.End("failed", err.Error())
+	}
+	// Drain events briefly to let router process.
+	time.Sleep(10 * time.Millisecond)
+	return err
+}
+
+// RunBatch executes all added tasks in parallel via errgroup.
+func (b *Bus) RunBatch(ctx context.Context) error {
+	if len(b.tasks) == 0 {
+		return nil
+	}
+
+	b.renderer.Init(len(b.tasks))
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	// Start all tasks.
+	for _, task := range b.tasks {
+		task := task
+		g.Go(func() error {
+			rep := &Reporter{taskID: task.ID, events: b.events}
+			rep.Start(task.Name)
+			err := task.Fn(ctx, rep)
+			if err != nil && !isEndSent(rep) {
+				rep.End("failed", err.Error())
+			}
+			return err
+		})
+	}
+
+	// Tick-driven rendering while tasks run.
+	ticker := time.NewTicker(100 * time.Millisecond)
+	renderDone := make(chan struct{})
+	go func() {
+		defer close(renderDone)
+		for {
+			select {
+			case <-ticker.C:
+				b.renderer.Flush()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	err := g.Wait()
+
+	ticker.Stop()
+	<-renderDone
+
+	// Final flush to show completed state.
+	b.renderer.Flush()
+
+	// Clear tasks for reuse.
+	b.tasks = b.tasks[:0]
+	return err
+}
+
+// Finish stops the router, flushes logs, and finalizes the renderer.
+func (b *Bus) Finish() error {
+	close(b.events)
+	<-b.done // wait for router to drain
+
+	b.renderer.Finish()
+
+	if b.log != nil {
+		return b.log.Flush()
+	}
+	return nil
+}
+
+// router reads events from the channel, assigns global seq, persists to log, and forwards to renderer.
+func (b *Bus) router() {
+	defer close(b.done)
+	for ev := range b.events {
+		ev.Seq = b.seq.Add(1)
+		if b.log != nil {
+			b.log.Write(ev)
+		}
+		b.renderer.HandleEvent(ev)
+	}
+}
+
+func isEndSent(_ *Reporter) bool {
+	// Simple guard: if the task Fn already called End(), we shouldn't send another.
+	// For now, return false — the task is expected to call End() or let the bus do it.
+	return false
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/render/ -run TestBus -v -count=1`
+Expected: PASS
+
+Add missing imports (`fmt`, `strings`) to the test file if needed. Iterate until all 5 bus tests pass.
+
+**Step 5: Run all render package tests**
+
+Run: `go test ./internal/render/ -v -count=1`
+Expected: ALL PASS
+
+**Step 6: Commit**
+
+```bash
+git add internal/render/bus.go internal/render/bus_test.go
+git commit -m "feat(render): add Bus orchestrator with Run/RunBatch/Finish"
+```
+
+---
+
+### Task 8: Wire Into sync.go
+
+**Files:**
+- Modify: `cmd/sync.go:476-588` (updatePRContent function)
+- Modify: `cmd/sync.go:737-774` (delete orderedPrinter)
+
+**Step 1: Run existing sync tests to capture baseline**
+
+Run: `go test ./cmd/ -run TestComputeSyncPlan -v -count=1`
+Expected: ALL PASS (capture the number of passing tests)
+
+**Step 2: Replace orderedPrinter usage in updatePRContent**
+
+In `cmd/sync.go`, replace the block at lines 536-587:
+
+**Delete** the `orderedPrinter` struct and its methods (lines 737-774).
+
+**Delete** `contentJob.index` field (line 492).
+
+**Replace** the goroutine launch block (lines 536-587) with:
+
+```go
+	bus := render.NewBus(os.Stdout, render.Options{})
+	for _, j := range jobs {
+		j := j
+		bus.AddTask(render.TaskSpec{
+			ID:   fmt.Sprintf("pr-%d", j.node.PR),
+			Name: fmt.Sprintf("PR %s", ui.PR(j.node.PR)),
+			Fn: func(ctx context.Context, r *render.Reporter) error {
+				var parts []string
+
+				// --- Title ---
+				r.Log("updating title...")
+				proposedTitle := j.localTitle
+				if hasClaude && j.titlePrompt != "" {
+					aiTitle, err := claudepkg.RunPrompt(j.titleSession, j.titlePrompt)
+					if err == nil {
+						aiTitle = strings.Split(aiTitle, "\n")[0]
+						aiTitle = strings.Trim(aiTitle, "\"' ")
+						proposedTitle = j.prefix + aiTitle
+					}
+				}
+
+				currentTitle, _ := ghpkg.PRViewTitle(j.node.PR)
+				if !similar(currentTitle, proposedTitle, 0.8) {
+					if err := ghpkg.PREditTitle(j.node.PR, proposedTitle); err == nil {
+						parts = append(parts, "title")
+					}
+				}
+
+				// --- Description (Claude only) ---
+				if hasClaude && j.descPrompt != "" {
+					r.Log("generating description...")
+					desc, err := claudepkg.RunPrompt(j.descSession, j.descPrompt)
+					if err == nil {
+						currentBody, _ := ghpkg.PRViewBody(j.node.PR)
+						currentDesc := extractDescription(currentBody)
+						if !similar(currentDesc, desc, 0.85) {
+							newBody := replaceDescription(currentBody, desc)
+							if err := ghpkg.PREditBody(j.node.PR, newBody); err == nil {
+								parts = append(parts, "description")
+							}
+						}
+					}
+				}
+
+				if len(parts) == 0 {
+					r.End("succeeded", fmt.Sprintf("%s PR %s unchanged", ui.SymOK, ui.PR(j.node.PR)))
+				} else {
+					r.End("succeeded", fmt.Sprintf("%s PR %s updated (%s)", ui.SymOK, ui.PR(j.node.PR), strings.Join(parts, " + ")))
+				}
+				return nil
+			},
+		})
+	}
+	if err := bus.RunBatch(context.Background()); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: some PR updates failed: %v\n", err)
+	}
+	bus.Finish()
+```
+
+**Add imports** at the top of `cmd/sync.go`:
+```go
+"context"
+"github.com/pavelpascari/sdf/internal/render"
+```
+
+**Remove** the `sync` import if `orderedPrinter` was the only user of `sync.WaitGroup` (check for other uses first).
+
+**Step 3: Run existing tests to verify no regression**
+
+Run: `go test ./cmd/ -run TestComputeSyncPlan -v -count=1`
+Expected: ALL PASS (same count as baseline)
+
+Run: `go test ./... -count=1`
+Expected: ALL PASS
+
+**Step 4: Build and verify**
+
+Run: `go build ./...`
+Expected: no errors
+
+Run: `go vet ./...`
+Expected: no issues
+
+**Step 5: Commit**
+
+```bash
+git add cmd/sync.go
+git commit -m "refactor(sync): replace orderedPrinter with render.Bus"
+```
+
+---
+
+### Task 9: Full Test Suite + Install
+
+**Step 1: Run all tests**
+
+Run: `go test ./... -count=1`
+Expected: ALL PASS
+
+**Step 2: Run linter**
+
+Run: `golangci-lint run ./...`
+Expected: No new issues
+
+**Step 3: Build and install**
+
+Run: `go install ./...`
+Expected: Clean build
+
+**Step 4: Manual smoke test**
+
+Run `sdf sync` in a real repo with a stack that has open PRs to verify the new rendering looks correct. Verify:
+- Each PR shows its own line with status updates
+- Spinner animates at the bottom
+- Results display in order when all complete
+- No terminal artifacts after completion
+
+**Step 5: Commit any fixups from smoke test**
+
+```bash
+git add -A
+git commit -m "fix(render): address issues from smoke testing"
+```
+
+(Skip this step if no fixups are needed.)

--- a/docs/plans/2026-02-27-rendering-alignment-analysis.md
+++ b/docs/plans/2026-02-27-rendering-alignment-analysis.md
@@ -1,0 +1,415 @@
+# Rendering System: Research Alignment Analysis
+
+Date: 2026-02-27
+Status: Draft
+Inputs: `2026-02-27-advanced-rendering.md`, `2026-02-20-terminal-ui-design.md`, current codebase
+
+## TL;DR
+
+The advanced rendering research doc describes a **general-purpose JSONL event bus + renderer** — a reusable engine for any CLI that runs parallel tasks. The current sdf codebase has a **single ad-hoc implementation** of the same idea (`orderedPrinter` in `sync.go`). The gap is large but well-defined: the research describes a separate module, and the current code confirms there's exactly one consumer ready to adopt it.
+
+**Recommendation: Build it as `internal/render` — a separate internal package**, not an external module. It maps cleanly onto sdf's existing architecture without requiring a public API contract. Extract it to a standalone module later if other projects want it.
+
+---
+
+## 1. Data Flow: What Carries What
+
+**JSONL is a serialization format for persistence and external output. It is never used for in-process communication.** The in-process bus uses typed Go structs over channels.
+
+```
+                          In-process (Go structs over channels)
+                         ┌──────────────────────────────────────────────┐
+                         │                                              │
+  goroutine 1 ─→ Reporter ─→ chan Event ─→ Router ─→ Renderer ─→ terminal (styled)
+  goroutine 2 ─→ Reporter ─┘               │
+  goroutine N ─→ Reporter ─┘               │
+                                            │  side-effect (serialization only)
+                                            ├─→ json.Encoder ─→ .sdf/logs/*.jsonl
+                                            │
+                                            └─→ (--json mode) JSON Renderer ─→ stdout
+```
+
+Three distinct boundaries:
+
+| Boundary | Transport | Format |
+|---|---|---|
+| **goroutine → Router** | `chan render.Event` (buffered Go channel) | Go structs — `render.Event`, `render.TaskRef`, etc. |
+| **Router → Renderer** | Direct function call or channel | Go structs — same `render.Event` |
+| **Router → Log file** | `json.Encoder` writing to `io.Writer` | JSONL (one JSON object per line) |
+| **JSON Renderer → stdout** | `json.Encoder` or `json.Marshal` | JSON (see `--json` mode below) |
+
+The Event struct is the single source of truth. JSONL is just one way to serialize it — used only when crossing process boundaries (log files, piped stdout, agent consumption).
+
+---
+
+## 2. What the Research Describes vs. What Exists Today
+
+| Concern | Research Doc (advanced-rendering) | Current Implementation |
+|---|---|---|
+| **Event schema** | Typed JSONL envelope (`task.start`, `task.progress`, `task.log`, `task.end`) with versioning, ordering, routing | None — `fmt.Printf` and `ui.SymOK` strings printed inline |
+| **Concurrency model** | errgroup fan-out → per-task Reporter → bounded channel → Router → Renderer | `sync.WaitGroup` + `orderedPrinter` (mutex + indexed slots) in `sync.go` only |
+| **Backpressure** | Progress = "latest wins" (droppable), lifecycle edges = never drop, `renderer.notice` counters | None — `orderedPrinter.set()` always succeeds (unbounded slice) |
+| **Terminal control** | Double-buffered diff renderer with CUP/EL/ED, alternate screen, Unicode width | `\r\033[K` on a single progress line; all other output is append-only `fmt.Print` |
+| **Rendering modes** | Full-screen (alt buffer) and inline (sticky footer) | Inline only — single `\r\033[K` line at bottom |
+| **JSONL persistence** | Router tees events to `.sdf/logs/` as serialized JSONL for replay/debugging (side-effect, not communication) | No event persistence; spy recording captures git/gh/claude invocations but not UI events |
+| **`--json` output** | Not explicitly addressed (research doc focuses on event streaming) | `--json` flag on `pr`/`new`/`config` outputs command-specific result objects |
+| **Resize handling** | `SIGWINCH` + `term.GetSize` → force full redraw | No resize handling |
+| **Error recovery** | Restore cursor/alt screen on panic; emit `task.error` consistently | Errors return up call stack; no terminal state cleanup |
+
+### Where They Already Align
+
+1. **Parallel execution, sequential display.** The terminal-ui-design doc's core rule #2 ("fire goroutines concurrently but display results in order") matches the research doc's renderer-managed slots. `orderedPrinter` is a minimal implementation of this exact pattern.
+
+2. **One line per action.** Both documents agree on the output density — one semantic line per task outcome. The research doc's `task.end` events map 1:1 to `orderedPrinter`'s result strings.
+
+3. **Semantic symbols.** The existing `ui.SymOK/SymFail/SymConflict/SymWarn/SymPlan` set maps directly to the `task.end.status` field values (`succeeded/failed/conflict/warning/planned`).
+
+4. **Single writer rule.** `orderedPrinter` already ensures only one goroutine flushes to the terminal (via mutex + `finish()`). The research doc formalizes this as the renderer being "the sole writer."
+
+---
+
+## 3. Gap Analysis: What's Missing
+
+### Gap 1: No Event Bus (the core abstraction)
+
+Today, commands interleave `fmt.Printf` calls between git/gh operations. There's no intermediate representation — output is generated inline with execution.
+
+**What it takes:**
+- Define the `Event` struct (the research doc provides complete Go code)
+- Create a `Reporter` that wraps a `chan<- Event` with convenience methods (`Start`, `Progress`, `LogLine`, `End`)
+- Commands create tasks and call reporter methods instead of `fmt.Printf`
+
+**Effort:** Small. The struct definitions and reporter are ~100 lines. The research doc provides working code.
+
+### Gap 2: No Router/Renderer Separation
+
+There's no component that:
+- Assigns global sequence numbers
+- Applies coalescing (latest-wins for progress)
+- Manages terminal layout (slot assignment)
+- Drives a tick-based render loop
+
+**What it takes:**
+- A `Router` goroutine that reads from the event channel, assigns seq, optionally persists to JSONL, and forwards to the renderer
+- A `Renderer` that maintains a frame buffer and diffs on tick (10-20 Hz)
+
+**Effort:** Medium. The router is ~150 lines. The renderer depends on scope — the research doc's minimal line-buffer renderer is ~100 lines; adding lipgloss styling and multi-region layout adds more.
+
+### Gap 3: No Command Orchestration Layer
+
+Each `Run*` function directly calls git/gh functions and prints. There's no "task plan → execute tasks → collect results" separation.
+
+**What it takes:**
+- Each command defines its work as a list of `TaskSpec` (id, name, function)
+- An orchestrator runs them via errgroup with a Reporter per task
+- Results flow back through the event bus to the renderer
+
+**Effort:** This is the big one. It requires refactoring each command's execution path. But not all commands need it — only commands with parallelizable work benefit (see Section 4).
+
+### Gap 4: No JSONL Persistence
+
+The spy recording system already captures git/gh/claude invocations as JSONL — but only under the `spyrecord` build tag for testing. UI events are never captured.
+
+**What it takes:**
+- The router tees events to a file writer (the research doc's `json.Encoder` approach)
+- Write to `.sdf/logs/<run-id>.jsonl`
+
+**Effort:** Trivial once the router exists — it's a single `tee` from the router's output.
+
+---
+
+## 4. Separate Module vs. Internal Package
+
+### Option A: `internal/render` (Recommended)
+
+```
+internal/
+  render/
+    event.go      — Event, TaskRef, RunRef structs (Go types, not JSON schemas)
+    reporter.go   — Per-task Reporter with Start/Progress/Log/End (writes to chan Event)
+    bus.go        — Orchestrator: wires reporters → router → renderer via channels
+    router.go     — Global seq assignment, fans out to renderer + log writer
+    renderer.go   — Renderer interface + TTY renderer (append-only, lipgloss styled)
+    json.go       — JSON Renderer: collects task.end events, emits result object (--json)
+    log.go        — JSONL log writer: serializes events to .sdf/logs/ (persistence only)
+```
+
+**Pros:**
+- No public API contract to maintain — free to iterate
+- Natural fit: `cmd/*` already imports `internal/*`
+- Can use `internal/ui` styles directly (lipgloss, symbols)
+- The spy recording pattern (`record_noop.go` / `record_spy.go`) is already per-package in `internal/`
+
+**Cons:**
+- Can't reuse in other projects without extracting later
+- Tightly coupled to sdf's conventions (but that's fine for now)
+
+### Option B: Standalone Go Module (`github.com/pavelpascari/termrender`)
+
+**Pros:**
+- Reusable across projects
+- Forced clean API boundary
+- Could attract community contributions
+
+**Cons:**
+- Premature — the API isn't validated yet
+- Semver pressure: breaking changes require major version bumps
+- Extra repo, CI, releases to manage
+- The research doc's schema is comprehensive but untested — iterating on it is easier inside sdf
+
+### Option C: `internal/render` now, extract later
+
+Start with Option A. Once the API stabilizes after 2-3 commands use it, extract to a standalone module. This is the Go community's standard advice: "a little copying is better than a little dependency."
+
+**Recommendation: Option C** (start with A, plan for extraction).
+
+---
+
+## 5. Which Commands Benefit and When
+
+Not all commands need the full event bus. Categorize by parallelism potential:
+
+### High Value (parallel work today or imminent)
+
+| Command | Current Parallelism | Rendering Gain |
+|---|---|---|
+| `sync` | Partial (PR content updates via `orderedPrinter`) | Full pipeline: rebase tasks could report progress, conflict prompts interleave with status |
+| `status` | None, but fetches + fast-forwards base | Could fetch PR state in parallel with base fast-forward |
+| `merge` | Planned — merge head, sync, repeat | Natural task pipeline: merge → sync → repeat, each step reported |
+
+### Medium Value (sequential but would benefit from structured output)
+
+| Command | Why |
+|---|---|
+| `pr` | Push + create + nav update are serial but distinct steps; event stream enables `--json` event mode for agents |
+| `fetch` / `register` | PR discovery + reconciliation are distinct phases |
+
+### Low Value (keep as-is)
+
+| Command | Why |
+|---|---|
+| `branch`, `new`, `switch` | Single fast operation, no parallelism needed |
+| `config`, `init`, `doctor` | Diagnostic/setup — simple append-only output is fine |
+
+### Suggested Adoption Order
+
+1. **Start with `sync`** — it already has `orderedPrinter` and the most complex output. Migrate `orderedPrinter` into `internal/render/ordered.go`, then gradually wire the event bus into the sync pipeline.
+2. **Then `status`** — it benefits from parallel PR fetching and is a read-only command (safe to experiment with).
+3. **Then `merge`** — the planned command will need the orchestration layer from day one.
+
+---
+
+## 6. `--json` Mode: How It Works
+
+The `--json` flag doesn't change the bus or the router. It swaps the **renderer**.
+
+There are three renderer implementations, selected at bus creation:
+
+### TTY Renderer (default)
+
+Styled append-only output. Consumes events from the router, prints one line per task outcome using lipgloss/symbols. Drives the `\r\033[K` progress counter during parallel work. This is what `orderedPrinter` does today.
+
+### JSON Renderer (`--json` flag)
+
+A **collecting renderer**. It silently accumulates `task.end` events and, when the bus finishes, outputs a single JSON result object to stdout. No progress lines, no styled output — just the final result.
+
+The JSON renderer does **not** emit JSONL event streams. It produces a command-specific result object, consistent with existing `--json` behavior (`sdf pr --json` → `PRResult`, `sdf new --json` → `NewResult`).
+
+Example for `sdf sync --json`:
+
+```json
+{
+  "stack": "my-feature",
+  "base": "main",
+  "tasks": [
+    {
+      "branch": "feature-1",
+      "pr": 142,
+      "action": "skip",
+      "status": "merged"
+    },
+    {
+      "branch": "feature-2",
+      "pr": 143,
+      "action": "rebase",
+      "status": "succeeded"
+    },
+    {
+      "branch": "feature-3",
+      "pr": 144,
+      "action": "rebase",
+      "status": "failed",
+      "error": "conflict in auth.go"
+    }
+  ],
+  "prs_updated": 2
+}
+```
+
+**How it works internally:**
+
+```go
+type JSONRenderer struct {
+    results []TaskResult  // accumulated from task.end events
+}
+
+func (r *JSONRenderer) HandleEvent(ev render.Event) {
+    if ev.Type == "task.end" {
+        r.results = append(r.results, taskResultFrom(ev))
+    }
+    // All other events (progress, log) are silently consumed
+}
+
+func (r *JSONRenderer) Finish() error {
+    // Command wraps r.results in its own result struct
+    // e.g. SyncResult{Stack: "...", Tasks: r.results}
+    return json.NewEncoder(os.Stdout).Encode(result)
+}
+```
+
+The command owns the result shape — the JSON renderer collects raw task outcomes, and the command's `Run*` function wraps them into its specific result struct before encoding.
+
+### JSONL Log (not a renderer — a router side-effect)
+
+The JSONL log file (`.sdf/logs/*.jsonl`) is **always written** regardless of output mode. It captures every event (start, progress, log, end) as a JSON line. This is a side-effect of the router, not a renderer.
+
+```
+TTY mode:     Router → TTY Renderer → styled terminal
+                 └──→ .sdf/logs/run.jsonl
+
+--json mode:  Router → JSON Renderer → result JSON to stdout
+                 └──→ .sdf/logs/run.jsonl
+
+Piped/CI:     Router → TTY Renderer (plain, no color) → stdout
+                 └──→ .sdf/logs/run.jsonl
+```
+
+The JSONL log is for debugging and replay. The `--json` output is for agents and scripts. They serve different audiences and have different schemas — events vs. results.
+
+---
+
+## 7. Architectural Recommendation
+
+### Phase 1: Extract and Formalize (internal/render)
+
+```
+internal/render/
+  event.go       — Event struct + types (from research doc, simplified)
+  reporter.go    — Reporter: Start/Progress/Log/End
+  bus.go         — Buffered channel + Run() that wires reporter→router→renderer
+  renderer.go    — Renderer interface + TTY renderer (append-only, lipgloss styled)
+  json.go        — JSON Renderer (collecting mode for --json flag)
+  log.go         — JSONL log writer (router side-effect, persistence only)
+```
+
+**Do not build** the full double-buffered alt-screen renderer yet. Start with the append-only model from `terminal-ui-design.md` — it's what sdf uses today and it works. The event bus is the valuable part; the renderer can evolve independently.
+
+### Phase 2: Wire Into sync
+
+Replace `orderedPrinter` in `sync.go` with the new event bus:
+
+```go
+// Before (today)
+var wg sync.WaitGroup
+printer := newOrderedPrinter(os.Stdout, len(jobs), "Updating PR content")
+for _, j := range jobs {
+    wg.Add(1)
+    go func(j contentJob) {
+        defer wg.Done()
+        // ... do work ...
+        printer.set(j.index, result)
+    }(j)
+}
+wg.Wait()
+printer.finish()
+
+// After (with render package)
+bus := render.NewBus(os.Stdout, render.Options{
+    Mode:     render.ModeOrdered, // append-only, sequential display
+    Parallel: len(jobs),
+})
+for _, j := range jobs {
+    bus.AddTask(render.TaskSpec{
+        ID:   fmt.Sprintf("pr-%d", j.pr),
+        Name: fmt.Sprintf("PR #%d (%s)", j.pr, j.branch),
+        Fn: func(ctx context.Context, r *render.Reporter) error {
+            // ... do work, call r.LogLine(), r.Progress() ...
+            return nil
+        },
+    })
+}
+return bus.Run(ctx) // handles errgroup, rendering, cleanup
+```
+
+### Phase 3: JSONL Persistence + JSON Renderer
+
+- Router tees events to `.sdf/logs/<timestamp>.jsonl` as a side-effect (always, regardless of output mode)
+- Add `JSONRenderer` — a collecting renderer that accumulates `task.end` events and emits a single result object when `--json` is passed
+- Each command defines its own result struct; the JSON renderer provides raw task outcomes for the command to wrap
+- JSONL logs are for debugging/replay; `--json` output is for agents/scripts (different schemas, different audiences)
+
+### Phase 4: Advanced Renderer (if needed)
+
+Only build the double-buffered, multi-region, alt-screen renderer if a command genuinely needs it (e.g., a future `sdf dashboard` or long-running `sdf watch`). The append-only model covers sync/status/merge.
+
+---
+
+## 8. What to Simplify from the Research Doc
+
+The research doc is thorough but over-specified for sdf's current needs. Defer these:
+
+| Feature | Why Defer |
+|---|---|
+| Schema B (compact progress frames) | sdf won't have thousands of progress events per second |
+| Layout regions (header/tasks/log/footer) | Append-only mode doesn't need layout management |
+| Alt screen buffer | No full-screen commands planned |
+| Backpressure / coalescing | Channel buffers of 100-1000 are fine for 2-10 parallel tasks |
+| `renderer.notice` counters | Useful for debugging but not MVP |
+| `layout.assign` events | Only needed for multi-region renderers |
+| Run-level events (`run.start`) | Single-run CLI doesn't need session management |
+| Unicode width handling | Already handled by lipgloss; defer custom truncation |
+
+### Keep from the Research Doc
+
+| Feature | Why Keep |
+|---|---|
+| Event struct with type + task + data | Core abstraction — enables everything else |
+| Reporter pattern | Clean API for commands to emit events |
+| errgroup-based orchestrator | Better than raw WaitGroup — cancellation + error propagation |
+| JSONL persistence (router side-effect) | Debugging/replay value is immediate; trivial to implement |
+| JSON Renderer (`--json` collecting mode) | Agent compatibility — same pattern as existing `PRResult`/`NewResult` |
+| Per-task seq for ordering | Needed for ordered display |
+
+---
+
+## 9. Dependency Impact
+
+### New Dependencies: None
+
+Everything needed is already in the dependency tree:
+- `encoding/json` — stdlib
+- `sync`, `context` — stdlib
+- `golang.org/x/sync/errgroup` — already used via charm ecosystem (check `go.sum`)
+- `charmbracelet/lipgloss` — already a dependency
+- `golang.org/x/term` — already a dependency (via huh/lipgloss)
+
+### Files Touched
+
+Phase 1 (new package): 4-5 new files in `internal/render/`
+Phase 2 (wire sync): `cmd/sync.go` — replace `orderedPrinter` block (~40 lines changed)
+Phase 3 (persistence): `internal/render/format.go` + minor router addition
+
+---
+
+## 10. Summary
+
+The research document is a **solid reference architecture** for the problem space. It over-specifies for sdf's immediate needs but that's correct for a research document — it maps the full territory.
+
+The practical path is:
+
+1. Build `internal/render` with the event struct + reporter + TTY renderer (append-only)
+2. Wire it into `sync` (replacing `orderedPrinter`)
+3. Add JSONL log persistence (router side-effect) + JSON collecting renderer (`--json`)
+4. Let the API stabilize across 2-3 commands before considering extraction
+
+The core insight from both documents is the same: **separate event production from rendering**. The event bus (Go structs over channels) is the valuable abstraction. The renderer is pluggable — start simple (append-only), evolve as needed. JSONL is a serialization detail for persistence and debugging, never the in-process communication mechanism.


### PR DESCRIPTION
<!-- sdf:description -->
Adds comprehensive research, design, and implementation planning for the new `internal/render` package — a JSONL-driven event bus and pluggable terminal renderer for parallel CLI task execution. The research doc surveys the terminal rendering landscape (ANSI control sequences, double-buffering, Unicode width handling, Go concurrency patterns) and defines a typed event protocol. The design doc distills this into a practical architecture for sdf: a Bus orchestrator with Run/RunBatch, TTYRenderer with batch and sequential modes, JSONRenderer for `--json` output, and JSONL log persistence. The implementation plan provides a task-by-task TDD breakdown across 9 tasks, from core types through wiring into `sync.go` to replace the existing `orderedPrinter`. This lays the groundwork for structured, parallel-aware rendering across all sdf commands.
<!-- /sdf:description -->

Research doc for JSONL-driven terminal rendering, alignment analysis mapping it to sdf's current architecture, approved design for internal/render package, and step-by-step TDD implementation plan.

<!-- sdf:stack-nav -->
---
Stack: `rdr`
1. https://github.com/pavelpascari/sdf/pull/100 ◀ this PR
2. https://github.com/pavelpascari/sdf/pull/98
3. https://github.com/pavelpascari/sdf/pull/101
4. https://github.com/pavelpascari/sdf/pull/99
5. https://github.com/pavelpascari/sdf/pull/104
6. https://github.com/pavelpascari/sdf/pull/105
7. https://github.com/pavelpascari/sdf/pull/106
8. https://github.com/pavelpascari/sdf/pull/107
9. https://github.com/pavelpascari/sdf/pull/108
10. https://github.com/pavelpascari/sdf/pull/109
11. https://github.com/pavelpascari/sdf/pull/110
12. https://github.com/pavelpascari/sdf/pull/111
13. https://github.com/pavelpascari/sdf/pull/112
14. https://github.com/pavelpascari/sdf/pull/113
15. https://github.com/pavelpascari/sdf/pull/114
16. https://github.com/pavelpascari/sdf/pull/115
17. https://github.com/pavelpascari/sdf/pull/116
18. https://github.com/pavelpascari/sdf/pull/117
19. https://github.com/pavelpascari/sdf/pull/118
20. https://github.com/pavelpascari/sdf/pull/119
21. https://github.com/pavelpascari/sdf/pull/120
22. https://github.com/pavelpascari/sdf/pull/121
23. https://github.com/pavelpascari/sdf/pull/123
<!-- /sdf:stack-nav -->