### PR TITLE
sync: structure generated PR descriptions as markdown

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -1010,8 +1010,8 @@ func buildDescriptionPrompt(branch string, subjects []string, diff, currentDesc 
 	var b strings.Builder
 
 	b.WriteString("You are a PR description generator. Output ONLY the description text — nothing else.\n")
-	b.WriteString("No preamble, no thinking, no commentary, no markdown headers, no formatting.\n")
-	b.WriteString("Start directly with the first sentence of the description.\n\n")
+	b.WriteString("Use clean GitHub-flavored Markdown.\n")
+	b.WriteString("Do not include stack navigation or metadata sections — sdf adds those separately.\n\n")
 
 	if currentDesc != "" {
 		b.WriteString("Current description:\n")
@@ -1033,7 +1033,13 @@ func buildDescriptionPrompt(branch string, subjects []string, diff, currentDesc 
 		b.WriteString("\n")
 	}
 
-	b.WriteString("\nWrite 2-5 sentences explaining what this change does and why. Focus on user impact and key changes.")
+	b.WriteString("\nWrite a concise Markdown description with this structure:\n")
+	b.WriteString("## Summary\n")
+	b.WriteString("- 1-3 bullets describing what changed and why\n")
+	b.WriteString("## Changes\n")
+	b.WriteString("- bullets listing key implementation details\n")
+	b.WriteString("Use inline code formatting for file/function names where helpful.\n")
+	b.WriteString("Keep it short and scannable.")
 
 	return b.String()
 }

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -729,7 +729,8 @@ func TestBuildDescriptionPrompt(t *testing.T) {
 		"feat: add user auth",
 		"fix: handle edge case",
 		"auth.go",
-		"2-5 sentences",
+		"## Summary",
+		"## Changes",
 		"Diff:",
 	}
 

--- a/cmd/testdata/descprompt_basic.golden
+++ b/cmd/testdata/descprompt_basic.golden
@@ -1,6 +1,6 @@
 You are a PR description generator. Output ONLY the description text — nothing else.
-No preamble, no thinking, no commentary, no markdown headers, no formatting.
-Start directly with the first sentence of the description.
+Use clean GitHub-flavored Markdown.
+Do not include stack navigation or metadata sections — sdf adds those separately.
 
 Branch: feat/auth
 
@@ -13,4 +13,10 @@ diff --git a/auth.go b/auth.go
 +func Login() {}
 
 
-Write 2-5 sentences explaining what this change does and why. Focus on user impact and key changes.
+Write a concise Markdown description with this structure:
+## Summary
+- 1-3 bullets describing what changed and why
+## Changes
+- bullets listing key implementation details
+Use inline code formatting for file/function names where helpful.
+Keep it short and scannable.

--- a/cmd/testdata/descprompt_existing.golden
+++ b/cmd/testdata/descprompt_existing.golden
@@ -1,6 +1,6 @@
 You are a PR description generator. Output ONLY the description text — nothing else.
-No preamble, no thinking, no commentary, no markdown headers, no formatting.
-Start directly with the first sentence of the description.
+Use clean GitHub-flavored Markdown.
+Do not include stack navigation or metadata sections — sdf adds those separately.
 
 Current description:
 This adds user authentication.
@@ -13,4 +13,10 @@ Branch: feat/auth
 Commits:
   - feat: add user auth
 
-Write 2-5 sentences explaining what this change does and why. Focus on user impact and key changes.
+Write a concise Markdown description with this structure:
+## Summary
+- 1-3 bullets describing what changed and why
+## Changes
+- bullets listing key implementation details
+Use inline code formatting for file/function names where helpful.
+Keep it short and scannable.


### PR DESCRIPTION
## Summary
- update Claude description prompt to generate concise GitHub-flavored Markdown
- enforce a consistent `## Summary` + `## Changes` shape for generated descriptions
- keep stack navigation/metadata out of generated description content
- update prompt tests and golden snapshots

## Testing
- go test ./cmd/...

Closes #73

---

**Note:** Unrelated commits (`pr: fail early when branch has no commits ahead` and `fetch: add --branch stack discovery mode`) were removed from this PR and will be submitted separately.