### PR TITLE
fix(ci): trigger goreleaser from release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,5 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger release workflow
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+        run: gh workflow run release.yml --ref "$TAG_NAME"


### PR DESCRIPTION
## Summary
- GITHUB_TOKEN-created tag pushes don't trigger other workflows by GitHub's design, so GoReleaser never ran for v0.2.2–v0.2.7
- Added explicit `workflow_dispatch` trigger to `release.yml` when release-please creates a release
- Backfilled all missing releases (v0.2.2–v0.2.7) manually

## Test plan
- [ ] Verify v0.2.2–v0.2.7 release workflow runs complete with binaries
- [ ] Next release-please merge should automatically trigger GoReleaser

🤖 Generated with [Claude Code](https://claude.com/claude-code)