### PR TITLE
fix: handle empty branch before creating PR

### DIFF
--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -59,6 +59,9 @@ func runPR(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Determine base branch
+	base := s.ParentBranch(branch)
+
 	node := s.FindNode(branch)
 	if node == nil {
 		return fmt.Errorf("branch %q is not in stack %q — run `sdf branch` to add it", branch, s.StackID)
@@ -66,6 +69,14 @@ func runPR(cmd *cobra.Command, args []string) error {
 
 	if node.PR > 0 {
 		return fmt.Errorf("branch %q already has PR #%d", branch, node.PR)
+	}
+
+	commitCount, err := gitpkg.CommitCount(base, branch)
+	if err != nil {
+		return fmt.Errorf("cannot determine commits ahead of %s: %w", base, err)
+	}
+	if commitCount == "0" {
+		return fmt.Errorf("%s has no commits ahead of %s — nothing to open a PR for", branch, base)
 	}
 
 	if !ghpkg.Available() {
@@ -77,9 +88,6 @@ func runPR(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		cfg = cfgpkg.Defaults()
 	}
-
-	// Determine base branch
-	base := s.ParentBranch(branch)
 
 	// Build default PR body
 	body := fmt.Sprintf("Part of stack: **%s**\n\nBase: `%s`", s.StackID, base)

--- a/cmd/pr_test.go
+++ b/cmd/pr_test.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	ghpkg "github.com/pavelpascari/sdf/internal/gh"
+	"github.com/pavelpascari/sdf/internal/stack"
+	"github.com/pavelpascari/sdf/internal/testutil"
+	"github.com/spf13/cobra"
+)
+
+func TestRunPR_EmptyBranchShowsFriendlyError(t *testing.T) {
+	dir := newTestRepo(t)
+
+	if err := stack.Init(dir, "my-stack", "main"); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := stack.LoadStack(dir, "my-stack")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Nodes = append(s.Nodes, stack.Node{
+		Branch: "main",
+		Status: "open",
+	})
+	if err := stack.Save(dir, s); err != nil {
+		t.Fatal(err)
+	}
+
+	fake := testutil.GHFakeBin(t, t.TempDir())
+	testutil.SetBinary(t, &ghpkg.Binary, fake)
+
+	c := &cobra.Command{}
+	c.Flags().String("title", "", "")
+	c.Flags().Bool("json", false, "")
+
+	err = runPR(c, nil)
+	if err == nil {
+		t.Fatal("expected error for empty branch")
+	}
+	if !strings.Contains(err.Error(), "has no commits ahead of") {
+		t.Fatalf("expected friendly empty-branch message, got: %v", err)
+	}
+}

--- a/www/src/data/cli-reference.json
+++ b/www/src/data/cli-reference.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-03-02T16:56:33Z",
+  "generated": "2026-03-02T23:07:27Z",
   "commands": [
     {
       "name": "ai",


### PR DESCRIPTION
## Summary
- detect when the current branch has no commits ahead of its stack base before any push or API call
- return a clear error message when there is nothing to open a PR for
- add a regression test for sdf pr empty-branch behavior

Fixes #157