### PR TITLE
feat: add sdf restack to reorder branches within a stack

### DIFF
--- a/cmd/restack.go
+++ b/cmd/restack.go
@@ -81,6 +81,46 @@ func runRestackLogic(sourceBranch, afterBranch string) error {
 		return err
 	}
 
+	// Fetch and check if stack is in sync
+	bus.Print("Fetching from origin...")
+	if err := gitpkg.FetchAll(); err != nil {
+		bus.Warnf("warning: fetch failed: %v", err)
+	}
+
+	// Fast-forward base
+	if err := gitpkg.FastForward(s.Base); err != nil {
+		bus.Warnf("warning: could not fast-forward %s: %v", s.Base, err)
+	}
+
+	// Check if sync is needed
+	syncPlan := computeSyncPlan(s, nil)
+	hasWork := false
+	for _, a := range syncPlan {
+		if a.kind != "skip-merged" && a.kind != "skip-closed" {
+			hasWork = true
+			break
+		}
+	}
+
+	if hasWork {
+		bus.Pause()
+		ok := ui.Confirm("Stack is not in sync. Run sdf sync first?")
+		bus.Resume()
+		if !ok {
+			return fmt.Errorf("stack must be in sync before restacking — run `sdf sync` first")
+		}
+		bus.Print("")
+		if err := runSyncFrom(root, s, 0, &syncOptions{}, nil, bus, nil); err != nil {
+			return fmt.Errorf("sync failed: %w", err)
+		}
+		// Reload stack after sync (BaseTips may have changed)
+		s, err = resolveStack(root, s.StackID)
+		if err != nil {
+			return fmt.Errorf("cannot reload stack after sync: %w", err)
+		}
+		bus.Print("")
+	}
+
 	// Working tree must be clean
 	clean, err := gitpkg.IsClean()
 	if err != nil {

--- a/cmd/restack.go
+++ b/cmd/restack.go
@@ -1,0 +1,67 @@
+package cmd
+
+import "github.com/pavelpascari/sdf/internal/stack"
+
+// reorderNodes returns a new slice with sourceBranch moved to immediately after
+// afterBranch. If afterBranch is "", source becomes first. The original slice
+// is not modified.
+func reorderNodes(nodes []stack.Node, sourceBranch, afterBranch string) []stack.Node {
+	var source stack.Node
+	remaining := make([]stack.Node, 0, len(nodes)-1)
+	for _, n := range nodes {
+		if n.Branch == sourceBranch {
+			source = n
+		} else {
+			remaining = append(remaining, n)
+		}
+	}
+
+	if afterBranch == "" {
+		result := make([]stack.Node, 0, len(nodes))
+		result = append(result, source)
+		result = append(result, remaining...)
+		return result
+	}
+
+	result := make([]stack.Node, 0, len(nodes))
+	for _, n := range remaining {
+		result = append(result, n)
+		if n.Branch == afterBranch {
+			result = append(result, source)
+		}
+	}
+	return result
+}
+
+// restackAction describes a single rebase that needs to happen: Branch should
+// be rebased from OldParent onto NewParent.
+type restackAction struct {
+	Branch    string
+	NewParent string
+	OldParent string
+}
+
+// computeRestackPlan compares old vs new parent for each node and returns the
+// branches whose effective parent changed (skipping merged/closed nodes).
+// Results are in new array order.
+func computeRestackPlan(s *stack.Stack, newNodes []stack.Node) []restackAction {
+	oldStack := &stack.Stack{StackID: s.StackID, Base: s.Base, Nodes: s.Nodes}
+	newStack := &stack.Stack{StackID: s.StackID, Base: s.Base, Nodes: newNodes}
+
+	var actions []restackAction
+	for _, node := range newNodes {
+		if node.Status == "merged" || node.Status == "closed" {
+			continue
+		}
+		oldParent := oldStack.ParentBranch(node.Branch)
+		newParent := newStack.ParentBranch(node.Branch)
+		if oldParent != newParent {
+			actions = append(actions, restackAction{
+				Branch:    node.Branch,
+				NewParent: newParent,
+				OldParent: oldParent,
+			})
+		}
+	}
+	return actions
+}

--- a/cmd/restack.go
+++ b/cmd/restack.go
@@ -14,25 +14,50 @@ import (
 )
 
 var restackCmd = &cobra.Command{
-	Use:   "restack <branch>",
+	Use:   "restack [branch]",
 	Short: "Move a branch to a new position in the stack",
 	Long: `Moves a branch to a new position (after the --after target), rebases all
-affected branches, pushes, and updates PR bases on GitHub.`,
+affected branches, pushes, and updates PR bases on GitHub.
+
+Use --continue to resume after resolving conflicts.
+Use --abort to restore all branches to their pre-restack state.`,
 	Example: `  sdf restack feature/job --after feature/index
-  sdf restack feature/auth --after main       # make it first in the stack`,
+  sdf restack feature/auth --after main
+  sdf restack --continue
+  sdf restack --abort`,
 	Annotations: map[string]string{"category": "stack"},
-	Args:        cobra.ExactArgs(1),
+	Args:        cobra.MaximumNArgs(1),
 	RunE:        runRestackCmd,
 }
 
 func init() {
 	rootCmd.AddCommand(restackCmd)
-	restackCmd.Flags().String("after", "", "branch to insert after (required)")
-	_ = restackCmd.MarkFlagRequired("after")
+	restackCmd.Flags().String("after", "", "branch to insert after")
+	restackCmd.Flags().Bool("continue", false, "resume after conflict resolution")
+	restackCmd.Flags().Bool("abort", false, "restore branches to pre-restack state")
 }
 
 func runRestackCmd(cmd *cobra.Command, args []string) error {
+	contFlag, _ := cmd.Flags().GetBool("continue")
+	abortFlag, _ := cmd.Flags().GetBool("abort")
+
+	if contFlag && abortFlag {
+		return fmt.Errorf("cannot use --continue and --abort together")
+	}
+	if contFlag {
+		return runRestackContinue()
+	}
+	if abortFlag {
+		return runRestackAbort()
+	}
+
+	if len(args) == 0 {
+		return fmt.Errorf("branch name required (or use --continue / --abort)")
+	}
 	after, _ := cmd.Flags().GetString("after")
+	if after == "" {
+		return fmt.Errorf("--after flag is required")
+	}
 	return runRestackLogic(args[0], after)
 }
 
@@ -157,11 +182,45 @@ func runRestackLogic(sourceBranch, afterBranch string) error {
 	}
 	bus.Print("")
 
+	// Save snapshot for --abort / --continue
+	branchSHAs := make(map[string]string)
+	for _, a := range plan {
+		sha, err := gitpkg.RevParse(a.Branch)
+		if err == nil {
+			branchSHAs[a.Branch] = sha
+		}
+	}
+
+	serialPlan := make([]stack.RestackAction, len(plan))
+	for i, a := range plan {
+		serialPlan[i] = stack.RestackAction{
+			Branch:    a.Branch,
+			NewParent: a.NewParent,
+			OldParent: a.OldParent,
+		}
+	}
+
+	originalNodes := make([]stack.Node, len(s.Nodes))
+	copy(originalNodes, s.Nodes)
+
+	ls, _ := stack.LoadLocal(root)
+	ls.RestackProgress = &stack.RestackProgress{
+		StackID:        s.StackID,
+		OriginalBranch: originalBranch,
+		OriginalNodes:  originalNodes,
+		BranchSHAs:     branchSHAs,
+		Plan:           serialPlan,
+		ResumeIndex:    0,
+	}
+	if err := stack.SaveLocal(root, ls); err != nil {
+		return fmt.Errorf("cannot save restack progress: %w", err)
+	}
+
 	// Apply new node order
 	s.Nodes = newNodes
 
 	// Rebase each affected branch
-	for _, a := range plan {
+	for i, a := range plan {
 		bus.Printf("  rebasing %s onto %s...", ui.Branch(a.Branch), ui.Branch(a.NewParent))
 
 		parentTip, err := gitpkg.RevParse(a.NewParent)
@@ -177,9 +236,15 @@ func runRestackLogic(sourceBranch, afterBranch string) error {
 
 		if err := gitpkg.RebaseOnto(parentTip, oldBase, a.Branch); err != nil {
 			if conflictErr := handleMoveConflict(s, a.Branch, err, bus); conflictErr != nil {
+				// Save progress with resume index
+				ls, _ := stack.LoadLocal(root)
+				if ls.RestackProgress != nil {
+					ls.RestackProgress.ResumeIndex = i
+				}
+				stack.SaveLocal(root, ls)
 				stack.Save(root, s)
 				gitpkg.Checkout(originalBranch)
-				return fmt.Errorf("rebase of %s failed: %w — resolve conflicts and run `sdf sync` to continue",
+				return fmt.Errorf("rebase of %s failed: %w — resolve conflicts and run `sdf restack --continue` or `sdf restack --abort`",
 					a.Branch, conflictErr)
 			}
 		}
@@ -223,6 +288,175 @@ func runRestackLogic(sourceBranch, afterBranch string) error {
 	// Save stack
 	if err := stack.Save(root, s); err != nil {
 		return fmt.Errorf("cannot save stack: %w", err)
+	}
+
+	// Clear restack progress
+	ls, _ = stack.LoadLocal(root)
+	ls.RestackProgress = nil
+	stack.SaveLocal(root, ls)
+
+	bus.Printf("\n%s Restack complete.", ui.SymOK)
+	return nil
+}
+
+func runRestackAbort() error {
+	root, err := stack.FindRoot()
+	if err != nil {
+		return err
+	}
+
+	bus := render.NewBus(os.Stdout, os.Stderr, render.Options{})
+	defer func() { _ = bus.Finish() }()
+
+	ls, err := stack.LoadLocal(root)
+	if err != nil {
+		return fmt.Errorf("cannot read local state: %w", err)
+	}
+	if ls.RestackProgress == nil {
+		return fmt.Errorf("no restack in progress")
+	}
+
+	progress := ls.RestackProgress
+	bus.Printf("Aborting restack in stack %s...", ui.Bold.Render(progress.StackID))
+
+	// Abort any in-progress rebase
+	gitpkg.RebaseAbort()
+
+	// Restore each branch to its pre-restack SHA
+	for branch, sha := range progress.BranchSHAs {
+		bus.Printf("  restoring %s to %s...", ui.Branch(branch), short(sha))
+		if err := gitpkg.Checkout(branch); err != nil {
+			bus.Warnf("  %s could not checkout %s: %v", ui.SymWarn, ui.Branch(branch), err)
+			continue
+		}
+		if err := gitpkg.ResetHard(sha); err != nil {
+			bus.Warnf("  %s could not reset %s: %v", ui.SymWarn, ui.Branch(branch), err)
+			continue
+		}
+		bus.Printf("  %s %s restored", ui.SymOK, ui.Branch(branch))
+
+		// Push restored branch
+		if err := gitpkg.Push(branch); err != nil {
+			bus.Warnf("  %s could not push %s: %v", ui.SymWarn, ui.Branch(branch), err)
+		}
+	}
+
+	// Restore original node order and BaseTips
+	s, err := stack.LoadStack(root, progress.StackID)
+	if err != nil {
+		return fmt.Errorf("cannot load stack: %w", err)
+	}
+	s.Nodes = progress.OriginalNodes
+	if err := stack.Save(root, s); err != nil {
+		return fmt.Errorf("cannot save stack: %w", err)
+	}
+
+	// Restore original branch
+	gitpkg.Checkout(progress.OriginalBranch)
+
+	// Clear progress
+	ls.RestackProgress = nil
+	if err := stack.SaveLocal(root, ls); err != nil {
+		return fmt.Errorf("cannot clear restack progress: %w", err)
+	}
+
+	bus.Printf("\n%s Restack aborted. All branches restored.", ui.SymOK)
+	return nil
+}
+
+func runRestackContinue() error {
+	root, err := stack.FindRoot()
+	if err != nil {
+		return err
+	}
+
+	bus := render.NewBus(os.Stdout, os.Stderr, render.Options{})
+	defer func() { _ = bus.Finish() }()
+
+	ls, err := stack.LoadLocal(root)
+	if err != nil {
+		return fmt.Errorf("cannot read local state: %w", err)
+	}
+	if ls.RestackProgress == nil {
+		return fmt.Errorf("no restack in progress")
+	}
+
+	progress := ls.RestackProgress
+	s, err := stack.LoadStack(root, progress.StackID)
+	if err != nil {
+		return fmt.Errorf("cannot load stack: %w", err)
+	}
+
+	bus.Printf("Continuing restack in stack %s...", ui.Bold.Render(progress.StackID))
+
+	// Resume from where we left off
+	for i := progress.ResumeIndex; i < len(progress.Plan); i++ {
+		a := progress.Plan[i]
+		bus.Printf("  rebasing %s onto %s...", ui.Branch(a.Branch), ui.Branch(a.NewParent))
+
+		parentTip, err := gitpkg.RevParse(a.NewParent)
+		if err != nil {
+			return fmt.Errorf("cannot resolve %s: %w", a.NewParent, err)
+		}
+
+		node := s.FindNode(a.Branch)
+		oldBase := node.BaseTip
+		if oldBase == "" {
+			oldBase = a.OldParent
+		}
+
+		if err := gitpkg.RebaseOnto(parentTip, oldBase, a.Branch); err != nil {
+			if conflictErr := handleMoveConflict(s, a.Branch, err, bus); conflictErr != nil {
+				ls.RestackProgress.ResumeIndex = i
+				stack.SaveLocal(root, ls)
+				stack.Save(root, s)
+				gitpkg.Checkout(progress.OriginalBranch)
+				return fmt.Errorf("rebase of %s failed: %w — resolve conflicts and run `sdf restack --continue` or `sdf restack --abort`",
+					a.Branch, conflictErr)
+			}
+		}
+
+		newTip, _ := gitpkg.RevParse(a.NewParent)
+		node.BaseTip = newTip
+
+		bus.Printf("  %s %s rebased", ui.SymOK, ui.Branch(a.Branch))
+
+		if err := gitpkg.Push(a.Branch); err != nil {
+			bus.Warnf("  %s could not push %s: %v", ui.SymWarn, ui.Branch(a.Branch), err)
+		} else {
+			bus.Printf("  %s %s pushed", ui.SymOK, ui.Branch(a.Branch))
+		}
+	}
+
+	// Update PR bases
+	if ghpkg.Available() {
+		for _, a := range progress.Plan {
+			node := s.FindNode(a.Branch)
+			if node != nil && node.PR > 0 {
+				if err := ghpkg.PREditBase(node.PR, a.NewParent); err != nil {
+					bus.Warnf("  %s could not update PR #%d base: %v", ui.SymWarn, node.PR, err)
+				} else {
+					bus.Printf("  PR %s base updated -> %s", ui.PR(node.PR), ui.Branch(a.NewParent))
+				}
+			}
+		}
+	}
+
+	// Update nav
+	if err := updateStackNavForAllPRs(root, s, nil, bus); err != nil {
+		bus.Warnf("warning: could not update PR navigation: %v", err)
+	}
+
+	// Restore original branch
+	gitpkg.Checkout(progress.OriginalBranch)
+
+	// Save stack and clear progress
+	if err := stack.Save(root, s); err != nil {
+		return fmt.Errorf("cannot save stack: %w", err)
+	}
+	ls.RestackProgress = nil
+	if err := stack.SaveLocal(root, ls); err != nil {
+		return fmt.Errorf("cannot clear restack progress: %w", err)
 	}
 
 	bus.Printf("\n%s Restack complete.", ui.SymOK)

--- a/cmd/restack.go
+++ b/cmd/restack.go
@@ -2,10 +2,15 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
+	ghpkg "github.com/pavelpascari/sdf/internal/gh"
+	gitpkg "github.com/pavelpascari/sdf/internal/git"
+	"github.com/pavelpascari/sdf/internal/render"
 	"github.com/pavelpascari/sdf/internal/stack"
+	"github.com/pavelpascari/sdf/internal/ui"
 )
 
 var restackCmd = &cobra.Command{
@@ -63,7 +68,125 @@ func validateRestack(s *stack.Stack, sourceBranch, afterBranch string) error {
 }
 
 func runRestackLogic(sourceBranch, afterBranch string) error {
-	return fmt.Errorf("not yet implemented")
+	root, err := stack.FindRoot()
+	if err != nil {
+		return err
+	}
+
+	bus := render.NewBus(os.Stdout, os.Stderr, render.Options{})
+	defer func() { _ = bus.Finish() }()
+
+	s, err := resolveStack(root, "")
+	if err != nil {
+		return err
+	}
+
+	// Working tree must be clean
+	clean, err := gitpkg.IsClean()
+	if err != nil {
+		return fmt.Errorf("cannot check working tree status: %w", err)
+	}
+	if !clean {
+		return fmt.Errorf("working tree is not clean — commit or stash changes first")
+	}
+
+	// Remember current branch to restore later
+	originalBranch, _ := gitpkg.CurrentBranch()
+
+	// Validate the move
+	if err := validateRestack(s, sourceBranch, afterBranch); err != nil {
+		return err
+	}
+
+	// Normalize afterBranch for reorderNodes
+	reorderAfter := afterBranch
+	if afterBranch == s.Base {
+		reorderAfter = ""
+	}
+
+	newNodes := reorderNodes(s.Nodes, sourceBranch, reorderAfter)
+	plan := computeRestackPlan(s, newNodes)
+
+	bus.Printf("Restacking %s after %s in stack %s...",
+		ui.Branch(sourceBranch), ui.Branch(afterBranch), ui.Bold.Render(s.StackID))
+
+	// Print plan
+	bus.Print("\nRestack plan:")
+	for _, a := range plan {
+		bus.Printf("  %s rebase %s onto %s", ui.SymPlan, ui.Branch(a.Branch), ui.Branch(a.NewParent))
+	}
+	bus.Print("")
+
+	// Apply new node order
+	s.Nodes = newNodes
+
+	// Rebase each affected branch
+	for _, a := range plan {
+		bus.Printf("  rebasing %s onto %s...", ui.Branch(a.Branch), ui.Branch(a.NewParent))
+
+		parentTip, err := gitpkg.RevParse(a.NewParent)
+		if err != nil {
+			return fmt.Errorf("cannot resolve %s: %w", a.NewParent, err)
+		}
+
+		node := s.FindNode(a.Branch)
+		oldBase := node.BaseTip
+		if oldBase == "" {
+			oldBase = a.OldParent
+		}
+
+		if err := gitpkg.RebaseOnto(parentTip, oldBase, a.Branch); err != nil {
+			if conflictErr := handleMoveConflict(s, a.Branch, err, bus); conflictErr != nil {
+				stack.Save(root, s)
+				gitpkg.Checkout(originalBranch)
+				return fmt.Errorf("rebase of %s failed: %w — resolve conflicts and run `sdf sync` to continue",
+					a.Branch, conflictErr)
+			}
+		}
+
+		// Update BaseTip
+		newTip, _ := gitpkg.RevParse(a.NewParent)
+		node.BaseTip = newTip
+
+		bus.Printf("  %s %s rebased", ui.SymOK, ui.Branch(a.Branch))
+
+		// Push (will fail in tests without remote — that's OK, non-fatal)
+		if err := gitpkg.Push(a.Branch); err != nil {
+			bus.Warnf("  %s could not push %s: %v", ui.SymWarn, ui.Branch(a.Branch), err)
+		} else {
+			bus.Printf("  %s %s pushed", ui.SymOK, ui.Branch(a.Branch))
+		}
+	}
+
+	// Update PR bases on GitHub
+	if ghpkg.Available() {
+		for _, a := range plan {
+			node := s.FindNode(a.Branch)
+			if node != nil && node.PR > 0 {
+				if err := ghpkg.PREditBase(node.PR, a.NewParent); err != nil {
+					bus.Warnf("  %s could not update PR #%d base: %v", ui.SymWarn, node.PR, err)
+				} else {
+					bus.Printf("  PR %s base updated → %s", ui.PR(node.PR), ui.Branch(a.NewParent))
+				}
+			}
+		}
+	}
+
+	// Update PR navigation
+	if err := updateStackNavForAllPRs(root, s, nil, bus); err != nil {
+		bus.Warnf("warning: could not update PR navigation: %v", err)
+	}
+
+	// Restore original branch
+	gitpkg.Checkout(originalBranch)
+
+	// Save stack
+	if err := stack.Save(root, s); err != nil {
+		return fmt.Errorf("cannot save stack: %w", err)
+	}
+
+	bus.Printf("\n%s Restack complete.", ui.SymOK)
+	return nil
 }
 
 // reorderNodes returns a new slice with sourceBranch moved to immediately after

--- a/cmd/restack.go
+++ b/cmd/restack.go
@@ -77,7 +77,9 @@ func validateRestack(s *stack.Stack, sourceBranch, afterBranch string) error {
 		return fmt.Errorf("branch %q is not part of stack %q", afterBranch, s.StackID)
 	}
 
-	// Normalize: if afterBranch is the base, treat as "" for reorderNodes
+	// The base branch (e.g. "main") is not a node in the Nodes array, so
+	// reorderNodes can't match on it. Empty string means "insert at front",
+	// which is correct — "after main" means first in the stack.
 	reorderAfter := afterBranch
 	if isBase {
 		reorderAfter = ""

--- a/cmd/restack.go
+++ b/cmd/restack.go
@@ -1,6 +1,70 @@
 package cmd
 
-import "github.com/pavelpascari/sdf/internal/stack"
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pavelpascari/sdf/internal/stack"
+)
+
+var restackCmd = &cobra.Command{
+	Use:   "restack <branch>",
+	Short: "Move a branch to a new position in the stack",
+	Long: `Moves a branch to a new position (after the --after target), rebases all
+affected branches, pushes, and updates PR bases on GitHub.`,
+	Example: `  sdf restack feature/job --after feature/index
+  sdf restack feature/auth --after main       # make it first in the stack`,
+	Annotations: map[string]string{"category": "stack"},
+	Args:        cobra.ExactArgs(1),
+	RunE:        runRestackCmd,
+}
+
+func init() {
+	rootCmd.AddCommand(restackCmd)
+	restackCmd.Flags().String("after", "", "branch to insert after (required)")
+	_ = restackCmd.MarkFlagRequired("after")
+}
+
+func runRestackCmd(cmd *cobra.Command, args []string) error {
+	after, _ := cmd.Flags().GetString("after")
+	return runRestackLogic(args[0], after)
+}
+
+func validateRestack(s *stack.Stack, sourceBranch, afterBranch string) error {
+	if sourceBranch == afterBranch {
+		return fmt.Errorf("cannot move %s after itself", sourceBranch)
+	}
+
+	sourceIdx := s.NodeIndex(sourceBranch)
+	if sourceIdx < 0 {
+		return fmt.Errorf("branch %q is not part of stack %q", sourceBranch, s.StackID)
+	}
+
+	isBase := afterBranch == s.Base
+	afterIdx := s.NodeIndex(afterBranch)
+	if !isBase && afterIdx < 0 {
+		return fmt.Errorf("branch %q is not part of stack %q", afterBranch, s.StackID)
+	}
+
+	// Normalize: if afterBranch is the base, treat as "" for reorderNodes
+	reorderAfter := afterBranch
+	if isBase {
+		reorderAfter = ""
+	}
+
+	newNodes := reorderNodes(s.Nodes, sourceBranch, reorderAfter)
+	plan := computeRestackPlan(s, newNodes)
+	if len(plan) == 0 {
+		return fmt.Errorf("%s is already in that position", sourceBranch)
+	}
+
+	return nil
+}
+
+func runRestackLogic(sourceBranch, afterBranch string) error {
+	return fmt.Errorf("not yet implemented")
+}
 
 // reorderNodes returns a new slice with sourceBranch moved to immediately after
 // afterBranch. If afterBranch is "", source becomes first. The original slice

--- a/cmd/restack.go
+++ b/cmd/restack.go
@@ -221,7 +221,8 @@ func runRestackLogic(sourceBranch, afterBranch string) error {
 	// Apply new node order
 	s.Nodes = newNodes
 
-	// Rebase each affected branch
+	// Rebase each affected branch (no pushes yet — defer until all succeed)
+	var rebased []string
 	for i, a := range plan {
 		bus.Printf("  rebasing %s onto %s...", ui.Branch(a.Branch), ui.Branch(a.NewParent))
 
@@ -254,14 +255,18 @@ func runRestackLogic(sourceBranch, afterBranch string) error {
 		// Update BaseTip
 		newTip, _ := gitpkg.RevParse(a.NewParent)
 		node.BaseTip = newTip
+		rebased = append(rebased, a.Branch)
 
 		bus.Printf("  %s %s rebased", ui.SymOK, ui.Branch(a.Branch))
+	}
 
-		// Push (will fail in tests without remote — that's OK, non-fatal)
-		if err := gitpkg.Push(a.Branch); err != nil {
-			bus.Warnf("  %s could not push %s: %v", ui.SymWarn, ui.Branch(a.Branch), err)
+	// All rebases succeeded — now push all affected branches
+	bus.Print("")
+	for _, branch := range rebased {
+		if err := gitpkg.Push(branch); err != nil {
+			bus.Warnf("  %s could not push %s: %v", ui.SymWarn, ui.Branch(branch), err)
 		} else {
-			bus.Printf("  %s %s pushed", ui.SymOK, ui.Branch(a.Branch))
+			bus.Printf("  %s %s pushed", ui.SymOK, ui.Branch(branch))
 		}
 	}
 
@@ -391,7 +396,8 @@ func runRestackContinue() error {
 
 	bus.Printf("Continuing restack in stack %s...", ui.Bold.Render(progress.StackID))
 
-	// Resume from where we left off
+	// Resume rebasing from where we left off (no pushes yet)
+	var rebased []string
 	for i := progress.ResumeIndex; i < len(progress.Plan); i++ {
 		a := progress.Plan[i]
 		bus.Printf("  rebasing %s onto %s...", ui.Branch(a.Branch), ui.Branch(a.NewParent))
@@ -420,13 +426,22 @@ func runRestackContinue() error {
 
 		newTip, _ := gitpkg.RevParse(a.NewParent)
 		node.BaseTip = newTip
+		rebased = append(rebased, a.Branch)
 
 		bus.Printf("  %s %s rebased", ui.SymOK, ui.Branch(a.Branch))
+	}
 
-		if err := gitpkg.Push(a.Branch); err != nil {
-			bus.Warnf("  %s could not push %s: %v", ui.SymWarn, ui.Branch(a.Branch), err)
+	// All rebases succeeded — push all affected branches
+	// Include branches rebased before the pause (from the full plan)
+	for i := 0; i < progress.ResumeIndex; i++ {
+		rebased = append(rebased, progress.Plan[i].Branch)
+	}
+	bus.Print("")
+	for _, branch := range rebased {
+		if err := gitpkg.Push(branch); err != nil {
+			bus.Warnf("  %s could not push %s: %v", ui.SymWarn, ui.Branch(branch), err)
 		} else {
-			bus.Printf("  %s %s pushed", ui.SymOK, ui.Branch(a.Branch))
+			bus.Printf("  %s %s pushed", ui.SymOK, ui.Branch(branch))
 		}
 	}
 

--- a/cmd/restack_test.go
+++ b/cmd/restack_test.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/pavelpascari/sdf/internal/stack"
+)
+
+func TestReorderNodes_MoveMiddleToFirst(t *testing.T) {
+	nodes := []stack.Node{
+		{Branch: "a", Status: "open"},
+		{Branch: "b", Status: "open"},
+		{Branch: "c", Status: "open"},
+		{Branch: "d", Status: "open"},
+	}
+	result := reorderNodes(nodes, "c", "a")
+	expected := []string{"a", "c", "b", "d"}
+	if len(result) != len(expected) {
+		t.Fatalf("expected %d nodes, got %d", len(expected), len(result))
+	}
+	for i, name := range expected {
+		if result[i].Branch != name {
+			t.Errorf("position %d: expected %s, got %s", i, name, result[i].Branch)
+		}
+	}
+}
+
+func TestReorderNodes_MoveToBase(t *testing.T) {
+	nodes := []stack.Node{
+		{Branch: "a", Status: "open"},
+		{Branch: "b", Status: "open"},
+		{Branch: "c", Status: "open"},
+	}
+	result := reorderNodes(nodes, "c", "")
+	expected := []string{"c", "a", "b"}
+	for i, name := range expected {
+		if result[i].Branch != name {
+			t.Errorf("position %d: expected %s, got %s", i, name, result[i].Branch)
+		}
+	}
+}
+
+func TestReorderNodes_MoveForward(t *testing.T) {
+	nodes := []stack.Node{
+		{Branch: "a", Status: "open"},
+		{Branch: "b", Status: "open"},
+		{Branch: "c", Status: "open"},
+		{Branch: "d", Status: "open"},
+	}
+	result := reorderNodes(nodes, "a", "c")
+	expected := []string{"b", "c", "a", "d"}
+	for i, name := range expected {
+		if result[i].Branch != name {
+			t.Errorf("position %d: expected %s, got %s", i, name, result[i].Branch)
+		}
+	}
+}
+
+func TestReorderNodes_PreservesFields(t *testing.T) {
+	nodes := []stack.Node{
+		{Branch: "a", PR: 1, Status: "open", BaseTip: "aaa"},
+		{Branch: "b", PR: 2, Status: "open", BaseTip: "bbb"},
+		{Branch: "c", PR: 3, Status: "open", BaseTip: "ccc"},
+	}
+	result := reorderNodes(nodes, "c", "a")
+	if result[1].Branch != "c" || result[1].PR != 3 || result[1].BaseTip != "ccc" {
+		t.Errorf("moved node lost fields: %+v", result[1])
+	}
+}
+
+func TestReorderNodes_AdjacentSwap(t *testing.T) {
+	nodes := []stack.Node{
+		{Branch: "a", Status: "open"},
+		{Branch: "b", Status: "open"},
+		{Branch: "c", Status: "open"},
+	}
+	result := reorderNodes(nodes, "b", "c")
+	expected := []string{"a", "c", "b"}
+	for i, name := range expected {
+		if result[i].Branch != name {
+			t.Errorf("position %d: expected %s, got %s", i, name, result[i].Branch)
+		}
+	}
+}
+
+func TestComputeRestackPlan_IdentifiesAffected(t *testing.T) {
+	s := &stack.Stack{
+		StackID: "test", Base: "main",
+		Nodes: []stack.Node{
+			{Branch: "a", Status: "open"},
+			{Branch: "b", Status: "open"},
+			{Branch: "c", Status: "open"},
+			{Branch: "d", Status: "open"},
+		},
+	}
+	newNodes := reorderNodes(s.Nodes, "c", "a")
+	affected := computeRestackPlan(s, newNodes)
+	if len(affected) != 3 {
+		t.Fatalf("expected 3 affected branches, got %d", len(affected))
+	}
+	expects := map[string]string{"c": "a", "b": "c", "d": "b"}
+	for _, a := range affected {
+		want, ok := expects[a.Branch]
+		if !ok {
+			t.Errorf("unexpected affected branch: %s", a.Branch)
+			continue
+		}
+		if a.NewParent != want {
+			t.Errorf("branch %s: expected new parent %s, got %s", a.Branch, want, a.NewParent)
+		}
+	}
+}
+
+func TestComputeRestackPlan_NoOpWhenSamePosition(t *testing.T) {
+	s := &stack.Stack{
+		StackID: "test", Base: "main",
+		Nodes: []stack.Node{
+			{Branch: "a", Status: "open"},
+			{Branch: "b", Status: "open"},
+			{Branch: "c", Status: "open"},
+		},
+	}
+	newNodes := reorderNodes(s.Nodes, "b", "a")
+	affected := computeRestackPlan(s, newNodes)
+	if len(affected) != 0 {
+		t.Errorf("expected 0 affected branches for no-op, got %d", len(affected))
+	}
+}
+
+func TestComputeRestackPlan_SkipsMergedNodes(t *testing.T) {
+	s := &stack.Stack{
+		StackID: "test", Base: "main",
+		Nodes: []stack.Node{
+			{Branch: "a", Status: "open"},
+			{Branch: "b", Status: "merged"},
+			{Branch: "c", Status: "open"},
+			{Branch: "d", Status: "open"},
+		},
+	}
+	newNodes := reorderNodes(s.Nodes, "d", "a")
+	affected := computeRestackPlan(s, newNodes)
+	for _, a := range affected {
+		if a.Branch == "b" {
+			t.Error("merged branch b should not be in affected list")
+		}
+	}
+}

--- a/cmd/restack_test.go
+++ b/cmd/restack_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pavelpascari/sdf/internal/stack"
@@ -143,5 +144,100 @@ func TestComputeRestackPlan_SkipsMergedNodes(t *testing.T) {
 		if a.Branch == "b" {
 			t.Error("merged branch b should not be in affected list")
 		}
+	}
+}
+
+func TestRestackValidation_BranchNotInStack(t *testing.T) {
+	err := validateRestack(
+		&stack.Stack{
+			StackID: "test", Base: "main",
+			Nodes: []stack.Node{{Branch: "a", Status: "open"}},
+		},
+		"nonexistent", "a",
+	)
+	if err == nil || !strings.Contains(err.Error(), "not part of stack") {
+		t.Errorf("expected 'not part of stack' error, got: %v", err)
+	}
+}
+
+func TestRestackValidation_AfterNotInStack(t *testing.T) {
+	err := validateRestack(
+		&stack.Stack{
+			StackID: "test", Base: "main",
+			Nodes: []stack.Node{
+				{Branch: "a", Status: "open"},
+				{Branch: "b", Status: "open"},
+			},
+		},
+		"b", "nonexistent",
+	)
+	if err == nil || !strings.Contains(err.Error(), "not part of stack") {
+		t.Errorf("expected 'not part of stack' error, got: %v", err)
+	}
+}
+
+func TestRestackValidation_AfterSelf(t *testing.T) {
+	err := validateRestack(
+		&stack.Stack{
+			StackID: "test", Base: "main",
+			Nodes: []stack.Node{
+				{Branch: "a", Status: "open"},
+				{Branch: "b", Status: "open"},
+			},
+		},
+		"b", "b",
+	)
+	if err == nil || !strings.Contains(err.Error(), "cannot move") {
+		t.Errorf("expected 'cannot move' error, got: %v", err)
+	}
+}
+
+func TestRestackValidation_AlreadyInPosition(t *testing.T) {
+	err := validateRestack(
+		&stack.Stack{
+			StackID: "test", Base: "main",
+			Nodes: []stack.Node{
+				{Branch: "a", Status: "open"},
+				{Branch: "b", Status: "open"},
+				{Branch: "c", Status: "open"},
+			},
+		},
+		"b", "a",
+	)
+	if err == nil || !strings.Contains(err.Error(), "already") {
+		t.Errorf("expected 'already in position' error, got: %v", err)
+	}
+}
+
+func TestRestackValidation_AfterBase(t *testing.T) {
+	err := validateRestack(
+		&stack.Stack{
+			StackID: "test", Base: "main",
+			Nodes: []stack.Node{
+				{Branch: "a", Status: "open"},
+				{Branch: "b", Status: "open"},
+			},
+		},
+		"b", "main",
+	)
+	if err != nil {
+		t.Errorf("expected no error for --after base, got: %v", err)
+	}
+}
+
+func TestRestackValidation_ValidMove(t *testing.T) {
+	err := validateRestack(
+		&stack.Stack{
+			StackID: "test", Base: "main",
+			Nodes: []stack.Node{
+				{Branch: "a", Status: "open"},
+				{Branch: "b", Status: "open"},
+				{Branch: "c", Status: "open"},
+			},
+		},
+		"c", "a",
+	)
+	if err != nil {
+		t.Errorf("expected no error for valid move, got: %v", err)
 	}
 }

--- a/cmd/restack_test.go
+++ b/cmd/restack_test.go
@@ -1,9 +1,13 @@
 package cmd
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	gitpkg "github.com/pavelpascari/sdf/internal/git"
 	"github.com/pavelpascari/sdf/internal/stack"
 )
 
@@ -239,5 +243,166 @@ func TestRestackValidation_ValidMove(t *testing.T) {
 	)
 	if err != nil {
 		t.Errorf("expected no error for valid move, got: %v", err)
+	}
+}
+
+func restackTestRepo(t *testing.T) string {
+	t.Helper()
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s: %s", strings.Join(args, " "), string(out))
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	writeFile := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	git("init", "-b", "main")
+	git("config", "user.email", "test@test.com")
+	git("config", "user.name", "Test")
+	git("config", "commit.gpgsign", "false")
+
+	writeFile("README.md", "# test\n")
+	git("add", "README.md")
+	git("commit", "-m", "initial")
+	mainTip := git("rev-parse", "HEAD")
+
+	git("checkout", "-b", "branchA")
+	writeFile("a1.txt", "a1\n")
+	git("add", "a1.txt")
+	git("commit", "-m", "a1")
+	branchATip := git("rev-parse", "HEAD")
+
+	git("checkout", "-b", "branchB")
+	writeFile("b1.txt", "b1\n")
+	git("add", "b1.txt")
+	git("commit", "-m", "b1")
+	branchBTip := git("rev-parse", "HEAD")
+
+	git("checkout", "-b", "branchC")
+	writeFile("c1.txt", "c1\n")
+	git("add", "c1.txt")
+	git("commit", "-m", "c1")
+	branchCTip := git("rev-parse", "HEAD")
+
+	git("checkout", "-b", "branchD")
+	writeFile("d1.txt", "d1\n")
+	git("add", "d1.txt")
+	git("commit", "-m", "d1")
+
+	s := &stack.Stack{
+		StackID: "test-stack",
+		Base:    "main",
+		Nodes: []stack.Node{
+			{Branch: "branchA", Status: "open", BaseTip: mainTip},
+			{Branch: "branchB", Status: "open", BaseTip: branchATip},
+			{Branch: "branchC", Status: "open", BaseTip: branchBTip},
+			{Branch: "branchD", Status: "open", BaseTip: branchCTip},
+		},
+	}
+	if err := stack.Save(dir, s); err != nil {
+		t.Fatal(err)
+	}
+
+	return dir
+}
+
+func TestRunRestack_MoveCAfterA(t *testing.T) {
+	restackTestRepo(t)
+
+	err := runRestackLogic("branchC", "branchA")
+	if err != nil {
+		t.Fatalf("restack failed: %v", err)
+	}
+
+	s, err := stack.Load(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []string{"branchA", "branchC", "branchB", "branchD"}
+	for i, name := range expected {
+		if s.Nodes[i].Branch != name {
+			t.Errorf("position %d: expected %s, got %s", i, name, s.Nodes[i].Branch)
+		}
+	}
+
+	// Verify branchC has a1.txt (from parent branchA) but not b1.txt
+	gitpkg.Checkout("branchC")
+	if _, err := os.Stat("a1.txt"); err != nil {
+		t.Error("branchC should have a1.txt from parent branchA")
+	}
+	if _, err := os.Stat("b1.txt"); err == nil {
+		t.Error("branchC should NOT have b1.txt (branchB is no longer its parent)")
+	}
+	if _, err := os.Stat("c1.txt"); err != nil {
+		t.Error("branchC should still have its own c1.txt")
+	}
+
+	// Verify branchB now has c1.txt (from new parent branchC)
+	gitpkg.Checkout("branchB")
+	if _, err := os.Stat("c1.txt"); err != nil {
+		t.Error("branchB should have c1.txt from new parent branchC")
+	}
+	if _, err := os.Stat("b1.txt"); err != nil {
+		t.Error("branchB should still have its own b1.txt")
+	}
+
+	// Verify branchD has everything (end of chain)
+	gitpkg.Checkout("branchD")
+	for _, f := range []string{"a1.txt", "c1.txt", "b1.txt", "d1.txt"} {
+		if _, err := os.Stat(f); err != nil {
+			t.Errorf("branchD should have %s", f)
+		}
+	}
+}
+
+func TestRunRestack_MoveToBase(t *testing.T) {
+	restackTestRepo(t)
+
+	err := runRestackLogic("branchC", "main")
+	if err != nil {
+		t.Fatalf("restack failed: %v", err)
+	}
+
+	s, err := stack.Load(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []string{"branchC", "branchA", "branchB", "branchD"}
+	for i, name := range expected {
+		if s.Nodes[i].Branch != name {
+			t.Errorf("position %d: expected %s, got %s", i, name, s.Nodes[i].Branch)
+		}
+	}
+
+	// branchC should only have its own file + README (parent is main)
+	gitpkg.Checkout("branchC")
+	if _, err := os.Stat("c1.txt"); err != nil {
+		t.Error("branchC should have c1.txt")
+	}
+	if _, err := os.Stat("a1.txt"); err == nil {
+		t.Error("branchC should NOT have a1.txt (main is its parent now)")
 	}
 }

--- a/cmd/restack_test.go
+++ b/cmd/restack_test.go
@@ -377,6 +377,43 @@ func TestRunRestack_MoveCAfterA(t *testing.T) {
 	}
 }
 
+func TestRunRestackAbort_NoRestackInProgress(t *testing.T) {
+	restackTestRepo(t)
+	err := runRestackAbort()
+	if err == nil || !strings.Contains(err.Error(), "no restack in progress") {
+		t.Errorf("expected 'no restack in progress' error, got: %v", err)
+	}
+}
+
+func TestRunRestackContinue_NoRestackInProgress(t *testing.T) {
+	restackTestRepo(t)
+	err := runRestackContinue()
+	if err == nil || !strings.Contains(err.Error(), "no restack in progress") {
+		t.Errorf("expected 'no restack in progress' error, got: %v", err)
+	}
+}
+
+func TestRunRestack_SnapshotSavedAndCleared(t *testing.T) {
+	dir := restackTestRepo(t)
+
+	// Before restack — no progress
+	ls, _ := stack.LoadLocal(dir)
+	if ls.RestackProgress != nil {
+		t.Fatal("expected no restack progress before restack")
+	}
+
+	err := runRestackLogic("branchC", "branchA")
+	if err != nil {
+		t.Fatalf("restack failed: %v", err)
+	}
+
+	// After successful restack — progress should be cleared
+	ls, _ = stack.LoadLocal(dir)
+	if ls.RestackProgress != nil {
+		t.Error("expected restack progress to be cleared after success")
+	}
+}
+
 func TestRunRestack_MoveToBase(t *testing.T) {
 	restackTestRepo(t)
 

--- a/docs/plans/2026-04-05-restack-design.md
+++ b/docs/plans/2026-04-05-restack-design.md
@@ -15,13 +15,15 @@ tedious.
 ```
 sdf restack <branch> --after <target-branch>
 sdf restack --continue
+sdf restack --abort
 ```
 
 Moves `<branch>` to the position immediately after `<target-branch>` in the
 stack. `<target-branch>` can be any branch in the same stack, or the stack's
 base branch (e.g. `main`) to make it first.
 
-`--continue` resumes after conflict resolution (same pattern as `sdf sync`).
+`--continue` resumes after conflict resolution.
+`--abort` restores all branches to their pre-restack state.
 
 ## Algorithm
 
@@ -35,19 +37,52 @@ Given `main ← A ← B ← C ← D`, running `sdf restack C --after A`:
    or unfetched changes.
 2. **Validate**: both branches in same stack, target is not source, working
    tree clean, move changes position (not a no-op).
-3. **Reorder**: rearrange Nodes array `[A, B, C, D]` → `[A, C, B, D]`.
-4. **Diff parents**: compare old vs new parent for each node. Only branches
+3. **Save snapshot**: record each branch's current SHA, the original node
+   order, and BaseTips to `.sdf/local.json` (`RestackProgress`). This enables
+   `--abort` and `--continue`.
+4. **Reorder**: rearrange Nodes array `[A, B, C, D]` → `[A, C, B, D]`.
+5. **Diff parents**: compare old vs new parent for each node. Only branches
    whose effective parent changed need rebasing:
    - C: parent B → A (changed)
    - B: parent A → C (changed)
    - D: parent C → B (changed, cascade)
-5. **Rebase in new array order**: for each affected branch, rebase onto its
+6. **Rebase in new array order**: for each affected branch, rebase onto its
    new parent. On conflict: offer Claude resolution, then manual pause
    (`sdf restack --continue`), skip, or abort.
-6. **Push** all rebased branches (force-push, history rewritten).
-7. **Update PR bases** on GitHub for branches whose parent changed and have a PR.
-8. **Update PR navigation** for all PRs in the stack.
-9. **Save** stack JSON with updated `BaseTip` values.
+7. **Push** all rebased branches (force-push, history rewritten).
+8. **Update PR bases** on GitHub for branches whose parent changed and have a PR.
+9. **Update PR navigation** for all PRs in the stack.
+10. **Save** stack JSON with updated `BaseTip` values. Clear snapshot.
+
+## Snapshot and Abort
+
+Before any rebasing, a `RestackProgress` is saved to `.sdf/local.json`:
+
+```json
+{
+  "restack_progress": {
+    "stack_id": "my-stack",
+    "original_branch": "branchC",
+    "original_nodes": [... original node order with BaseTips ...],
+    "branch_shas": {"branchA": "abc", "branchB": "def", ...},
+    "plan": [... restackAction list ...],
+    "resume_index": 0
+  }
+}
+```
+
+**`--abort`** reads the snapshot and:
+1. For each branch in `branch_shas`: `git reset --hard <saved-SHA>` (via checkout + reset)
+2. Force-push all restored branches
+3. Restore original node order and BaseTips in stack JSON
+4. Clear the snapshot
+
+**`--continue`** reads the snapshot and:
+1. Resumes rebasing from `resume_index` (the branch that had conflicts)
+2. Continues through the remaining plan
+3. On success, clears the snapshot
+
+The snapshot is cleared on successful completion or explicit abort.
 
 ## Edge Cases
 
@@ -58,12 +93,14 @@ Given `main ← A ← B ← C ← D`, running `sdf restack C --after A`:
 - Merged/closed nodes between old and new positions → stay in array, skipped
   by `ParentBranch` as usual.
 - `--after` is the stack base branch → branch becomes first node in stack.
+- `--abort` with no restack in progress → error.
+- `--continue` with no restack in progress → error.
 
 ## Conflict Handling
 
-Same pattern as `sdf move`: pause at conflict, offer Claude resolution attempt,
-fall back to manual resolution. Progress saved to `.sdf/local.json` so
-`sdf restack --continue` can resume from the failed branch.
+On rebase conflict: offer Claude resolution attempt, then manual pause. Save
+`resume_index` to the snapshot so `--continue` knows where to pick up. The
+user can also `--abort` to restore everything to the pre-restack state.
 
 ## Output
 
@@ -93,9 +130,9 @@ Updated 3 PR description(s).
 
 ## Files
 
-- New: `cmd/restack.go` — command implementation
-- New: `cmd/restack_test.go` — tests
-- Modify: `main.go` — register the command
+- Modify: `cmd/restack.go` — command implementation
+- Modify: `cmd/restack_test.go` — tests
+- Modify: `internal/stack/stack.go` — `RestackProgress` type + `LocalState` field
 
 ## Testing
 
@@ -106,4 +143,6 @@ Updated 3 PR description(s).
 - Push: all affected branches pushed
 - PR base update: GitHub PR bases match new parents
 - Cascade: downstream branches beyond the moved region are rebased
-- Conflict: pause and resume via --continue
+- Abort: restores branches to pre-restack SHAs and original node order
+- Abort with no restack in progress: error
+- Continue with no restack in progress: error

--- a/docs/plans/2026-04-05-restack-design.md
+++ b/docs/plans/2026-04-05-restack-design.md
@@ -1,0 +1,109 @@
+# sdf restack — Reorder Branches Within a Stack
+
+**Issue:** #199
+**Date:** 2026-04-05
+
+## Problem
+
+When a branch needs to be moved to a different position in the stack, there is
+no built-in command. Users must manually `git rebase --onto`, cascade-rebase
+downstream branches, edit the stack JSON, and force-push — error-prone and
+tedious.
+
+## Command
+
+```
+sdf restack <branch> --after <target-branch>
+sdf restack --continue
+```
+
+Moves `<branch>` to the position immediately after `<target-branch>` in the
+stack. `<target-branch>` can be any branch in the same stack, or the stack's
+base branch (e.g. `main`) to make it first.
+
+`--continue` resumes after conflict resolution (same pattern as `sdf sync`).
+
+## Algorithm
+
+Given `main ← A ← B ← C ← D`, running `sdf restack C --after A`:
+
+1. **Fetch and verify sync**: fetch from origin, reconcile PR states, and
+   verify the stack is fully synced (no pending rebases, no local/remote
+   divergence). If the stack is not in sync, offer to run `sdf sync` first
+   (single y/n prompt). If the user declines, abort. This prevents restacking
+   from a stale state where history rewriting could conflict with unpushed
+   or unfetched changes.
+2. **Validate**: both branches in same stack, target is not source, working
+   tree clean, move changes position (not a no-op).
+3. **Reorder**: rearrange Nodes array `[A, B, C, D]` → `[A, C, B, D]`.
+4. **Diff parents**: compare old vs new parent for each node. Only branches
+   whose effective parent changed need rebasing:
+   - C: parent B → A (changed)
+   - B: parent A → C (changed)
+   - D: parent C → B (changed, cascade)
+5. **Rebase in new array order**: for each affected branch, rebase onto its
+   new parent. On conflict: offer Claude resolution, then manual pause
+   (`sdf restack --continue`), skip, or abort.
+6. **Push** all rebased branches (force-push, history rewritten).
+7. **Update PR bases** on GitHub for branches whose parent changed and have a PR.
+8. **Update PR navigation** for all PRs in the stack.
+9. **Save** stack JSON with updated `BaseTip` values.
+
+## Edge Cases
+
+- Stack not in sync with remote → offer to run sync first, abort if declined.
+- Moving to same position or after immediate predecessor → no-op, print message.
+- Moving after self → error.
+- Branch not in stack → error.
+- Merged/closed nodes between old and new positions → stay in array, skipped
+  by `ParentBranch` as usual.
+- `--after` is the stack base branch → branch becomes first node in stack.
+
+## Conflict Handling
+
+Same pattern as `sdf move`: pause at conflict, offer Claude resolution attempt,
+fall back to manual resolution. Progress saved to `.sdf/local.json` so
+`sdf restack --continue` can resume from the failed branch.
+
+## Output
+
+```
+Restacking C after A in stack my-stack...
+
+Restack plan:
+  → rebase C onto A
+  → rebase B onto C
+  → rebase D onto B (cascade)
+
+  rebasing C onto A...
+  ✓ C rebased and pushed
+  rebasing B onto C...
+  ✓ B rebased and pushed
+  rebasing D onto B...
+  ✓ D rebased and pushed
+
+Restack complete.
+
+  PR #3 base updated → A
+  PR #2 base updated → C
+  PR #4 base updated → B
+
+Updated 3 PR description(s).
+```
+
+## Files
+
+- New: `cmd/restack.go` — command implementation
+- New: `cmd/restack_test.go` — tests
+- Modify: `main.go` — register the command
+
+## Testing
+
+- Validate: error cases (not in sync, not in stack, same position, dirty tree, after self)
+- Reorder logic: array manipulation produces correct new order
+- Parent diff: correctly identifies which branches need rebasing
+- Rebase: branches end up on correct parents with correct commits
+- Push: all affected branches pushed
+- PR base update: GitHub PR bases match new parents
+- Cascade: downstream branches beyond the moved region are rebased
+- Conflict: pause and resume via --continue

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -121,6 +121,12 @@ func RebaseOnto(newBase, oldBase, branch string) error {
 	return err
 }
 
+// ResetHard resets the current branch to the given ref, discarding all changes.
+func ResetHard(ref string) error {
+	_, err := run("reset", "--hard", ref)
+	return err
+}
+
 // RebaseAbort aborts an in-progress rebase.
 func RebaseAbort() error {
 	_, err := run("rebase", "--abort")

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -41,8 +41,27 @@ const LocalFile = "local.json"
 // LocalState is the root structure of .sdf/local.json.
 // Each subsystem owns its own field — they don't clobber each other.
 type LocalState struct {
-	SyncProgress  *SyncProgress     `json:"sync_progress,omitempty"`
-	SplitSessions map[string]string `json:"split_sessions,omitempty"` // stack_name → session_id
+	SyncProgress    *SyncProgress     `json:"sync_progress,omitempty"`
+	SplitSessions   map[string]string `json:"split_sessions,omitempty"` // stack_name → session_id
+	RestackProgress *RestackProgress  `json:"restack_progress,omitempty"`
+}
+
+// RestackProgress tracks a restack operation so --continue can resume
+// and --abort can restore branches to their pre-restack state.
+type RestackProgress struct {
+	StackID        string            `json:"stack_id"`
+	OriginalBranch string            `json:"original_branch"` // branch user was on
+	OriginalNodes  []Node            `json:"original_nodes"`  // node order + BaseTips before restack
+	BranchSHAs     map[string]string `json:"branch_shas"`     // branch → SHA before restack
+	Plan           []RestackAction   `json:"plan"`            // planned rebases
+	ResumeIndex    int               `json:"resume_index"`    // index in Plan to resume from
+}
+
+// RestackAction is the JSON-serializable version of a planned rebase.
+type RestackAction struct {
+	Branch    string `json:"branch"`
+	NewParent string `json:"new_parent"`
+	OldParent string `json:"old_parent"`
 }
 
 // SyncProgress tracks a paused sync so `sdf sync --continue` can resume.

--- a/www/src/data/cli-reference.json
+++ b/www/src/data/cli-reference.json
@@ -296,16 +296,28 @@
     {
       "name": "restack",
       "category": "stack",
-      "use": "restack <branch>",
+      "use": "restack [branch]",
       "short": "Move a branch to a new position in the stack",
-      "long": "Moves a branch to a new position (after the --after target), rebases all\naffected branches, pushes, and updates PR bases on GitHub.",
-      "example": "  sdf restack feature/job --after feature/index\n  sdf restack feature/auth --after main       # make it first in the stack",
+      "long": "Moves a branch to a new position (after the --after target), rebases all\naffected branches, pushes, and updates PR bases on GitHub.\n\nUse --continue to resume after resolving conflicts.\nUse --abort to restore all branches to their pre-restack state.",
+      "example": "  sdf restack feature/job --after feature/index\n  sdf restack feature/auth --after main\n  sdf restack --continue\n  sdf restack --abort",
       "flags": [
+        {
+          "name": "abort",
+          "type": "bool",
+          "default": "false",
+          "description": "restore branches to pre-restack state"
+        },
         {
           "name": "after",
           "type": "string",
           "default": "",
-          "description": "branch to insert after (required)"
+          "description": "branch to insert after"
+        },
+        {
+          "name": "continue",
+          "type": "bool",
+          "default": "false",
+          "description": "resume after conflict resolution"
         }
       ]
     },
@@ -499,5 +511,5 @@
       "description": "Auto-update PR titles and descriptions during sync"
     }
   ],
-  "hash": "6b2ebf2be939d2197bfcd00080bbdf418020ef81f4d49e5ea04d7bc62b214f84"
+  "hash": "94db1a61b31c4d620c5ac383e6aa095fb045e0fde86eb3b945eacaf888c627c5"
 }

--- a/www/src/data/cli-reference.json
+++ b/www/src/data/cli-reference.json
@@ -294,6 +294,22 @@
       "deprecated": "use `sdf fetch` instead"
     },
     {
+      "name": "restack",
+      "category": "stack",
+      "use": "restack <branch>",
+      "short": "Move a branch to a new position in the stack",
+      "long": "Moves a branch to a new position (after the --after target), rebases all\naffected branches, pushes, and updates PR bases on GitHub.",
+      "example": "  sdf restack feature/job --after feature/index\n  sdf restack feature/auth --after main       # make it first in the stack",
+      "flags": [
+        {
+          "name": "after",
+          "type": "string",
+          "default": "",
+          "description": "branch to insert after (required)"
+        }
+      ]
+    },
+    {
       "name": "split",
       "category": "stack",
       "use": "split",
@@ -483,5 +499,5 @@
       "description": "Auto-update PR titles and descriptions during sync"
     }
   ],
-  "hash": "323924a9369ebfb1352d8466867ae09b23c402d5630d1bea4bede364ba8af8f6"
+  "hash": "6b2ebf2be939d2197bfcd00080bbdf418020ef81f4d49e5ea04d7bc62b214f84"
 }


