### PR TITLE
chore: use content hash in generated CLI reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,8 +168,8 @@ docs:
 .PHONY: docs-check
 docs-check:
 	@echo "Checking CLI reference freshness..."
-	@go run ./cmd/docgen --no-timestamp | jq '.' > /tmp/sdf-cli-ref-check.json
-	@jq 'del(.generated)' www/src/data/cli-reference.json > /tmp/sdf-cli-ref-current.json 2>/dev/null || cp www/src/data/cli-reference.json /tmp/sdf-cli-ref-current.json
+	@go run ./cmd/docgen | jq '.' > /tmp/sdf-cli-ref-check.json
+	@jq '.' www/src/data/cli-reference.json > /tmp/sdf-cli-ref-current.json
 	@diff -q /tmp/sdf-cli-ref-check.json /tmp/sdf-cli-ref-current.json > /dev/null 2>&1 \
 		|| (echo "ERROR: CLI reference is stale. Run 'make docs' and commit." && exit 1)
 	@echo "CLI reference is up to date."

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/pavelpascari/sdf/cmd"
 	"github.com/pavelpascari/sdf/internal/config"
@@ -14,9 +14,9 @@ import (
 
 // CLIReference is the top-level JSON output structure.
 type CLIReference struct {
-	Generated  string                 `json:"generated,omitempty"`
 	Commands   []CommandDoc           `json:"commands"`
 	ConfigKeys []config.ConfigKeyMeta `json:"config_keys"`
+	Hash       string                 `json:"hash"`
 }
 
 // CommandDoc describes a single CLI command.
@@ -42,22 +42,13 @@ type FlagDoc struct {
 }
 
 func main() {
-	noTimestamp := false
-	for _, arg := range os.Args[1:] {
-		if arg == "--no-timestamp" {
-			noTimestamp = true
-		}
-	}
-
 	root := cmd.RootCmd()
 
 	ref := CLIReference{
 		Commands:   extractCommands(root),
 		ConfigKeys: config.ConfigKeys(),
 	}
-	if !noTimestamp {
-		ref.Generated = time.Now().UTC().Format(time.RFC3339)
-	}
+	ref.Hash = computeHash(ref)
 
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
@@ -65,6 +56,17 @@ func main() {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func computeHash(ref CLIReference) string {
+	clone := ref
+	clone.Hash = ""
+	data, err := json.Marshal(clone)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("%x", sum[:])
 }
 
 func extractCommands(parent *cobra.Command) []CommandDoc {

--- a/cmd/docgen/main_test.go
+++ b/cmd/docgen/main_test.go
@@ -1,0 +1,22 @@
+package main
+
+import "testing"
+
+func TestComputeHash_DeterministicAndIgnoresHashField(t *testing.T) {
+	ref := CLIReference{
+		Commands: []CommandDoc{
+			{Name: "status", Use: "status", Short: "Show status"},
+		},
+	}
+
+	h1 := computeHash(ref)
+	if h1 == "" {
+		t.Fatal("expected non-empty hash")
+	}
+
+	ref.Hash = "some-other-value"
+	h2 := computeHash(ref)
+	if h1 != h2 {
+		t.Fatalf("expected hash to ignore Hash field, got %q vs %q", h1, h2)
+	}
+}

--- a/www/src/data/cli-reference.json
+++ b/www/src/data/cli-reference.json
@@ -1,5 +1,4 @@
 {
-  "generated": "2026-03-10T20:57:15Z",
   "commands": [
     {
       "name": "ai",
@@ -19,7 +18,7 @@
     {
       "name": "branch",
       "category": "stack",
-      "use": "branch \u003cname\u003e",
+      "use": "branch <name>",
       "short": "Add a new branch to the current stack",
       "flags": [
         {
@@ -45,9 +44,9 @@
     {
       "name": "completion",
       "category": "utility",
-      "use": "completion \u003cbash|zsh|fish|powershell\u003e",
+      "use": "completion <bash|zsh|fish|powershell>",
       "short": "Generate or install shell completion scripts",
-      "long": "Generate shell completion scripts for sdf.\n\nTo load completions manually:\n\n  Bash:\n    $ sdf completion bash \u003e ~/.local/share/bash-completion/completions/sdf\n\n  Zsh:\n    $ sdf completion zsh \u003e \"${fpath[1]}/_sdf\"\n\n  Fish:\n    $ sdf completion fish \u003e ~/.config/fish/completions/sdf.fish\n\n  PowerShell:\n    PS\u003e sdf completion powershell | Out-String | Invoke-Expression\n\nOr use 'sdf completion install' to auto-detect your shell and install.",
+      "long": "Generate shell completion scripts for sdf.\n\nTo load completions manually:\n\n  Bash:\n    $ sdf completion bash > ~/.local/share/bash-completion/completions/sdf\n\n  Zsh:\n    $ sdf completion zsh > \"${fpath[1]}/_sdf\"\n\n  Fish:\n    $ sdf completion fish > ~/.config/fish/completions/sdf.fish\n\n  PowerShell:\n    PS> sdf completion powershell | Out-String | Invoke-Expression\n\nOr use 'sdf completion install' to auto-detect your shell and install.",
       "subcommands": [
         {
           "name": "install",
@@ -65,7 +64,7 @@
       "subcommands": [
         {
           "name": "set",
-          "use": "set \u003ckey\u003e \u003cvalue\u003e",
+          "use": "set <key> <value>",
           "short": "Set a configuration value",
           "example": "  sdf config set branch_prefix.enabled true\n  sdf config set --global pr_title.conventional_commits true",
           "flags": [
@@ -180,7 +179,7 @@
     {
       "name": "move",
       "category": "stack",
-      "use": "move \u003ccommit\u003e...",
+      "use": "move <commit>...",
       "short": "Move commits from current branch to parent",
       "long": "Cherry-picks listed commits onto the parent branch, strips them from the\ncurrent branch via rebase, and cascade-rebases downstream branches.",
       "example": "  sdf move abc1234                   # move one commit\n  sdf move abc1234 def5678           # move multiple commits",
@@ -428,5 +427,6 @@
       "default": "false",
       "description": "Auto-update PR titles and descriptions during sync"
     }
-  ]
+  ],
+  "hash": "f29817712355631a2fa277f87e65ea109bfa3b89f489b3e24d088d2c5a935d71"
 }


### PR DESCRIPTION
## Summary
- replace volatile generated timestamp in cli-reference.json with deterministic SHA-256 content hash
- hash is computed over the document with the hash field blanked, so it is stable and self-consistent
- simplify docs-check to compare full generated JSON directly
- add docgen unit test for deterministic hash behavior

Fixes #136