### PR TITLE
feat(prnav): add sdf attribution note to stack navigation

### DIFF
--- a/cmd/prnav.go
+++ b/cmd/prnav.go
@@ -48,6 +48,7 @@ func buildStackNav(s *stack.Stack, prs map[int]ghpkg.PRInfo, currentBranch strin
 		b.WriteString("\n")
 	}
 
+	b.WriteString("\n<sub>This stack is managed with [sdf](https://stacked-diffs-flow.com).</sub>\n")
 	b.WriteString(stackNavClose)
 	return b.String()
 }

--- a/cmd/testdata/stacknav_three_branches.golden
+++ b/cmd/testdata/stacknav_three_branches.golden
@@ -4,4 +4,6 @@ Stack: `auth-feature`
 1. https://github.com/test/repo/pull/10
 2. https://github.com/test/repo/pull/11 ◀ this PR
 3. https://github.com/test/repo/pull/12
+
+<sub>This stack is managed with [sdf](https://stacked-diffs-flow.com).</sub>
 <!-- /sdf:stack-nav -->

--- a/cmd/testdata/stacknav_with_merged.golden
+++ b/cmd/testdata/stacknav_with_merged.golden
@@ -4,4 +4,6 @@ Stack: `payments`
 1. https://github.com/test/repo/pull/20
 2. https://github.com/test/repo/pull/21 ◀ this PR
 3. pay/ui
+
+<sub>This stack is managed with [sdf](https://stacked-diffs-flow.com).</sub>
 <!-- /sdf:stack-nav -->


### PR DESCRIPTION
Every PR's stack navigation section now includes a small note linking
to stacked-diffs-flow.com, helping contributors discover sdf.

https://claude.ai/code/session_01KnXpqHoEKBeC9hTn65X2Ki