### PR TITLE
feat: add status verbose mode with commit summaries

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -26,16 +26,17 @@ type StatusResult struct {
 
 // StatusNodeResult describes a single branch in the stack status.
 type StatusNodeResult struct {
-	Branch       string `json:"branch"`
-	PR           int    `json:"pr,omitempty"`
-	Status       string `json:"status"`
-	SyncState    string `json:"sync_state,omitempty"`
-	CommitsAhead int    `json:"commits_ahead,omitempty"`
-	IsCurrent    bool   `json:"is_current,omitempty"`
-	CIStatus     string `json:"ci_status,omitempty"`
-	ReviewStatus string `json:"review_status,omitempty"`
-	Mergeable    string `json:"mergeable,omitempty"`
-	IsDraft      bool   `json:"is_draft,omitempty"`
+	Branch       string   `json:"branch"`
+	PR           int      `json:"pr,omitempty"`
+	Status       string   `json:"status"`
+	SyncState    string   `json:"sync_state,omitempty"`
+	CommitsAhead int      `json:"commits_ahead,omitempty"`
+	CommitLog    []string `json:"commit_log,omitempty"`
+	IsCurrent    bool     `json:"is_current,omitempty"`
+	CIStatus     string   `json:"ci_status,omitempty"`
+	ReviewStatus string   `json:"review_status,omitempty"`
+	Mergeable    string   `json:"mergeable,omitempty"`
+	IsDraft      bool     `json:"is_draft,omitempty"`
 }
 
 var statusCmd = &cobra.Command{
@@ -50,6 +51,7 @@ func init() {
 	rootCmd.AddCommand(statusCmd)
 	statusCmd.Flags().String("stack", "", "stack to show (default: auto-detect)")
 	statusCmd.Flags().Bool("json", false, "output result as JSON")
+	statusCmd.Flags().BoolP("verbose", "v", false, "show commit hashes and messages per branch")
 	_ = statusCmd.RegisterFlagCompletionFunc("stack", completeStackNames)
 }
 
@@ -62,6 +64,7 @@ func RunStatus(args []string) error {
 func runStatus(cmd *cobra.Command, args []string) error {
 	stackFlag, _ := cmd.Flags().GetString("stack")
 	jsonFlag, _ := cmd.Flags().GetBool("json")
+	verbose, _ := cmd.Flags().GetBool("verbose")
 
 	// Accept positional arg as stack name: sdf status <stack-name>
 	stackName := stackFlag
@@ -201,6 +204,12 @@ func runStatus(cmd *cobra.Command, args []string) error {
 			}
 		}
 
+		if verbose {
+			if logOut, err := gitpkg.Log(parent, node.Branch); err == nil && logOut != "" {
+				nr.CommitLog = strings.Split(logOut, "\n")
+			}
+		}
+
 		nodeResults = append(nodeResults, nr)
 	}
 
@@ -272,6 +281,11 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		mergeStr := formatMergeability(nr)
 
 		bus.Printf(" %s %s  %-30s %s %s%s%s", marker, icon, ui.Branch(nr.Branch), prInfo, statusStr, syncStr, mergeStr)
+		if verbose && len(nr.CommitLog) > 0 {
+			for _, line := range nr.CommitLog {
+				bus.Printf("     %s", line)
+			}
+		}
 	}
 
 	// Print sync suggestion

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -12,7 +12,7 @@ func TestStatusResultJSON(t *testing.T) {
 		Base:          "main",
 		CurrentBranch: "feat-a",
 		Nodes: []StatusNodeResult{
-			{Branch: "feat-a", PR: 42, Status: "open", SyncState: "in_sync", CommitsAhead: 3, IsCurrent: true, CIStatus: "pass", ReviewStatus: "approved", Mergeable: "mergeable"},
+			{Branch: "feat-a", PR: 42, Status: "open", SyncState: "in_sync", CommitsAhead: 3, CommitLog: []string{"abc1234 add users table"}, IsCurrent: true, CIStatus: "pass", ReviewStatus: "approved", Mergeable: "mergeable"},
 			{Branch: "feat-b", PR: 43, Status: "open", SyncState: "needs_sync", CommitsAhead: 1, CIStatus: "fail", ReviewStatus: "changes_requested", Mergeable: "conflicting"},
 		},
 		NeedsSync:     []string{"feat-b"},
@@ -55,6 +55,9 @@ func TestStatusResultJSON(t *testing.T) {
 	}
 	if roundtrip.Nodes[1].Mergeable != "conflicting" {
 		t.Errorf("mergeable = %q, want %q", roundtrip.Nodes[1].Mergeable, "conflicting")
+	}
+	if len(roundtrip.Nodes[0].CommitLog) != 1 {
+		t.Fatalf("commit_log len = %d, want 1", len(roundtrip.Nodes[0].CommitLog))
 	}
 }
 

--- a/www/src/data/cli-reference.json
+++ b/www/src/data/cli-reference.json
@@ -337,6 +337,13 @@
           "type": "string",
           "default": "",
           "description": "stack to show (default: auto-detect)"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "description": "show commit hashes and messages per branch"
         }
       ]
     },
@@ -448,5 +455,5 @@
       "description": "Auto-update PR titles and descriptions during sync"
     }
   ],
-  "hash": "0deb092ee2e793ec1a447cde8d530a02ba6ee0699acfdc6531318c71579b4bb9"
+  "hash": "2957e7baa578307ac5ca9664e7bdc5b88634250f773e7e7ce6c65c2e6f2b43b6"
 }


### PR DESCRIPTION
## Summary
- add sdf status verbose flag (-v)
- include per-branch commit hash and subject lines in terminal output
- include commit log entries in JSON output when verbose is enabled
- update status JSON tests for commit log roundtrip

Fixes #103