### PR TITLE
fix(sdf status): Optimize PRList to scope search by branch name

### DIFF
--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -63,11 +63,33 @@ func Version() (string, error) {
 }
 
 // PRList returns PR information for the given branches.
+// It uses GitHub search qualifiers to scope the query to only the requested
+// branches, avoiding a full scan of all repository PRs.
 func PRList(branches []string) ([]PRInfo, error) {
+	if len(branches) == 0 {
+		return nil, nil
+	}
+
+	// Build a search query that scopes to only the branches we need.
+	// GitHub search supports: head:branch1 OR head:branch2 ...
+	searchParts := make([]string, len(branches))
+	for i, b := range branches {
+		searchParts[i] = "head:" + b
+	}
+	searchQuery := strings.Join(searchParts, " ")
+
+	// Use a limit proportional to the number of branches (with headroom for
+	// duplicate PRs per branch, e.g. closed + reopened).
+	limit := len(branches) * 3
+	if limit < 10 {
+		limit = 10
+	}
+
 	out, err := run("pr", "list",
 		"--state", "all",
 		"--json", "number,headRefName,state,baseRefName,url,statusCheckRollup,reviewDecision,mergeable,isDraft",
-		"--limit", "100",
+		"--search", searchQuery,
+		"--limit", fmt.Sprintf("%d", limit),
 	)
 	if err != nil {
 		return nil, err
@@ -78,7 +100,8 @@ func PRList(branches []string) ([]PRInfo, error) {
 		return nil, fmt.Errorf("cannot parse gh pr list output: %w", err)
 	}
 
-	// Filter to only branches we care about
+	// Filter to only branches we care about (safety net — the search query
+	// should already scope results, but GitHub search can be fuzzy).
 	branchSet := make(map[string]bool)
 	for _, b := range branches {
 		branchSet[b] = true

--- a/internal/gh/gh_test.go
+++ b/internal/gh/gh_test.go
@@ -32,8 +32,10 @@ func TestPRList_ParsesJSON(t *testing.T) {
 	if len(log) != 1 {
 		t.Fatalf("expected 1 invocation, got %d", len(log))
 	}
-	if log[0] != "pr list --state all --json number,headRefName,state,baseRefName,url,statusCheckRollup,reviewDecision,mergeable,isDraft --limit 100" {
-		t.Errorf("unexpected arguments: %s", log[0])
+	// Should use --search with head: qualifiers to scope the query
+	expected := "pr list --state all --json number,headRefName,state,baseRefName,url,statusCheckRollup,reviewDecision,mergeable,isDraft --search head:feat/a head:feat/b head:feat/c --limit 10"
+	if log[0] != expected {
+		t.Errorf("unexpected arguments:\n  got:  %s\n  want: %s", log[0], expected)
 	}
 
 	// Check parsed data
@@ -92,6 +94,25 @@ func TestPRList_KeepsBestState(t *testing.T) {
 	}
 	if prs[0].Number != 2 {
 		t.Errorf("expected PR #2 (OPEN wins over CLOSED), got #%d", prs[0].Number)
+	}
+}
+
+func TestPRList_EmptyBranches(t *testing.T) {
+	// PRList with no branches should return nil without calling gh
+	prs, err := PRList(nil)
+	if err != nil {
+		t.Fatalf("PRList(nil) failed: %v", err)
+	}
+	if prs != nil {
+		t.Fatalf("expected nil, got %v", prs)
+	}
+
+	prs, err = PRList([]string{})
+	if err != nil {
+		t.Fatalf("PRList([]) failed: %v", err)
+	}
+	if prs != nil {
+		t.Fatalf("expected nil, got %v", prs)
 	}
 }
 


### PR DESCRIPTION
PRList previously ran `gh pr list --state all --limit 100` which fetched up to 100 PRs from the entire repo and filtered client-side. On large repos with many PRs this made commands like `sdf status` noticeably slow.

Now uses `--search head:branch1 head:branch2 ...` to let GitHub's API filter server-side, and scales the --limit proportionally to branch count instead of a fixed 100. Client-side filtering retained as a safety net.

https://claude.ai/code/session_01XkLkaqJu4ypJEdyk3Riasw