### PR TITLE
fix: block sdf split on branches based on non-main ancestors

### DIFF
--- a/cmd/split.go
+++ b/cmd/split.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"math"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -95,7 +97,7 @@ func runSplitCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("cannot split the base branch %q", base)
 	}
 
-	nearestAncestor, err := nearestAncestorBranch(fromBranch)
+	nearestAncestor, err := nearestAncestorBranch(fromBranch, base)
 	if err != nil {
 		return err
 	}
@@ -501,17 +503,21 @@ func printStackChain(s *stack.Stack) {
 
 // nearestAncestorBranch returns the closest local ancestor branch of target,
 // preferring the one with the fewest commits between ancestor and target.
-func nearestAncestorBranch(target string) (string, error) {
+// Branches that are ancestors of base (i.e., already merged) are skipped.
+func nearestAncestorBranch(target, base string) (string, error) {
 	branches, err := gitpkg.LocalBranches()
 	if err != nil {
 		return "", fmt.Errorf("cannot inspect local branches: %w", err)
 	}
 
 	best := ""
-	bestDistance := int(^uint(0) >> 1) // max int
+	bestDistance := math.MaxInt
 	for _, b := range branches {
 		if b == target {
 			continue
+		}
+		if gitpkg.IsAncestor(b, base) {
+			continue // merged into base, skip
 		}
 		if !gitpkg.IsAncestor(b, target) {
 			continue
@@ -521,11 +527,8 @@ func nearestAncestorBranch(target string) (string, error) {
 		if err != nil {
 			continue
 		}
-		var distance int
-		if _, err := fmt.Sscanf(countStr, "%d", &distance); err != nil {
-			continue
-		}
-		if distance <= 0 {
+		distance, err := strconv.Atoi(countStr)
+		if err != nil || distance <= 0 {
 			continue
 		}
 		if distance < bestDistance {

--- a/cmd/split_test.go
+++ b/cmd/split_test.go
@@ -179,6 +179,72 @@ func TestSplitRejectsNestedBranch(t *testing.T) {
 	}
 }
 
+func TestSplitAllowsBranchOnMain(t *testing.T) {
+	resetSplitFlags()
+	dir := splitTestRepo(t)
+
+	git := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s: %s", strings.Join(args, " "), string(out))
+		}
+	}
+
+	git("checkout", "-b", "feat/clean", "main")
+	os.WriteFile(filepath.Join(dir, "clean.go"), []byte("package clean\n"), 0644)
+	git("add", "clean.go")
+	git("commit", "-m", "clean feature")
+
+	testutil.SetBinary(t, &claudepkg.Binary, "true")
+
+	// Should pass the ancestry guard (fails later because Claude is stubbed).
+	err := RunSplit([]string{"--from", "feat/clean", "--stack", "test", "--base", "main"})
+	if err != nil && strings.Contains(err.Error(), "based on") {
+		t.Fatalf("branch on main should pass ancestry check, got: %v", err)
+	}
+}
+
+func TestSplitIgnoresMergedBranch(t *testing.T) {
+	resetSplitFlags()
+	dir := splitTestRepo(t)
+
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s: %s", strings.Join(args, " "), string(out))
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	// Create and merge a feature branch into main.
+	git("checkout", "-b", "feat/old", "main")
+	os.WriteFile(filepath.Join(dir, "old.go"), []byte("package old\n"), 0644)
+	git("add", "old.go")
+	git("commit", "-m", "old feature")
+	git("checkout", "main")
+	git("merge", "--no-ff", "feat/old", "-m", "merge feat/old")
+
+	// Create a new branch on main after the merge.
+	git("checkout", "-b", "feat/new")
+	os.WriteFile(filepath.Join(dir, "new.go"), []byte("package new\n"), 0644)
+	git("add", "new.go")
+	git("commit", "-m", "new feature")
+
+	testutil.SetBinary(t, &claudepkg.Binary, "true")
+
+	// feat/old is merged into main, so it should be skipped by the guard.
+	err := RunSplit([]string{"--from", "feat/new", "--stack", "test", "--base", "main"})
+	if err != nil && strings.Contains(err.Error(), "based on") {
+		t.Fatalf("merged branch should be ignored, got: %v", err)
+	}
+}
+
 func TestBuildSplitPRBody(t *testing.T) {
 	s := &stack.Stack{
 		StackID: "my-feature",


### PR DESCRIPTION
## Summary
- add pre-flight ancestry guard for sdf split
- detect nearest local ancestor branch of --from
- error out when the branch is based on a non-base feature branch
- add regression test for nested branch feat/api based on feat/db-schema

Fixes #102