### PR TITLE
chore: remove remaining sdf context command references from design docs

### DIFF
--- a/PLAN-pr-splitting.md
+++ b/PLAN-pr-splitting.md
@@ -318,9 +318,8 @@ Starting Claude Code session with stack context...
 
 This works by:
 1. Completing the split
-2. Writing context docs for each layer (`.sdf/context/<layer>.md`)
-3. Launching `claude` with `sdf context show` piped in as initial context
-4. The session name is deterministic: `split-<stack_name>` so it's resumable
+2. Launching `claude` with the split plan piped in as initial context
+3. The session name is deterministic: `split-<stack_name>` so it's resumable
 
 ---
 
@@ -453,19 +452,17 @@ func EditPlan(plan *Plan) (*Plan, error) {
 }
 ```
 
-### Phase 4: PR Creation and Context
+### Phase 4: PR Creation
 
 After execution, for each layer:
-1. Create a context doc (`.sdf/context/<stack>/<layer>.md`) with the description
-2. Run `sdf pr` to create the GitHub PR with the context doc as body
-3. Update stack navigation links across all PRs
+1. Run `sdf pr` to create the GitHub PR with the layer description as body
+2. Update stack navigation links across all PRs
 
 ### Phase 5: Session Continuity (--session flag)
 
 After split + PR creation:
-1. Assemble full stack context via `sdf context show`
-2. Launch `claude --session split-<stack_name>` with the context piped in
-3. The session inherits awareness of all layers
+1. Launch `claude --session split-<stack_name>` with the split plan piped in as context
+2. The session inherits awareness of all layers
 
 ---
 

--- a/SPLIT-DESIGN.md
+++ b/SPLIT-DESIGN.md
@@ -306,7 +306,6 @@ Creates a new `.sdf/stacks/<name>.json` with the split stack topology. This mean
 - `sdf status` shows the new stack
 - `sdf sync` cascade-rebases if any PR is amended
 - `sdf merge` merges the head PR and shifts the stack
-- Context docs can be added to each branch
 
 -----
 
@@ -473,7 +472,6 @@ The split creates a standard sdf stack. After splitting:
 | `sdf sync` | Cascade-rebases if any PR in the split is amended |
 | `sdf merge` | Merges the head PR and shifts the stack forward |
 | `sdf pr` | Works on new branches added to the split stack |
-| `sdf context` | Context docs can be created for each split branch |
 | `sdf switch` | Navigate between split branches |
 
 The original branch remains as a reference. The user can delete it when satisfied with the split, or keep it indefinitely.
@@ -583,4 +581,4 @@ Following existing patterns:
 
 4. **Relationship to original branch** — After a successful split, should the tool suggest deleting the original branch? Or keep it as a permanent reference? Current design: keep it, let the user decide.
 
-5. **Config options** — What should be configurable? Candidates: minimum PR size threshold, default validation mode (ship vs local), branch naming pattern, whether to auto-create context docs for split branches.
+5. **Config options** — What should be configurable? Candidates: minimum PR size threshold, default validation mode (ship vs local), branch naming pattern.


### PR DESCRIPTION
The sdf context feature was removed several versions back. This cleans
up the remaining references in PLAN-pr-splitting.md and SPLIT-DESIGN.md
that still mentioned `sdf context show`, `.sdf/context/` paths, and
context doc creation.

https://claude.ai/code/session_015DaeJtjDq3MowTDrvapvWt