### PR TITLE
fix: preserve conventional prefix on PR title updates

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -690,6 +690,7 @@ func updatePRContent(_ string, s *stack.Stack, opts *syncOptions, result *SyncRe
 		node         stack.Node
 		prefix       string // conventional commit prefix (e.g. "feat: ")
 		localTitle   string // fallback title from branch name
+		currentTitle string // current PR title on GitHub
 		titlePrompt  string
 		descPrompt   string
 		titleSession string
@@ -711,14 +712,15 @@ func updatePRContent(_ string, s *stack.Stack, opts *syncOptions, result *SyncRe
 		}
 
 		localTitle := cfgpkg.GeneratePRTitle(opts.cfg, s.StackID, node.Branch, subjects)
+		currentTitle, _ := ghpkg.PRViewTitle(node.PR)
 		j := contentJob{
-			node:       *node,
-			localTitle: localTitle,
+			node:         *node,
+			localTitle:   localTitle,
+			currentTitle: currentTitle,
 		}
 
 		if hasClaude {
 			diff, _ := gitpkg.DiffFull(parent, node.Branch)
-			currentTitle, _ := ghpkg.PRViewTitle(node.PR)
 			currentBody, _ := ghpkg.PRViewBody(node.PR)
 			currentDesc := extractDescription(currentBody)
 
@@ -746,7 +748,7 @@ func updatePRContent(_ string, s *stack.Stack, opts *syncOptions, result *SyncRe
 			ID:   fmt.Sprintf("pr-%d-title", j.node.PR),
 			Name: fmt.Sprintf("PR %s title", ui.PR(j.node.PR)),
 			Fn: func(ctx context.Context, r *render.Reporter) error {
-				currentTitle, _ := ghpkg.PRViewTitle(j.node.PR)
+				currentTitle := j.currentTitle
 				prefix := j.prefix
 				if p, _, ok := splitConventionalTitle(currentTitle); ok {
 					prefix = p
@@ -848,15 +850,35 @@ func splitConventionalTitle(title string) (prefix, body string, ok bool) {
 	if head == "" {
 		return "", "", false
 	}
-	// Match "type" or "type(scope)" in ASCII lowercase.
+	// Match "type" or "type(scope)" — e.g. "feat", "fix(auth)".
+	// Type must start with lowercase ASCII letter; scope (if present)
+	// must be wrapped in balanced parens with no nesting.
+	inScope := false
 	for i, r := range head {
 		if i == 0 && (r < 'a' || r > 'z') {
 			return "", "", false
 		}
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '(' || r == ')' || r == '-' || r == '_' {
+		if r == '(' {
+			if inScope {
+				return "", "", false // nested paren
+			}
+			inScope = true
+			continue
+		}
+		if r == ')' {
+			if !inScope {
+				return "", "", false // unmatched close
+			}
+			inScope = false
+			continue
+		}
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.' {
 			continue
 		}
 		return "", "", false
+	}
+	if inScope {
+		return "", "", false // unclosed paren
 	}
 	return head + ": ", parts[1], true
 }

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -874,20 +874,38 @@ func TestSyncResultJSON_WithError(t *testing.T) {
 }
 
 func TestSplitConventionalTitle(t *testing.T) {
-	prefix, body, ok := splitConventionalTitle("fix(sync): preserve title prefix")
-	if !ok {
-		t.Fatal("expected conventional title to parse")
+	tests := []struct {
+		input      string
+		wantPrefix string
+		wantBody   string
+		wantOK     bool
+	}{
+		{"fix(sync): preserve title prefix", "fix(sync): ", "preserve title prefix", true},
+		{"feat: add feature", "feat: ", "add feature", true},
+		{"chore(deps-dev): bump eslint", "chore(deps-dev): ", "bump eslint", true},
+		{"ci: update workflow", "ci: ", "update workflow", true},
+		{"plain title", "", "", false},
+		{"no colon", "", "", false},
+		{"Uppercase: not conventional", "", "", false},
+		{"feat((nested): bad", "", "", false},
+		{"feat(unclosed: bad", "", "", false},
+		{"feat): unmatched close", "", "", false},
+		{": empty type", "", "", false},
 	}
-	if prefix != "fix(sync): " {
-		t.Fatalf("prefix = %q", prefix)
-	}
-	if body != "preserve title prefix" {
-		t.Fatalf("body = %q", body)
-	}
-
-	_, _, ok = splitConventionalTitle("plain title")
-	if ok {
-		t.Fatal("plain title should not parse as conventional")
+	for _, tt := range tests {
+		prefix, body, ok := splitConventionalTitle(tt.input)
+		if ok != tt.wantOK {
+			t.Errorf("splitConventionalTitle(%q): ok = %v, want %v", tt.input, ok, tt.wantOK)
+			continue
+		}
+		if ok {
+			if prefix != tt.wantPrefix {
+				t.Errorf("splitConventionalTitle(%q): prefix = %q, want %q", tt.input, prefix, tt.wantPrefix)
+			}
+			if body != tt.wantBody {
+				t.Errorf("splitConventionalTitle(%q): body = %q, want %q", tt.input, body, tt.wantBody)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve existing conventional commit prefix when updating PR titles during sync
- avoid duplicate/double prefixes if AI returns a prefixed title
- normalize fallback/local title updates through the same prefix-preserving path
- add unit tests for conventional title prefix split/strip helpers

Fixes #68