### PR TITLE
fix: make sdf pr respect repository PR templates

### DIFF
--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 
 	cfgpkg "github.com/pavelpascari/sdf/internal/config"
 	ghpkg "github.com/pavelpascari/sdf/internal/gh"
@@ -90,7 +93,11 @@ func runPR(cmd *cobra.Command, args []string) error {
 	}
 
 	// Build default PR body
-	body := fmt.Sprintf("Part of stack: **%s**\n\nBase: `%s`", s.StackID, base)
+	stackBody := fmt.Sprintf("Part of stack: **%s**\n\nBase: `%s`", s.StackID, base)
+	body := stackBody
+	if tmpl := loadPRTemplate(root); tmpl != "" {
+		body = tmpl + "\n\n---\n\n" + stackBody
+	}
 
 	// Determine title
 	prTitle := title
@@ -159,4 +166,44 @@ func runPR(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// loadPRTemplate finds and returns the repository's PR template content.
+// Returns "" if no template is found.
+func loadPRTemplate(root string) string {
+	candidates := []string{
+		filepath.Join(root, ".github", "pull_request_template.md"),
+		filepath.Join(root, ".github", "PULL_REQUEST_TEMPLATE.md"),
+		filepath.Join(root, "docs", "pull_request_template.md"),
+		filepath.Join(root, "PULL_REQUEST_TEMPLATE.md"),
+	}
+	for _, p := range candidates {
+		if data, err := os.ReadFile(p); err == nil {
+			return strings.TrimSpace(string(data))
+		}
+	}
+
+	dir := filepath.Join(root, ".github", "PULL_REQUEST_TEMPLATE")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	var files []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		ext := filepath.Ext(e.Name())
+		if ext != ".md" && ext != ".markdown" {
+			continue
+		}
+		files = append(files, filepath.Join(dir, e.Name()))
+	}
+	sort.Strings(files)
+	for _, p := range files {
+		if data, err := os.ReadFile(p); err == nil {
+			return strings.TrimSpace(string(data))
+		}
+	}
+	return ""
 }

--- a/cmd/pr_test.go
+++ b/cmd/pr_test.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -60,5 +62,68 @@ func TestRunPR_EmptyBranchAheadOfBase(t *testing.T) {
 	log := testutil.ReadLog(t, fakeDir, "gh")
 	if len(log) != 0 {
 		t.Fatalf("expected no gh calls for empty branch, got %v", log)
+	}
+}
+
+func TestLoadPRTemplate_FromRootFile(t *testing.T) {
+	dir := newTestRepo(t)
+	path := filepath.Join(dir, "PULL_REQUEST_TEMPLATE.md")
+	if err := os.WriteFile(path, []byte("Template body"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tmpl := loadPRTemplate(dir)
+	if !strings.Contains(tmpl, "Template body") {
+		t.Fatalf("unexpected template content: %q", tmpl)
+	}
+}
+
+func TestLoadPRTemplate_FromGithubDir(t *testing.T) {
+	dir := newTestRepo(t)
+
+	// .github/pull_request_template.md takes precedence
+	ghDir := filepath.Join(dir, ".github")
+	os.MkdirAll(ghDir, 0755)
+	os.WriteFile(filepath.Join(ghDir, "pull_request_template.md"), []byte("GitHub template"), 0644)
+
+	tmpl := loadPRTemplate(dir)
+	if !strings.Contains(tmpl, "GitHub template") {
+		t.Fatalf("unexpected template content: %q", tmpl)
+	}
+}
+
+func TestLoadPRTemplate_FromTemplateDirectory(t *testing.T) {
+	dir := newTestRepo(t)
+	templateDir := filepath.Join(dir, ".github", "PULL_REQUEST_TEMPLATE")
+	os.MkdirAll(templateDir, 0755)
+	os.WriteFile(filepath.Join(templateDir, "feature.md"), []byte("Feature template"), 0644)
+
+	tmpl := loadPRTemplate(dir)
+	if !strings.Contains(tmpl, "Feature template") {
+		t.Fatalf("unexpected template content: %q", tmpl)
+	}
+}
+
+func TestLoadPRTemplate_Precedence(t *testing.T) {
+	dir := newTestRepo(t)
+
+	// Create both .github/pull_request_template.md and root PULL_REQUEST_TEMPLATE.md
+	ghDir := filepath.Join(dir, ".github")
+	os.MkdirAll(ghDir, 0755)
+	os.WriteFile(filepath.Join(ghDir, "pull_request_template.md"), []byte("github dir wins"), 0644)
+	os.WriteFile(filepath.Join(dir, "PULL_REQUEST_TEMPLATE.md"), []byte("root loses"), 0644)
+
+	tmpl := loadPRTemplate(dir)
+	if !strings.Contains(tmpl, "github dir wins") {
+		t.Fatalf("expected .github/ to take precedence, got: %q", tmpl)
+	}
+}
+
+func TestLoadPRTemplate_Missing(t *testing.T) {
+	dir := newTestRepo(t)
+
+	tmpl := loadPRTemplate(dir)
+	if tmpl != "" {
+		t.Fatalf("expected empty template, got: %q", tmpl)
 	}
 }


### PR DESCRIPTION
## Summary
- detect standard GitHub PR template locations when running sdf pr
- include template content in the created PR body while preserving stack metadata
- support both single-file and github pull request template directory layouts
- add unit tests for template discovery behavior

Fixes #77