### PR TITLE
fix: use datePublished in release checklist script

### DIFF
--- a/scripts/release-checklist.sh
+++ b/scripts/release-checklist.sh
@@ -47,7 +47,7 @@ if [[ -z "$RELEASE_POST" ]]; then
   echo "  ---"
   echo "  title: \"SDF v${VERSION}\""
   echo "  description: \"...\""
-  echo "  date: $(date +%Y-%m-%d)"
+  echo "  datePublished: $(date +%Y-%m-%d)"
   echo "  tags: [release]"
   echo "  version: \"${VERSION}\""
   echo "  ---"
@@ -56,7 +56,7 @@ fi
 
 # ── Validate the post has the required fields ───────────────────────
 MISSING=""
-for field in title description date; do
+for field in title description datePublished; do
   if ! grep -q "^${field}:" "$RELEASE_POST" 2>/dev/null; then
     MISSING="${MISSING} ${field}"
   fi


### PR DESCRIPTION
## Summary
- Release checklist script checks for `date:` in blog post frontmatter, but posts use `datePublished:`
- Also fixes the example frontmatter in the error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)