### PR TITLE
docs: add dedicated sub-page for each command

### DIFF
--- a/www/src/content/docs/commands.mdx
+++ b/www/src/content/docs/commands.mdx
@@ -13,6 +13,25 @@ export const cmd = (name) => cliRef.commands.find(c => c.name === name);
 
 All commands are run from within a git repository. Most require the repository to have at least one stack registered (via `sdf new` or `sdf fetch`).
 
+Dedicated command pages:
+
+- [`sdf ai intro`](/docs/commands/ai)
+- [`sdf branch`](/docs/commands/branch)
+- [`sdf completion`](/docs/commands/completion)
+- [`sdf config`](/docs/commands/config)
+- [`sdf doctor`](/docs/commands/doctor)
+- [`sdf fetch`](/docs/commands/fetch)
+- [`sdf merge`](/docs/commands/merge)
+- [`sdf move`](/docs/commands/move)
+- [`sdf new`](/docs/commands/new)
+- [`sdf pr`](/docs/commands/pr)
+- [`sdf register`](/docs/commands/register)
+- [`sdf split`](/docs/commands/split)
+- [`sdf status`](/docs/commands/status)
+- [`sdf switch`](/docs/commands/switch)
+- [`sdf sync`](/docs/commands/sync)
+- [`sdf version`](/docs/commands/version)
+
 ---
 
 ## Stack management

--- a/www/src/content/docs/commands/ai.mdx
+++ b/www/src/content/docs/commands/ai.mdx
@@ -1,0 +1,13 @@
+---
+title: "`sdf ai`"
+description: "Reference page for sdf ai."
+---
+
+import CommandRef from '../../../components/CommandRef.astro';
+import cliRef from '../../../data/cli-reference.json';
+
+export const cmd = (name) => cliRef.commands.find(c => c.name === name);
+
+# `sdf ai`
+
+<CommandRef command={cmd('ai')} />

--- a/www/src/content/docs/commands/branch.mdx
+++ b/www/src/content/docs/commands/branch.mdx
@@ -1,0 +1,13 @@
+---
+title: "`sdf branch`"
+description: "Reference page for sdf branch."
+---
+
+import CommandRef from '../../../components/CommandRef.astro';
+import cliRef from '../../../data/cli-reference.json';
+
+export const cmd = (name) => cliRef.commands.find(c => c.name === name);
+
+# `sdf branch`
+
+<CommandRef command={cmd('branch')} />

--- a/www/src/content/docs/commands/completion.mdx
+++ b/www/src/content/docs/commands/completion.mdx
@@ -1,0 +1,13 @@
+---
+title: "`sdf completion`"
+description: "Reference page for sdf completion."
+---
+
+import CommandRef from '../../../components/CommandRef.astro';
+import cliRef from '../../../data/cli-reference.json';
+
+export const cmd = (name) => cliRef.commands.find(c => c.name === name);
+
+# `sdf completion`
+
+<CommandRef command={cmd('completion')} />

--- a/www/src/content/docs/commands/config.mdx
+++ b/www/src/content/docs/commands/config.mdx
@@ -1,0 +1,13 @@
+---
+title: "`sdf config`"
+description: "Reference page for sdf config."
+---
+
+import CommandRef from '../../../components/CommandRef.astro';
+import cliRef from '../../../data/cli-reference.json';
+
+export const cmd = (name) => cliRef.commands.find(c => c.name === name);
+
+# `sdf config`
+
+<CommandRef command={cmd('config')} />

--- a/www/src/content/docs/commands/doctor.mdx
+++ b/www/src/content/docs/commands/doctor.mdx
@@ -1,0 +1,13 @@
+---
+title: "`sdf doctor`"
+description: "Reference page for sdf doctor."
+---
+
+import CommandRef from '../../../components/CommandRef.astro';
+import cliRef from '../../../data/cli-reference.json';
+
+export const cmd = (name) => cliRef.commands.find(c => c.name === name);
+
+# `sdf doctor`
+
+<CommandRef command={cmd('doctor')} />

--- a/www/src/content/docs/commands/fetch.mdx
+++ b/www/src/content/docs/commands/fetch.mdx
@@ -1,0 +1,13 @@
+---
+title: "`sdf fetch`"
+description: "Reference page for sdf fetch."
+---
+
+import CommandRef from '../../../components/CommandRef.astro';
+import cliRef from '../../../data/cli-reference.json';
+
+export const cmd = (name) => cliRef.commands.find(c => c.name === name);
+
+# `sdf fetch`
+
+<CommandRef command={cmd('fetch')} />

--- a/www/src/content/docs/commands/merge.mdx
+++ b/www/src/content/docs/commands/merge.mdx
@@ -1,0 +1,13 @@
+---
+title: "`sdf merge`"
+description: "Reference page for sdf merge."
+---
+
+import CommandRef from '../../../components/CommandRef.astro';
+import cliRef from '../../../data/cli-reference.json';
+
+export const cmd = (name) => cliRef.commands.find(c => c.name === name);
+
+# `sdf merge`
+
+<CommandRef command={cmd('merge')} />

