### PR TITLE
fix(ci): add actions:write permission for workflow dispatch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,7 @@ on:
       - main
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 


### PR DESCRIPTION
## Summary
- The release-please workflow's "Trigger release workflow" step fails with `HTTP 403: Resource not accessible by integration` because `GITHUB_TOKEN` lacks `actions: write` permission
- Add `actions: write` to the workflow's permissions block

## Test plan
- [ ] Merge and trigger a release
- [ ] Verify the "Trigger release workflow" step dispatches successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)