### PR DESCRIPTION
## Summary

Fixes #199

Adds `sdf restack` command that moves a branch to a new position in the stack in a single command (fetch through PR update). Not transactional — if a rebase fails mid-way, partial progress is saved. The user can `--continue` after resolving conflicts, or `--abort` to restore all branches to their pre-restack state.

```
sdf restack <branch> --after <target>    # move branch to new position
sdf restack --continue                    # resume after conflict resolution
sdf restack --abort                       # restore pre-restack state
```

### What it does

1. **Fetch + verify sync** — checks stack is in sync, offers to run `sdf sync` if not
2. **Validate** — both branches in same stack, not a no-op, working tree clean
3. **Save snapshot** — records branch SHAs, node order, and BaseTips to `.sdf/local.json` for abort/continue
4. **Reorder** — rearranges Nodes array to new topology
5. **Rebase** — rebases affected branches onto new parents (with Claude conflict resolution)
6. **Push** — force-pushes all rebased branches
7. **Update PR bases** — retargets PRs on GitHub
8. **Update PR navigation** — refreshes stack nav in all PRs
9. **Clear snapshot** — removes progress from local state

### Abort and Continue

On conflict, the user has three options:
- **Resolve + `--continue`** — fix conflicts, `git add`, then `sdf restack --continue`
- **`--abort`** — restores every branch to its pre-restack SHA via `git reset --hard`, force-pushes, restores original stack order
- Claude auto-resolution is attempted first (same as `sdf move`)

