### PR TITLE
ci: pin govulncheck to v1.1.4 (latest panics on generics under Go 1.26)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,13 @@ jobs:
           go-version-file: go.mod
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        # Pinned: govulncheck @latest (x/tools v0.46.0) panics with
+        # "ForEachElement called on type containing *types.TypeParam" during
+        # symbol-level SSA analysis of generics under Go 1.26.x. v1.1.4 is the
+        # last release without that regression. The vulnerability database is
+        # fetched fresh at runtime regardless of tool version, so coverage is
+        # unaffected. Revisit once a fixed govulncheck release is out.
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
       - name: Run govulncheck
         run: govulncheck ./...


### PR DESCRIPTION
## Pin govulncheck to v1.1.4

`govulncheck@latest` now pulls `golang.org/x/tools v0.46.0`, which **panics** during symbol-level SSA analysis of this codebase's generics under Go 1.26.x:

```
panic: ForEachElement called on type containing *types.TypeParam
```

A panic exits non-zero, failing the Security job. This is a tool regression, **not a real vulnerability** — confirmed by running the pinned version:

```
$ govulncheck ./...   # v1.1.4
=== Symbol Results ===
No vulnerabilities found.
Your code is affected by 0 vulnerabilities.
```

`v1.1.4` is the last release before the regression. It keeps the existing **symbol-level** precision, and the vulnerability **database is fetched fresh at runtime regardless of tool version**, so coverage is unchanged. Revert to `@latest` once a fixed govulncheck release is available.

`main` currently passes this check only by luck (its reachable-generics set doesn't hit the panic path); this hardens it. The same pin is also included in #230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
