### PR TITLE
fix: filter deleted branches from shell completions

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -239,10 +239,20 @@ func completeStackBranches(_ *cobra.Command, args []string, _ string) ([]string,
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
+
+	localBranches, err := gitpkg.LocalBranches()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	localSet := make(map[string]bool, len(localBranches))
+	for _, b := range localBranches {
+		localSet[b] = true
+	}
+
 	var branches []string
 	for _, s := range stacks {
 		for _, n := range s.Nodes {
-			if n.Status != "merged" {
+			if n.Status != "merged" && localSet[n.Branch] {
 				branches = append(branches, n.Branch)
 			}
 		}

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -10,6 +11,17 @@ import (
 	"github.com/pavelpascari/sdf/internal/stack"
 	"github.com/spf13/cobra"
 )
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %s", strings.Join(args, " "), string(out))
+	}
+	return strings.TrimSpace(string(out))
+}
 
 func TestCompleteStackNames(t *testing.T) {
 	dir := newTestRepo(t)
@@ -60,6 +72,9 @@ func TestCompleteStackBranches(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	runGit(t, dir, "checkout", "-b", "my-feature/db-schema")
+	runGit(t, dir, "checkout", "-b", "my-feature/api")
+
 	branches, directive := completeStackBranches(nil, nil, "")
 	if directive != cobra.ShellCompDirectiveNoFileComp {
 		t.Errorf("expected ShellCompDirectiveNoFileComp, got %d", directive)
@@ -79,6 +94,40 @@ func TestCompleteStackBranches(t *testing.T) {
 	}
 	if found["my-feature/merged-one"] {
 		t.Error("merged branches should not be suggested")
+	}
+}
+
+func TestCompleteStackBranches_SkipsDeletedBranches(t *testing.T) {
+	dir := newTestRepo(t)
+
+	s := &stack.Stack{
+		StackID: "my-feature",
+		Base:    "main",
+		Nodes: []stack.Node{
+			{Branch: "my-feature/existing", Status: "open"},
+			{Branch: "my-feature/deleted", Status: "open"},
+		},
+	}
+	if err := stack.Init(dir, "my-feature", "main"); err != nil {
+		t.Fatal(err)
+	}
+	if err := stack.Save(dir, s); err != nil {
+		t.Fatal(err)
+	}
+
+	runGit(t, dir, "checkout", "-b", "my-feature/existing")
+	runGit(t, dir, "checkout", "main")
+	runGit(t, dir, "checkout", "-b", "my-feature/deleted")
+	runGit(t, dir, "checkout", "main")
+	runGit(t, dir, "branch", "-D", "my-feature/deleted")
+
+	branches, directive := completeStackBranches(nil, nil, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("expected ShellCompDirectiveNoFileComp, got %d", directive)
+	}
+
+	if len(branches) != 1 || branches[0] != "my-feature/existing" {
+		t.Fatalf("expected only existing branch, got %v", branches)
 	}
 }
 

--- a/www/src/data/cli-reference.json
+++ b/www/src/data/cli-reference.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-03-02T16:56:33Z",
+  "generated": "2026-03-02T23:01:51Z",
   "commands": [
     {
       "name": "ai",


### PR DESCRIPTION
## Summary
- filter   e2e  (base: main)
     e2e_e2e

  feature-split  (base: main)
     feature-split/1-design-docs
     feature-split/2-build-config
     feature-split/3-git-and-claude-helpers
     feature-split/4-split-plan-parsing
     feature-split/5-split-hunk-parsing
     feature-split/6-split-ai-analysis
     feature-split/7-split-execution
     feature-split/8-split-command
     feature-split/9-split-iteration-docs

  fix-goreleaser  (base: main)
     fix-goreleaser_fix-goreleaser

  fix-release-checklist-yaml  (base: main)
     fix-release-checklist-yaml_fix-release-checklist-yaml

  git-hooks  (base: claude/sdf-new-instead-init-cPTKJ)
     git-hooks/git-hooks

  pr-dx-cleanup  (base: main)
     pr-dx/cleanup
     pr-dx/pr-create
     pr-dx/pr-update
     claude/explore-go-cli-libraries-1yaVE
     pr-dx-cleanup/terminal-ui

  rdr  (base: main)
     rdr_rdr
     rdr_render-package
     rdr_bus-evolution
     rdr_sync-render-integration
     rdr_sync-json-mode
     rdr_status-bus
     rdr_status-json
     rdr_merge-bus
     rdr_merge-json
     rdr_branch-bus
     rdr_branch-json
     rdr_fetch-bus
     rdr_fetch-json
     rdr_switch-bus
     rdr_switch-json
     rdr_doctor-bus
     rdr_doctor-json
     rdr_config-bus
     rdr_config-json
     rdr_move-bus
     rdr_move-json
     rdr_ci-status
     rdr_mergeability

  releases  (base: main)
     releases_releases
     releases_changelog-sections

  stack-resilience  (base: main)
     stack-resilience/merge
     stack-resilience/reconcile
     stack-resilience/sync-reconcile
     stack-resilience/insert-branch
     stack-resilience/drift-status

  sync-scoping  (base: main)
     sync-scoping_sync-scoping
     sync-scoping_foo/stack branch completions against actual local git branches
- keep merged branches excluded as before
- add regression test for stale stack metadata where branch was deleted

Fixes #161