**Example:**
```
# Current: main ← auth ← validation ← api-routes ← tests
sdf restack api-routes --after auth
# Result:  main ← auth ← api-routes ← validation ← tests
```

## Test plan

- [x] `TestReorderNodes_MoveMiddleToFirst` — array reorder backward
- [x] `TestReorderNodes_MoveToBase` — move to first position
- [x] `TestReorderNodes_MoveForward` — array reorder forward
- [x] `TestReorderNodes_PreservesFields` — PR/BaseTip/Status preserved
- [x] `TestReorderNodes_AdjacentSwap` — swap two adjacent
- [x] `TestComputeRestackPlan_IdentifiesAffected` — correct parent diffs
- [x] `TestComputeRestackPlan_NoOpWhenSamePosition` — detects no-op
- [x] `TestComputeRestackPlan_SkipsMergedNodes` — skips merged/closed
- [x] `TestRestackValidation_BranchNotInStack` — error for unknown branch
- [x] `TestRestackValidation_AfterNotInStack` — error for unknown target
- [x] `TestRestackValidation_AfterSelf` — error for self-move
- [x] `TestRestackValidation_AlreadyInPosition` — error for no-op
- [x] `TestRestackValidation_AfterBase` — valid: move to first
- [x] `TestRestackValidation_ValidMove` — valid move accepted
- [x] `TestRunRestack_MoveCAfterA` — full integration: rebase + file verification
- [x] `TestRunRestack_MoveToBase` — full integration: move to first position
- [x] `TestRunRestackAbort_NoRestackInProgress` — error when no restack active
- [x] `TestRunRestackContinue_NoRestackInProgress` — error when no restack active
- [x] `TestRunRestack_SnapshotSavedAndCleared` — snapshot lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)