### PR TITLE
fix(ci): pass -R flag to gh workflow run in release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,4 +29,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ steps.release.outputs.tag_name }}
-        run: gh workflow run release.yml --ref "$TAG_NAME"
+        run: gh workflow run release.yml --ref "$TAG_NAME" -R "${{ github.repository }}"


### PR DESCRIPTION
## Summary
- The release-please workflow's "Trigger release workflow" step fails with `fatal: not a git repository` because the job never checks out the repo
- Add `-R ${{ github.repository }}` so `gh` knows which repo to dispatch to without needing a local git clone

## Test plan
- [ ] Merge, then trigger a release (or wait for release-please to create one)
- [ ] Verify the "Trigger release workflow" step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)