### PR TITLE
fix: handle gh merge delete-branch 404 as non-fatal

### DIFF
--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -234,8 +234,17 @@ func PREditTitle(prNumber int, title string) error {
 // PRMerge merges a PR using the specified method ("squash", "merge", or "rebase").
 // Also deletes the remote branch after merging.
 func PRMerge(prNumber int, method string) error {
-	_, err := run("pr", "merge", fmt.Sprintf("%d", prNumber),
+	out, err := run("pr", "merge", fmt.Sprintf("%d", prNumber),
 		"--"+method, "--delete-branch")
+	if err != nil {
+		// If merge succeeded but remote branch deletion returned 404, treat it
+		// as success: the branch is already gone, which is the desired state.
+		if strings.Contains(out, "failed to delete remote branch") &&
+			(strings.Contains(out, "HTTP 404") || strings.Contains(out, "Reference does not exist")) {
+			return nil
+		}
+		return err
+	}
 	return err
 }
 

--- a/internal/gh/gh_test.go
+++ b/internal/gh/gh_test.go
@@ -202,6 +202,27 @@ func TestPRMerge_Arguments(t *testing.T) {
 	}
 }
 
+func TestPRMerge_IgnoresDeleteBranch404(t *testing.T) {
+	dir := t.TempDir()
+	fake := testutil.FakeBinFail(t, dir, "gh",
+		"failed to delete remote branch feat/auth: HTTP 404: Reference does not exist")
+	testutil.SetBinary(t, &Binary, fake)
+
+	if err := PRMerge(42, "squash"); err != nil {
+		t.Fatalf("PRMerge should ignore delete-branch 404, got: %v", err)
+	}
+}
+
+func TestPRMerge_PropagatesOtherErrors(t *testing.T) {
+	dir := t.TempDir()
+	fake := testutil.FakeBinFail(t, dir, "gh", "GraphQL: Pull request is not mergeable")
+	testutil.SetBinary(t, &Binary, fake)
+
+	if err := PRMerge(42, "squash"); err == nil {
+		t.Fatal("expected PRMerge to return error for non-404 failures")
+	}
+}
+
 func TestPRViewBody_ParsesJSON(t *testing.T) {
 	dir := t.TempDir()
 	// PRViewBody uses "pr view" prefix — the canonical default is the full


### PR DESCRIPTION
## Summary
- handle  failures where remote branch deletion returns HTTP 404
- treat this case as success because the branch is already deleted
- add unit tests to verify 404 is ignored and non-404 errors are still returned

Fixes #165