--- a/www/src/content/docs/commands/move.mdx
+++ b/www/src/content/docs/commands/move.mdx
@@ -1,0 +1,13 @@
+---
+title: "`sdf move`"
+description: "Reference page for sdf move."
+---
+
+import CommandRef from '../../../components/CommandRef.astro';
+import cliRef from '../../../data/cli-reference.json';
+
+export const cmd = (name) => cliRef.commands.find(c => c.name === name);
+
+# `sdf move`
+
+<CommandRef command={cmd('move')} />

--- a/www/src/content/docs/commands/new.mdx
+++ b/www/src/content/docs/commands/new.mdx
@@ -1,0 +1,13 @@
+---
+title: "`sdf new`"
+description: "Reference page for sdf new."
+---
+
+import CommandRef from '../../../components/CommandRef.astro';
+import cliRef from '../../../data/cli-reference.json';
+
+export const cmd = (name) => cliRef.commands.find(c => c.name === name);
+
+# `sdf new`
+
+<CommandRef command={cmd('new')} />

--- a/www/src/content/docs/commands/pr.mdx
+++ b/www/src/content/docs/commands/pr.mdx
@@ -1,0 +1,13 @@
+---
+title: "`sdf pr`"
+description: "Reference page for sdf pr."
+---
+
+import CommandRef from '../../../components/CommandRef.astro';
+import cliRef from '../../../data/cli-reference.json';
+
+export const cmd = (name) => cliRef.commands.find(c => c.name === name);
+
+# `sdf pr`
+
+<CommandRef command={cmd('pr')} />

--- a/www/src/content/docs/commands/register.mdx
+++ b/www/src/content/docs/commands/register.mdx
@@ -1,0 +1,13 @@
+---
+title: "`sdf register`"
+description: "Reference page for sdf register."
+---
+
+import CommandRef from '../../../components/CommandRef.astro';
+import cliRef from '../../../data/cli-reference.json';
+
+export const cmd = (name) => cliRef.commands.find(c => c.name === name);
+
+# `sdf register`
+
+<CommandRef command={cmd('register')} />

--- a/www/src/content/docs/commands/split.mdx
+++ b/www/src/content/docs/commands/split.mdx
@@ -1,0 +1,13 @@
+---
+title: "`sdf split`"
+description: "Reference page for sdf split."
+---
+
+import CommandRef from '../../../components/CommandRef.astro';
+import cliRef from '../../../data/cli-reference.json';
+
+export const cmd = (name) => cliRef.commands.find(c => c.name === name);
+
+# `sdf split`
+
+<CommandRef command={cmd('split')} />

--- a/www/src/content/docs/commands/status.mdx
+++ b/www/src/content/docs/commands/status.mdx
@@ -1,0 +1,13 @@
+---
+title: "`sdf status`"
+description: "Reference page for sdf status."
+---
+
+import CommandRef from '../../../components/CommandRef.astro';
+import cliRef from '../../../data/cli-reference.json';
+
+export const cmd = (name) => cliRef.commands.find(c => c.name === name);
+
+# `sdf status`
+
+<CommandRef command={cmd('status')} />

--- a/www/src/content/docs/commands/switch.mdx
+++ b/www/src/content/docs/commands/switch.mdx
@@ -1,0 +1,13 @@
+---
+title: "`sdf switch`"
+description: "Reference page for sdf switch."
+---
+
+import CommandRef from '../../../components/CommandRef.astro';
+import cliRef from '../../../data/cli-reference.json';
+
+export const cmd = (name) => cliRef.commands.find(c => c.name === name);
+
+# `sdf switch`
+
+<CommandRef command={cmd('switch')} />

--- a/www/src/content/docs/commands/sync.mdx
+++ b/www/src/content/docs/commands/sync.mdx
@@ -1,0 +1,13 @@
+---
+title: "`sdf sync`"
+description: "Reference page for sdf sync."
+---
+
+import CommandRef from '../../../components/CommandRef.astro';
+import cliRef from '../../../data/cli-reference.json';
+
+export const cmd = (name) => cliRef.commands.find(c => c.name === name);
+
+# `sdf sync`
+
+<CommandRef command={cmd('sync')} />

--- a/www/src/content/docs/commands/version.mdx
+++ b/www/src/content/docs/commands/version.mdx
@@ -1,0 +1,13 @@
+---
+title: "`sdf version`"
+description: "Reference page for sdf version."
+---
+
+import CommandRef from '../../../components/CommandRef.astro';
+import cliRef from '../../../data/cli-reference.json';
+
+export const cmd = (name) => cliRef.commands.find(c => c.name === name);
+
+# `sdf version`
+
+<CommandRef command={cmd('version')} />


### PR DESCRIPTION
## Summary
- add dedicated docs sub-pages under docs/commands for each CLI command
- each page renders the generated CommandRef for that command
- add an index section in docs/commands linking to all dedicated pages

Fixes #137