### PR TITLE
feat: sdf↔flow integration — idempotent commands, PR draft/ready, structured sync JSON (v0.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,143 @@ Or use a relative path with the `{repo}` placeholder:
 sdf config set worktree.base_path /workareas/{repo}
 ```
 
+## JSON output contract
+
+Every `sdf` command that writes machine-readable output accepts `--json` and prints a single JSON object to stdout. This section documents the stable field names that automation tools and AI agents can rely on.
+
+### Idempotency and `created`
+
+`new`, `branch`, and `pr` are idempotent. Re-running a command that already succeeded returns the current resource with `"created": false` and exits 0. The first successful run returns `"created": true`. On re-run, a note is printed to stderr; stdout is always valid JSON.
+
+```sh
+sdf new my-feature --json
+# first run:  { "stack": "my-feature", ..., "created": true }
+# second run: { "stack": "my-feature", ..., "created": false }
+```
+
+### `sdf new --json`
+
+```json
+{
+  "stack": "my-feature",
+  "base": "main",
+  "branch": "my-feature/my-feature",
+  "worktree_path": "/path/to/my-feature-my-feature",
+  "pushed": true,
+  "created": true
+}
+```
+
+- `worktree_path` — absolute path to the branch's worktree directory; present only when the stack was created with `--worktrees`, omitted otherwise.
+- `created` — `true` when this invocation created the stack; `false` when it already existed.
+
+### `sdf branch --json`
+
+```json
+{
+  "branch": "my-feature/ui",
+  "parent": "my-feature/api",
+  "worktree_path": "/path/to/my-feature-ui",
+  "created": true
+}
+```
+
+### `sdf pr --json` and `sdf pr --draft` / `sdf pr --ready`
+
+```sh
+sdf pr --json            # create a ready PR
+sdf pr --draft --json    # create as draft
+sdf pr --ready --json    # flip an existing draft PR to ready
+```
+
+`PRResult` fields:
+
+```json
+{
+  "number": 42,
+  "pr": 42,
+  "url": "https://github.com/org/repo/pull/42",
+  "title": "feat(ui): add login form",
+  "draft": false,
+  "created": true
+}
+```
+
+- `pr` — alias of `number`; both fields are always present.
+- `draft` — `true` when the PR is in draft state.
+- `created` — `true` when this invocation opened the PR; `false` when the PR already existed (idempotent re-run).
+- `--ready` — marks an existing draft PR as ready. Idempotent on an already-ready PR. Errors clearly if no PR exists for the branch.
+
+### `sdf status --json` — `sync_state` enum
+
+Each node in `branches[]` carries a `sync_state` field:
+
+| Value | Meaning |
+|-------|---------|
+| `"in_sync"` | Branch is current with its (effective) parent. |
+| `"needs_sync"` | Parent advanced or a parent merged; branch must be synced. |
+| `"conflicted"` | A rebase is paused in this branch's worktree, awaiting conflict resolution. |
+| `""` (omitted) | Base branch or a node without a meaningful sync state. |
+
+`status` (the PR lifecycle field on each node) remains `open | merged | closed` — it is distinct from `sync_state`.
+
+### Worktree `sdf sync --json` — `branches[].status` and `conflicts`
+
+Run inside a branch's worktree, `sdf sync` and `sdf sync --continue` emit exactly one entry in `branches[]`:
+
+```json
+{
+  "branches": [
+    {
+      "branch": "my-feature/ui",
+      "status": "conflicted",
+      "conflicts": ["src/app.go", "src/handler.go"],
+      "pushed": false
+    }
+  ]
+}
+```
+
+`status` values:
+
+| Value | Meaning |
+|-------|---------|
+| `"clean"` | Branch was rebased onto its parent and pushed (`pushed: true`). |
+| `"noop"` | Already up to date with parent; nothing was rebased or pushed. |
+| `"conflicted"` | Rebase paused; `conflicts` lists the conflicted file paths. |
+
+**A conflict is a normal, actionable outcome — not a process error.** When `status` is `"conflicted"`, the top-level `error` field is empty and the process exits 0. Resolve the conflicts in the worktree, stage the files, then re-run `sdf sync --continue`.
+
+`error` and `error_code` at the top level are reserved for genuine failures (lock timeout, push rejection, IO errors).
+
+### Lock-timeout error (`error_code`)
+
+When two `sdf` invocations race and one cannot acquire the stack lock, the blocked invocation emits:
+
+```json
+{
+  "error": "timed out waiting for stack lock",
+  "error_code": "lock_timeout"
+}
+```
+
+and exits with code **75** (EX_TEMPFAIL). Integrators can detect `error_code: "lock_timeout"` and retry. All other errors exit with code 1.
+
+In non-`--json` mode, exit 75 is the distinguishable signal; the human-readable error is printed to stderr.
+
+### Stable field-name summary
+
+| Command | Stable JSON keys |
+|---------|-----------------|
+| `new` | `stack`, `base`, `branch`, `worktree_path`, `pushed`, `created`, `error_code` |
+| `branch` | `branch`, `parent`, `worktree_path`, `created`, `error_code` |
+| `pr` | `number`, `pr`, `url`, `title`, `draft`, `created`, `error_code` |
+| `status` node | `branch`, `status`, `sync_state`, `worktree_path`, `pr` |
+| `sync` | `branches[].{branch, status, conflicts, pushed}`, `error`, `error_code` |
+| `switch --path-only` | bare absolute path on stdout (no JSON wrapper) |
+
+All JSON changes across sdf releases are additive. No existing field is renamed or removed.
+
 ## Configuration
 
 `sdf` uses a two-tier configuration system:

--- a/cmd/branch.go
+++ b/cmd/branch.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -13,6 +14,11 @@ import (
 	"github.com/pavelpascari/sdf/internal/stack"
 	"github.com/spf13/cobra"
 )
+
+// errBranchExists is a sentinel returned by the in-lock re-check when a
+// concurrent invocation has already inserted the node. It is never surfaced
+// to the user — the caller treats it as the idempotent-return path.
+var errBranchExists = errors.New("branch already exists")
 
 // NewBranchResult is the structured output of sdf branch when --json is used.
 type NewBranchResult struct {
@@ -148,12 +154,18 @@ func runBranch(cmd *cobra.Command, args []string) error {
 	// Insert node into the stack JSON under the advisory lock so concurrent
 	// "sdf branch" calls cannot lose each other's writes.
 	// newNode (incl. WorktreePath) was built above, outside the lock.
-	// Inside the fn we re-find the insertion point in the FRESH stack loaded
-	// by WithLock (positions may have shifted under concurrency).
+	// Inside the fn we re-check existence (closes the TOCTOU race from the
+	// outer FindNode fast-path) and re-find the insertion point in the FRESH
+	// stack loaded by WithLock (positions may have shifted under concurrency).
 	var insertAt int
 	var downstreamPR int
 	var downstreamBranch string
 	err = stack.WithLock(root, s.StackID, func(ls *stack.Stack) error {
+		// In-lock existence re-check: a concurrent invocation may have already
+		// inserted this node between our outer FindNode check and now.
+		if ls.FindNode(branchName) != nil {
+			return errBranchExists
+		}
 		// Re-find parent in the freshly-loaded stack.
 		freshIdx := ls.NodeIndex(parent)
 		if freshIdx < 0 {
@@ -170,6 +182,37 @@ func runBranch(cmd *cobra.Command, args []string) error {
 		}
 		return nil
 	})
+	if errors.Is(err, errBranchExists) {
+		// Lost the race — a concurrent invocation already created the node.
+		// Reload the stack to get the winner's node (worktree_path etc. may
+		// differ from what we would have set), then return idempotently.
+		fresh, loadErr := stack.LoadStack(root, s.StackID)
+		if loadErr != nil {
+			return loadErr
+		}
+		existingNode := fresh.FindNode(branchName)
+		var wtp string
+		if existingNode != nil {
+			wtp = existingNode.WorktreePath
+		}
+		result := NewBranchResult{
+			Branch:       branchName,
+			Stack:        s.StackID,
+			Parent:       fresh.ParentBranch(branchName),
+			WorktreePath: wtp,
+			Created:      false,
+		}
+		if jsonFlag {
+			data, marshalErr := json.MarshalIndent(result, "", "  ")
+			if marshalErr != nil {
+				return fmt.Errorf("cannot marshal result: %w", marshalErr)
+			}
+			fmt.Println(string(data))
+			return nil
+		}
+		fmt.Fprintf(os.Stderr, "branch %q already exists in stack %q — returning current state\n", branchName, s.StackID)
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/cmd/branch.go
+++ b/cmd/branch.go
@@ -138,7 +138,15 @@ func runBranch(cmd *cobra.Command, args []string) error {
 		// Create the branch in its own worktree, branched from the parent.
 		// The main repo's checkout is left untouched.
 		if err := addWorktreeForNode(cfg, root, &newNode, parent); err != nil {
-			return err
+			// If the branch already exists (concurrent/previous invocation created
+			// it), fall through to the in-lock re-check rather than hard-erroring.
+			// The WithLock block will either find the node (idempotent return) or
+			// insert exactly one node serialized against the concurrent writer.
+			if !gitpkg.BranchExists(branchName) {
+				return err
+			}
+			// Branch exists; record the worktree path so the node is consistent.
+			newNode.WorktreePath = cfg.WorktreePathFor(root, branchName)
 		}
 	} else {
 		if currentBranch != parent {
@@ -147,7 +155,12 @@ func runBranch(cmd *cobra.Command, args []string) error {
 			}
 		}
 		if err := gitpkg.CreateBranch(branchName); err != nil {
-			return fmt.Errorf("cannot create branch: %w", err)
+			// If the branch already exists (concurrent/previous invocation created
+			// it), fall through to the in-lock re-check rather than hard-erroring.
+			if !gitpkg.BranchExists(branchName) {
+				return fmt.Errorf("cannot create branch: %w", err)
+			}
+			// Branch exists; continue to the WithLock block below.
 		}
 	}
 

--- a/cmd/branch.go
+++ b/cmd/branch.go
@@ -20,6 +20,8 @@ type NewBranchResult struct {
 	Stack        string `json:"stack"`
 	Parent       string `json:"parent"`
 	WorktreePath string `json:"worktree_path,omitempty"`
+	Created      bool   `json:"created"`
+	ErrorCode    string `json:"error_code,omitempty"`
 }
 
 var branchCmd = &cobra.Command{
@@ -71,9 +73,26 @@ func runBranch(cmd *cobra.Command, args []string) error {
 		branchName = cfgpkg.ApplyPrefix(cfg, s.StackID, branchName)
 	}
 
-	// Check if branch already exists in this stack
-	if s.FindNode(branchName) != nil {
-		return fmt.Errorf("branch %q already exists in stack %q", branchName, s.StackID)
+	// Check if branch already exists in this stack — idempotent re-run returns
+	// the existing node's state without recreating the branch or worktree.
+	if existing := s.FindNode(branchName); existing != nil {
+		result := NewBranchResult{
+			Branch:       branchName,
+			Stack:        s.StackID,
+			Parent:       s.ParentBranch(branchName),
+			WorktreePath: existing.WorktreePath,
+			Created:      false,
+		}
+		if jsonFlag {
+			data, err := json.MarshalIndent(result, "", "  ")
+			if err != nil {
+				return fmt.Errorf("cannot marshal result: %w", err)
+			}
+			fmt.Println(string(data))
+			return nil
+		}
+		fmt.Fprintf(os.Stderr, "branch %q already exists in stack %q — returning current state\n", branchName, s.StackID)
+		return nil
 	}
 
 	// Check cross-stack uniqueness
@@ -185,6 +204,7 @@ func runBranch(cmd *cobra.Command, args []string) error {
 			Stack:        s.StackID,
 			Parent:       parent,
 			WorktreePath: newNode.WorktreePath,
+			Created:      true,
 		}
 		_ = bus.Finish()
 		data, err := json.MarshalIndent(result, "", "  ")

--- a/cmd/branch_test.go
+++ b/cmd/branch_test.go
@@ -227,11 +227,27 @@ func TestRunBranch_AppendOnBase(t *testing.T) {
 	}
 }
 
-func TestRunBranch_DuplicateName(t *testing.T) {
-	_ = branchTestRepo(t, false) // [A, B]
+func TestRunBranch_DuplicateNameIsIdempotent(t *testing.T) {
+	dir := branchTestRepo(t, false) // [branchA, branchB]
 
-	err := RunBranch([]string{"--no-prefix", "branchA"})
-	if err == nil {
-		t.Fatal("expected error for duplicate branch name")
+	// Re-adding an existing branch is idempotent: no error, no duplicate node.
+	if err := RunBranch([]string{"--no-prefix", "branchA"}); err != nil {
+		t.Fatalf("re-adding an existing branch must be idempotent, got %v", err)
+	}
+
+	s, err := stack.LoadStack(dir, "test-stack")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify exactly one branchA node (no duplicate)
+	count := 0
+	for _, n := range s.Nodes {
+		if n.Branch == "branchA" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("branchA appears %d times, want 1 (no duplicate)", count)
 	}
 }

--- a/cmd/branch_test.go
+++ b/cmd/branch_test.go
@@ -251,3 +251,75 @@ func TestRunBranch_DuplicateNameIsIdempotent(t *testing.T) {
 		t.Errorf("branchA appears %d times, want 1 (no duplicate)", count)
 	}
 }
+
+// TestRunBranch_InLockRecheckIdempotent exercises the in-lock existence
+// re-check path in runBranch. It simulates the race window by inserting a
+// node into the stack JSON directly via stack.WithLock BEFORE RunBranch
+// acquires its own lock, ensuring that the inner re-check (not just the outer
+// fast-path FindNode) catches the duplicate and returns idempotently.
+//
+// This covers the TOCTOU fix: the outer FindNode sees no node, but by the
+// time WithLock runs, the node already exists — the in-lock re-check must
+// return created:false with no error and exactly one node.
+func TestRunBranch_InLockRecheckIdempotent(t *testing.T) {
+	dir := branchTestRepo(t, false) // [branchA, branchB], HEAD on branchB
+
+	// Simulate a concurrent winner: insert "newbranch" into the stack JSON
+	// directly under the lock, as if another process created it first.
+	// branchTestRepo leaves HEAD on branchB, so we also create the git branch
+	// to keep the repo consistent with the node we're injecting.
+	tip := func() string {
+		t.Helper()
+		cmd := exec.Command("git", "rev-parse", "HEAD")
+		cmd.Dir = dir
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return strings.TrimSpace(string(out))
+	}()
+
+	// Create the git branch so RunBranch doesn't fail on git-side ops (it tries
+	// CreateBranch before acquiring the lock; that call will return an error
+	// which the idempotent path also handles gracefully, but having the branch
+	// present is cleaner for this unit-level test).
+	gitpkg.Checkout("branchB")
+	if err := exec.Command("git", "-C", dir, "branch", "newbranch").Run(); err != nil {
+		t.Fatalf("pre-create git branch: %v", err)
+	}
+
+	// Pre-insert the node into the stack JSON so the in-lock re-check fires.
+	if err := stack.WithLock(dir, "test-stack", func(ls *stack.Stack) error {
+		ls.Nodes = append(ls.Nodes, stack.Node{
+			Branch:  "newbranch",
+			Status:  "open",
+			BaseTip: tip,
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("pre-insert node: %v", err)
+	}
+
+	// RunBranch must detect the node inside the lock, return no error (idempotent).
+	if err := RunBranch([]string{"--no-prefix", "newbranch"}); err != nil {
+		t.Fatalf("RunBranch must be idempotent when node already exists under lock, got: %v", err)
+	}
+
+	// Exactly one "newbranch" node must exist.
+	s, err := stack.LoadStack(dir, "test-stack")
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for _, n := range s.Nodes {
+		if n.Branch == "newbranch" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("newbranch appears %d times after in-lock-recheck idempotent run, want 1", count)
+	}
+	if len(s.Nodes) != 3 {
+		t.Errorf("stack has %d nodes, want 3 (branchA, branchB, newbranch)", len(s.Nodes))
+	}
+}

--- a/cmd/branch_test.go
+++ b/cmd/branch_test.go
@@ -323,3 +323,66 @@ func TestRunBranch_InLockRecheckIdempotent(t *testing.T) {
 		t.Errorf("stack has %d nodes, want 3 (branchA, branchB, newbranch)", len(s.Nodes))
 	}
 }
+
+// TestRunBranch_GitBranchExistsNodeAbsent exercises the concurrent LOSER path:
+// the git branch already exists (created by the winner) but the stack node
+// does NOT exist yet (the winner's WithLock write hasn't landed or this process
+// loaded the stack before the winner persisted). RunBranch must NOT hard-error
+// on the failing CreateBranch call; instead it must fall through to the
+// WithLock block, insert exactly one node, and return without error.
+//
+// This is the C1 gap fix: previously runBranch would hard-error at
+// gitpkg.CreateBranch when the branch existed, never reaching the in-lock
+// re-check. Now it probes BranchExists after the error and continues.
+func TestRunBranch_GitBranchExistsNodeAbsent(t *testing.T) {
+	dir := branchTestRepo(t, false) // [branchA, branchB], HEAD on branchB
+
+	// Simulate the WINNER's git side: create the git branch directly without
+	// touching the stack JSON (as if the winner created the branch but hasn't
+	// persisted the node yet — or we are the loser who loaded the stack first).
+	gitpkg.Checkout("branchB")
+	if err := exec.Command("git", "-C", dir, "branch", "branchX").Run(); err != nil {
+		t.Fatalf("pre-create git branch branchX: %v", err)
+	}
+
+	// Stack JSON has NO node for branchX — this is the loser's exact state.
+	s0, err := stack.LoadStack(dir, "test-stack")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s0.FindNode("branchX") != nil {
+		t.Fatal("test setup error: branchX node must not exist yet")
+	}
+
+	// RunBranch must NOT return an error (the git-already-exists must fall
+	// through to the in-lock path which inserts the node cleanly).
+	if err := RunBranch([]string{"--no-prefix", "branchX"}); err != nil {
+		t.Fatalf("RunBranch must succeed when git branch exists but node absent, got: %v", err)
+	}
+
+	// Exactly one branchX node must now exist.
+	s, err := stack.LoadStack(dir, "test-stack")
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for _, n := range s.Nodes {
+		if n.Branch == "branchX" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("branchX appears %d times, want 1", count)
+	}
+	if len(s.Nodes) != 3 {
+		t.Errorf("stack has %d nodes, want 3 (branchA, branchB, branchX)", len(s.Nodes))
+	}
+	// The node must be valid.
+	node := s.FindNode("branchX")
+	if node == nil {
+		t.Fatal("branchX node not found after RunBranch")
+	}
+	if node.Status == "" {
+		t.Error("branchX node has empty status")
+	}
+}

--- a/cmd/branch_worktree_test.go
+++ b/cmd/branch_worktree_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	cfgpkg "github.com/pavelpascari/sdf/internal/config"
+	gitpkg "github.com/pavelpascari/sdf/internal/git"
 	"github.com/pavelpascari/sdf/internal/stack"
 )
 
@@ -67,5 +68,64 @@ func TestBranchIsIdempotent(t *testing.T) {
 	}
 	if count != 1 {
 		t.Errorf("feat/b appears %d times, want 1", count)
+	}
+}
+
+// TestBranchWorktree_GitBranchExistsNodeAbsent exercises the concurrent LOSER
+// path in worktree mode: the git branch already exists but the stack node does
+// not. addWorktreeForNode will fail because the branch exists; the fix probes
+// BranchExists and falls through to WithLock which inserts the node cleanly.
+func TestBranchWorktree_GitBranchExistsNodeAbsent(t *testing.T) {
+	root := bareRepoWithClone(t)
+	if _, err := runNewCore("feat", "main", "feat/a", false, true); err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	// Create the git branch directly without creating a worktree or stack node,
+	// simulating the winner's git-side work before it persisted the node.
+	if err := exec.Command("git", "-C", root, "branch", "feat/b", "main").Run(); err != nil {
+		t.Fatalf("pre-create git branch feat/b: %v", err)
+	}
+
+	// Stack JSON must have NO node for feat/b.
+	s0, err := stack.LoadStack(root, "feat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s0.FindNode("feat/b") != nil {
+		t.Fatal("test setup error: feat/b node must not exist yet")
+	}
+
+	// RunBranch must not hard-error; it must fall through and insert the node.
+	if err := RunBranch([]string{"feat/b", "--no-prefix"}); err != nil {
+		t.Fatalf("RunBranch must succeed when git branch exists but node absent (worktree mode), got: %v", err)
+	}
+
+	s, err := stack.LoadStack(root, "feat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	node := s.FindNode("feat/b")
+	if node == nil {
+		t.Fatal("feat/b node not found after RunBranch")
+	}
+	count := 0
+	for _, n := range s.Nodes {
+		if n.Branch == "feat/b" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("feat/b appears %d times, want 1", count)
+	}
+	// In worktree mode the node must carry a worktree path.
+	cfg := cfgpkg.Defaults()
+	want := cfg.WorktreePathFor(root, "feat/b")
+	if node.WorktreePath != want {
+		t.Errorf("WorktreePath = %q, want %q", node.WorktreePath, want)
+	}
+	// The git branch must still exist.
+	if !gitpkg.BranchExists("feat/b") {
+		t.Error("git branch feat/b should still exist")
 	}
 }

--- a/cmd/branch_worktree_test.go
+++ b/cmd/branch_worktree_test.go
@@ -45,3 +45,27 @@ func TestBranchWorktreeModeCreatesWorktree(t *testing.T) {
 		t.Errorf("main repo HEAD changed to %q", out)
 	}
 }
+
+func TestBranchIsIdempotent(t *testing.T) {
+	root := bareRepoWithClone(t)
+	if _, err := runNewCore("feat", "main", "feat/a", false, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunBranch([]string{"feat/b", "--no-prefix"}); err != nil {
+		t.Fatal(err)
+	}
+	// Re-running the same branch must not error and must not duplicate the node.
+	if err := RunBranch([]string{"feat/b", "--no-prefix"}); err != nil {
+		t.Fatalf("re-add must be idempotent, got %v", err)
+	}
+	s, _ := stack.LoadStack(root, "feat")
+	count := 0
+	for _, n := range s.Nodes {
+		if n.Branch == "feat/b" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("feat/b appears %d times, want 1", count)
+	}
+}

--- a/cmd/errorcode.go
+++ b/cmd/errorcode.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"errors"
+
+	"github.com/pavelpascari/sdf/internal/stack"
+)
+
+// errorCodeFor returns a stable machine code for an error, or "" for ordinary errors.
+func errorCodeFor(err error) string {
+	if errors.Is(err, stack.ErrLockTimeout) {
+		return "lock_timeout"
+	}
+	return ""
+}
+
+// exitCodeFor maps an error to a process exit code: 75 (EX_TEMPFAIL) for a
+// lock-timeout (retryable), 1 otherwise.
+func exitCodeFor(err error) int {
+	if errorCodeFor(err) == "lock_timeout" {
+		return 75
+	}
+	return 1
+}

--- a/cmd/external_merge_test.go
+++ b/cmd/external_merge_test.go
@@ -1,0 +1,129 @@
+// cmd/external_merge_test.go
+// Test: J8 — external merge propagation.
+// When a human merges a PR on GitHub, a subsequent sdf status must show the
+// merged node as status:"merged" and its immediate child as
+// sync_state:"needs_sync", so that flow's cascade triggers correctly.
+//
+// We simulate gh's state by directly writing the merged status into the stack
+// JSON (just as ReconcileFromPRs would), advance main past the merged node's
+// tip, then run status --json and assert both invariants.
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/pavelpascari/sdf/internal/stack"
+)
+
+// commitOnMain commits a file on the main branch inside the repo at root
+// using git -C (no checkout change required; main must already be the HEAD
+// or reachable). Since in a worktree-mode repo the main repo's HEAD is on
+// main, this is safe to call from the clone root.
+func commitOnMain(t *testing.T, root, file, content, msg string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(root, file), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"add", file},
+		{"-c", "user.email=t@t.com", "-c", "user.name=T", "commit", "-m", msg},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+}
+
+// captureStatusJSON runs RunStatus(["--json"]) and returns its stdout bytes.
+// Flags are reset before the call; the caller must have chdir'd to the repo root.
+func captureStatusJSON(t *testing.T) []byte {
+	t.Helper()
+	resetStatusFlags()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	runErr := RunStatus([]string{"--json"})
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatal(err)
+	}
+	if runErr != nil {
+		t.Fatalf("status --json: %v", runErr)
+	}
+	return buf.Bytes()
+}
+
+// TestExternalMergePropagatesNeedsSync asserts J8: when feat/a is externally
+// merged (status set to "merged") and main advances past its tip (simulating
+// the squash-merge commit), status reports feat/a as merged and feat/b as
+// needs_sync (because ParentBranch skips feat/a → feat/b's effective parent is
+// main, which has moved beyond feat/b's recorded BaseTip).
+func TestExternalMergePropagatesNeedsSync(t *testing.T) {
+	// Build: main ← feat/a (worktree) ← feat/b (worktree)
+	root := bareRepoWithClone(t)
+	if _, err := runNewCore("feat", "main", "feat/a", false, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunBranch([]string{"feat/b", "--no-prefix"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate feat/a being merged on GitHub: write merged status directly into
+	// the stack JSON (this is exactly what ReconcileFromPRs + ApplyRoutineChange
+	// would do when gh reports state:"MERGED").
+	s, err := stack.LoadStack(root, "feat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nodeA := s.FindNode("feat/a")
+	if nodeA == nil {
+		t.Fatal("precondition: feat/a not found in stack")
+	}
+	nodeA.Status = "merged"
+	if err := stack.Save(root, s); err != nil {
+		t.Fatal(err)
+	}
+
+	// Advance main past feat/a's tip (simulates the squash-merge commit that
+	// GitHub pushes to main when the PR is merged).
+	// The main repo's HEAD is on main (worktree mode leaves main repo on base).
+	commitOnMain(t, root, "merged.txt", "m\n", "merge of feat/a")
+
+	// Run status --json from the main repo root.
+	chdir(t, root)
+	out := captureStatusJSON(t)
+
+	var sr StatusResult
+	if err := json.Unmarshal(out, &sr); err != nil {
+		t.Fatalf("unmarshal status result: %v\nraw: %s", err, out)
+	}
+
+	// Assert both invariants.
+	var gotStatusA, gotSyncStateB string
+	for _, n := range sr.Nodes {
+		switch n.Branch {
+		case "feat/a":
+			gotStatusA = n.Status
+		case "feat/b":
+			gotSyncStateB = n.SyncState
+		}
+	}
+	if gotStatusA != "merged" {
+		t.Errorf("feat/a status = %q, want \"merged\"", gotStatusA)
+	}
+	if gotSyncStateB != "needs_sync" {
+		t.Errorf("feat/b sync_state = %q, want \"needs_sync\"", gotSyncStateB)
+	}
+}

--- a/cmd/lock_timeout_test.go
+++ b/cmd/lock_timeout_test.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pavelpascari/sdf/internal/stack"
+)
+
+func TestLockTimeoutMapsToErrorCode(t *testing.T) {
+	if code := errorCodeFor(fmt.Errorf("wrap: %w", stack.ErrLockTimeout)); code != "lock_timeout" {
+		t.Errorf("got %q, want lock_timeout", code)
+	}
+	if code := errorCodeFor(fmt.Errorf("other")); code != "" {
+		t.Errorf("non-lock error must have empty code, got %q", code)
+	}
+	if exitCodeFor(fmt.Errorf("x: %w", stack.ErrLockTimeout)) != 75 {
+		t.Errorf("lock timeout must exit 75")
+	}
+}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -107,18 +109,60 @@ func runNewCore(stackName, base, branchFlag string, jsonFlag, worktree bool) (st
 	// Migrate legacy layout if needed
 	stack.MigrateIfNeeded(root)
 
-	// Check if a stack with this name already exists — idempotent re-run returns
-	// current state instead of erroring, so flow can safely re-issue the command
-	// on crash-resume.
-	if existing, loadErr := stack.LoadStack(root, stackName); loadErr == nil {
+	// Resolve the base branch before acquiring the lock (no I/O risk here).
+	baseBranch := base
+	if baseBranch == "" {
+		detected, err := gitpkg.DefaultBranch()
+		if err != nil {
+			return "", fmt.Errorf("cannot auto-detect default branch: %w\nSpecify one explicitly with --base <branch>", err)
+		}
+		baseBranch = detected
+	}
+
+	// Validate the base branch exists
+	if !gitpkg.BranchExists(baseBranch) && !gitpkg.BranchExists("origin/"+baseBranch) {
+		return "", fmt.Errorf("base branch %q does not exist — check the name or use --base <branch>", baseBranch)
+	}
+
+	// Ensure .sdf/ exists so AcquireLock can create its lock file.
+	// This is idempotent — MkdirAll succeeds if the directory already exists.
+	if err := os.MkdirAll(filepath.Join(root, stack.SDFDir), 0755); err != nil {
+		return "", fmt.Errorf("cannot create .sdf directory: %w", err)
+	}
+
+	// Existence check + Init are performed atomically under the stack advisory
+	// lock so two concurrent "sdf new <same-stack>" invocations cannot both see
+	// "not found" and double-create. AcquireLock is used directly because
+	// WithLock calls LoadStack, which fails for stacks that don't exist yet.
+	//
+	// errStackExists is a local sentinel: the winner returns false/created,
+	// the loser (or a sequential re-run) returns the idempotent state.
+	errStackExists := errors.New("stack already exists")
+	var existingStack *stack.Stack
+	lockErr := func() error {
+		lock, err := stack.AcquireLock(root, stackName, stack.LockTimeout)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = lock.Release() }()
+
+		// In-lock existence re-check.
+		if s, loadErr := stack.LoadStack(root, stackName); loadErr == nil {
+			existingStack = s
+			return errStackExists
+		}
+		return stack.Init(root, stackName, baseBranch)
+	}()
+	if errors.Is(lockErr, errStackExists) {
+		// Stack already exists (race winner or sequential re-run) — return idempotently.
 		var firstNode stack.Node
-		if len(existing.Nodes) > 0 {
-			firstNode = existing.Nodes[0]
+		if len(existingStack.Nodes) > 0 {
+			firstNode = existingStack.Nodes[0]
 		}
 		if jsonFlag {
 			result := NewResult{
 				Stack:        stackName,
-				Base:         existing.Base,
+				Base:         existingStack.Base,
 				Branch:       firstNode.Branch,
 				WorktreePath: firstNode.WorktreePath,
 				Pushed:       false,
@@ -135,24 +179,8 @@ func runNewCore(stackName, base, branchFlag string, jsonFlag, worktree bool) (st
 		fmt.Fprintf(os.Stderr, "note: stack %q already exists — returning current state\n", stackName)
 		return "", nil
 	}
-
-	// Resolve the base branch
-	baseBranch := base
-	if baseBranch == "" {
-		detected, err := gitpkg.DefaultBranch()
-		if err != nil {
-			return "", fmt.Errorf("cannot auto-detect default branch: %w\nSpecify one explicitly with --base <branch>", err)
-		}
-		baseBranch = detected
-	}
-
-	// Validate the base branch exists
-	if !gitpkg.BranchExists(baseBranch) && !gitpkg.BranchExists("origin/"+baseBranch) {
-		return "", fmt.Errorf("base branch %q does not exist — check the name or use --base <branch>", baseBranch)
-	}
-
-	if err := stack.Init(root, stackName, baseBranch); err != nil {
-		return "", err
+	if lockErr != nil {
+		return "", lockErr
 	}
 
 	// Mark worktree mode on the freshly-created stack under the advisory lock

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -15,10 +15,13 @@ import (
 
 // NewResult is the structured output of sdf new when --json is used.
 type NewResult struct {
-	Stack  string `json:"stack"`
-	Base   string `json:"base"`
-	Branch string `json:"branch"`
-	Pushed bool   `json:"pushed"`
+	Stack        string `json:"stack"`
+	Base         string `json:"base"`
+	Branch       string `json:"branch"`
+	WorktreePath string `json:"worktree_path,omitempty"`
+	Pushed       bool   `json:"pushed"`
+	Created      bool   `json:"created"`
+	ErrorCode    string `json:"error_code,omitempty"`
 }
 
 var newCmd = &cobra.Command{
@@ -104,9 +107,33 @@ func runNewCore(stackName, base, branchFlag string, jsonFlag, worktree bool) (st
 	// Migrate legacy layout if needed
 	stack.MigrateIfNeeded(root)
 
-	// Check if a stack with this name already exists
-	if _, err := stack.LoadStack(root, stackName); err == nil {
-		return "", fmt.Errorf("stack %q already exists in %s", stackName, root)
+	// Check if a stack with this name already exists — idempotent re-run returns
+	// current state instead of erroring, so flow can safely re-issue the command
+	// on crash-resume.
+	if existing, loadErr := stack.LoadStack(root, stackName); loadErr == nil {
+		var firstNode stack.Node
+		if len(existing.Nodes) > 0 {
+			firstNode = existing.Nodes[0]
+		}
+		if jsonFlag {
+			result := NewResult{
+				Stack:        stackName,
+				Base:         existing.Base,
+				Branch:       firstNode.Branch,
+				WorktreePath: firstNode.WorktreePath,
+				Pushed:       false,
+				Created:      false,
+			}
+			data, err := json.MarshalIndent(result, "", "  ")
+			if err != nil {
+				return "", fmt.Errorf("cannot marshal result: %w", err)
+			}
+			output := string(data)
+			fmt.Println(output)
+			return output, nil
+		}
+		fmt.Fprintf(os.Stderr, "note: stack %q already exists — returning current state\n", stackName)
+		return "", nil
 	}
 
 	// Resolve the base branch
@@ -203,10 +230,12 @@ func runNewCore(stackName, base, branchFlag string, jsonFlag, worktree bool) (st
 
 	if jsonFlag {
 		result := NewResult{
-			Stack:  stackName,
-			Base:   baseBranch,
-			Branch: branchName,
-			Pushed: pushed,
+			Stack:        stackName,
+			Base:         baseBranch,
+			Branch:       branchName,
+			WorktreePath: node.WorktreePath,
+			Pushed:       pushed,
+			Created:      true,
 		}
 		data, err := json.MarshalIndent(result, "", "  ")
 		if err != nil {

--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -125,20 +125,16 @@ func TestNew_CreatesBranchWithCustomName(t *testing.T) {
 	}
 }
 
-func TestNew_RejectsExistingStack(t *testing.T) {
+func TestNew_IdempotentExistingStack(t *testing.T) {
 	newTestRepo(t)
 
 	if err := RunNew([]string{"--base", "main", "my-feature"}); err != nil {
 		t.Fatal(err)
 	}
 
-	// Second new with same name should fail
-	err := RunNew([]string{"--base", "main", "my-feature"})
-	if err == nil {
-		t.Fatal("expected error for duplicate stack name")
-	}
-	if !strings.Contains(err.Error(), "already exists") {
-		t.Errorf("expected 'already exists' error, got: %s", err)
+	// Second new with same name must succeed (idempotent re-run for flow crash-resume).
+	if err := RunNew([]string{"--base", "main", "my-feature"}); err != nil {
+		t.Fatalf("re-run must not error: %v", err)
 	}
 }
 

--- a/cmd/new_worktree_test.go
+++ b/cmd/new_worktree_test.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -37,6 +38,8 @@ func bareRepoWithClone(t *testing.T) string {
 	run(work, "add", ".")
 	run(work, "commit", "-m", "init")
 	run(work, "push", "-u", "origin", "main")
+	// Set remote HEAD so DefaultBranch() auto-detection works in tests.
+	run(work, "remote", "set-head", "origin", "main")
 
 	// Resolve symlinks so that paths returned here match what git and os.Getwd
 	// return (on macOS /var is a symlink to /private/var).
@@ -81,5 +84,43 @@ func TestNewWorktreeModeCreatesWorktree(t *testing.T) {
 	out, _ := exec.Command("git", "-C", root, "rev-parse", "--abbrev-ref", "HEAD").CombinedOutput()
 	if got := string(out); got != "main\n" {
 		t.Errorf("main repo HEAD = %q, want main", got)
+	}
+}
+
+func TestNewJSONIncludesWorktreePath(t *testing.T) {
+	root := bareRepoWithClone(t)
+	out, err := RunNewWithOutput([]string{"--branch", "feat/a", "--worktrees", "--json", "feat"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var r NewResult
+	if e := json.Unmarshal([]byte(out), &r); e != nil {
+		t.Fatal(e)
+	}
+	if r.WorktreePath == "" {
+		t.Errorf("worktree_path must be set for --worktrees")
+	}
+	if !r.Created {
+		t.Errorf("created must be true on first create")
+	}
+	_ = root
+}
+
+func TestNewIsIdempotent(t *testing.T) {
+	bareRepoWithClone(t)
+	if _, err := RunNewWithOutput([]string{"--branch", "feat/a", "--worktrees", "--json", "feat"}); err != nil {
+		t.Fatal(err)
+	}
+	out, err := RunNewWithOutput([]string{"--branch", "feat/a", "--worktrees", "--json", "feat"})
+	if err != nil {
+		t.Fatalf("re-run must not error: %v", err)
+	}
+	var r NewResult
+	json.Unmarshal([]byte(out), &r)
+	if r.Created {
+		t.Errorf("created must be false on re-run")
+	}
+	if r.Stack != "feat" || r.Branch != "feat/a" {
+		t.Errorf("re-run must return existing state: %+v", r)
 	}
 }

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -40,6 +40,8 @@ func init() {
 	prCmd.Flags().String("title", "", "PR title (default: auto-generated from branch name)")
 	prCmd.Flags().Bool("json", false, "output result as JSON")
 	prCmd.Flags().Bool("draft", false, "open the PR as a draft")
+	prCmd.Flags().Bool("ready", false, "mark the branch's draft PR as ready for review")
+	prCmd.Flags().String("branch", "", "target branch (default: current)")
 }
 
 // RunPR is a compatibility wrapper for callers that use the old interface.
@@ -67,15 +69,22 @@ func runPR(cmd *cobra.Command, args []string) error {
 	title, _ := cmd.Flags().GetString("title")
 	jsonFlag, _ := cmd.Flags().GetBool("json")
 	draft, _ := cmd.Flags().GetBool("draft")
+	ready, _ := cmd.Flags().GetBool("ready")
+	branchFlag, _ := cmd.Flags().GetString("branch")
 
 	root, err := stack.FindRoot()
 	if err != nil {
 		return err
 	}
 
-	branch, err := gitpkg.CurrentBranch()
-	if err != nil {
-		return fmt.Errorf("cannot determine current branch: %w", err)
+	var branch string
+	if branchFlag != "" {
+		branch = branchFlag
+	} else {
+		branch, err = gitpkg.CurrentBranch()
+		if err != nil {
+			return fmt.Errorf("cannot determine current branch: %w", err)
+		}
 	}
 
 	s, err := resolveStack(root, "")
@@ -86,6 +95,23 @@ func runPR(cmd *cobra.Command, args []string) error {
 	node := s.FindNode(branch)
 	if node == nil {
 		return fmt.Errorf("branch %q is not in stack %q — run `sdf branch` to add it", branch, s.StackID)
+	}
+
+	// --ready: flip a draft PR to ready-for-review. Idempotent.
+	if ready {
+		if node.PR == 0 {
+			return fmt.Errorf("no PR for branch %q — run `sdf pr` first", branch)
+		}
+		if ghpkg.Available() {
+			if err := ghpkg.PRReady(node.PR); err != nil {
+				return fmt.Errorf("cannot mark PR #%d ready: %w", node.PR, err)
+			}
+		}
+		res := PRResult{Number: node.PR, Pr: node.PR, Draft: false, Created: false}
+		if pv, e := ghpkg.PRView(branch); e == nil {
+			res.URL = pv.URL
+		}
+		return emitPRResult(res, jsonFlag)
 	}
 
 	// Idempotent: if a PR already exists for this branch, return its details

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -129,7 +129,7 @@ func runPR(cmd *cobra.Command, args []string) error {
 	if !jsonFlag {
 		fmt.Printf("Creating PR: %s (base: %s)...\n", prTitle, ui.Branch(base))
 	}
-	url, err := ghpkg.PRCreate(prTitle, body, base, branch)
+	url, err := ghpkg.PRCreate(prTitle, body, base, branch, false)
 	if err != nil {
 		return fmt.Errorf("cannot create PR: %w", err)
 	}

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -19,9 +19,13 @@ import (
 
 // PRResult is the structured output of sdf pr when --json is used.
 type PRResult struct {
-	Number int    `json:"number"`
-	URL    string `json:"url"`
-	Title  string `json:"title"`
+	Number    int    `json:"number"`
+	Pr        int    `json:"pr"`
+	URL       string `json:"url"`
+	Title     string `json:"title"`
+	Draft     bool   `json:"draft"`
+	Created   bool   `json:"created"`
+	ErrorCode string `json:"error_code,omitempty"`
 }
 
 var prCmd = &cobra.Command{
@@ -35,6 +39,7 @@ func init() {
 	rootCmd.AddCommand(prCmd)
 	prCmd.Flags().String("title", "", "PR title (default: auto-generated from branch name)")
 	prCmd.Flags().Bool("json", false, "output result as JSON")
+	prCmd.Flags().Bool("draft", false, "open the PR as a draft")
 }
 
 // RunPR is a compatibility wrapper for callers that use the old interface.
@@ -43,9 +48,25 @@ func RunPR(args []string) error {
 	return rootCmd.Execute()
 }
 
+// emitPRResult outputs a PRResult in JSON or human-readable form.
+// Task 6 (--ready) will reuse this helper.
+func emitPRResult(res PRResult, jsonFlag bool) error {
+	if jsonFlag {
+		data, err := json.MarshalIndent(res, "", "  ")
+		if err != nil {
+			return fmt.Errorf("cannot marshal result: %w", err)
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+	fmt.Println(res.URL)
+	return nil
+}
+
 func runPR(cmd *cobra.Command, args []string) error {
 	title, _ := cmd.Flags().GetString("title")
 	jsonFlag, _ := cmd.Flags().GetBool("json")
+	draft, _ := cmd.Flags().GetBool("draft")
 
 	root, err := stack.FindRoot()
 	if err != nil {
@@ -67,8 +88,22 @@ func runPR(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("branch %q is not in stack %q — run `sdf branch` to add it", branch, s.StackID)
 	}
 
+	// Idempotent: if a PR already exists for this branch, return its details
+	// instead of erroring. This allows `sdf pr` to be re-run safely.
 	if node.PR > 0 {
-		return fmt.Errorf("branch %q already has PR #%d", branch, node.PR)
+		res := PRResult{
+			Number:  node.PR,
+			Pr:      node.PR,
+			Created: false,
+		}
+		// Best-effort: enrich with live details from gh when available.
+		if ghpkg.Available() {
+			if info, viewErr := ghpkg.PRView(branch); viewErr == nil {
+				res.URL = info.URL
+				res.Draft = info.IsDraft
+			}
+		}
+		return emitPRResult(res, jsonFlag)
 	}
 
 	if !ghpkg.Available() {
@@ -129,7 +164,7 @@ func runPR(cmd *cobra.Command, args []string) error {
 	if !jsonFlag {
 		fmt.Printf("Creating PR: %s (base: %s)...\n", prTitle, ui.Branch(base))
 	}
-	url, err := ghpkg.PRCreate(prTitle, body, base, branch, false)
+	url, err := ghpkg.PRCreate(prTitle, body, base, branch, draft)
 	if err != nil {
 		return fmt.Errorf("cannot create PR: %w", err)
 	}
@@ -147,27 +182,27 @@ func runPR(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if jsonFlag {
-		result := PRResult{
-			Number: node.PR,
-			URL:    url,
-			Title:  prTitle,
-		}
-		data, err := json.MarshalIndent(result, "", "  ")
-		if err != nil {
-			return fmt.Errorf("cannot marshal result: %w", err)
-		}
-		fmt.Println(string(data))
-	} else {
-		fmt.Println(url)
+	result := PRResult{
+		Number:  node.PR,
+		Pr:      node.PR,
+		URL:     url,
+		Title:   prTitle,
+		Draft:   draft,
+		Created: true,
+	}
 
-		// Update stack navigation in all PRs
-		fmt.Println("Updating stack navigation in PR descriptions...")
-		navBus := render.NewBus(os.Stdout, os.Stderr, render.Options{})
-		defer func() { _ = navBus.Finish() }()
-		if err := updateStackNavForAllPRs(root, s, nil, navBus); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: could not update PR descriptions: %v\n", err)
-		}
+	if jsonFlag {
+		return emitPRResult(result, true)
+	}
+
+	fmt.Println(url)
+
+	// Update stack navigation in all PRs
+	fmt.Println("Updating stack navigation in PR descriptions...")
+	navBus := render.NewBus(os.Stdout, os.Stderr, render.Options{})
+	defer func() { _ = navBus.Finish() }()
+	if err := updateStackNavForAllPRs(root, s, nil, navBus); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not update PR descriptions: %v\n", err)
 	}
 
 	return nil

--- a/cmd/pr_test.go
+++ b/cmd/pr_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -125,5 +126,72 @@ func TestLoadPRTemplate_Missing(t *testing.T) {
 	tmpl := loadPRTemplate(dir)
 	if tmpl != "" {
 		t.Fatalf("expected empty template, got: %q", tmpl)
+	}
+}
+
+func TestPRIdempotentWhenPRExists(t *testing.T) {
+	root := bareRepoWithClone(t)
+	if _, err := runNewCore("feat", "main", "feat/a", false, true); err != nil {
+		t.Fatal(err)
+	}
+	s, err := stack.LoadStack(root, "feat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Nodes[0].PR = 7 // pretend a PR already exists
+	if err := stack.Save(root, s); err != nil {
+		t.Fatal(err)
+	}
+	// Re-running pr for a branch that already has a PR must NOT error.
+	chdir(t, s.Nodes[0].WorktreePath)
+	err = RunPR([]string{"--json"})
+	if err != nil {
+		t.Fatalf("pr must be idempotent when a PR exists, got %v", err)
+	}
+}
+
+func TestPRResultFieldsOnIdempotent(t *testing.T) {
+	root := bareRepoWithClone(t)
+	if _, err := runNewCore("feat", "main", "feat/a", false, true); err != nil {
+		t.Fatal(err)
+	}
+	s, err := stack.LoadStack(root, "feat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Nodes[0].PR = 42
+	if err := stack.Save(root, s); err != nil {
+		t.Fatal(err)
+	}
+	chdir(t, s.Nodes[0].WorktreePath)
+
+	// Capture stdout
+	origStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err = RunPR([]string{"--json"})
+
+	w.Close()
+	os.Stdout = origStdout
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+
+	if err != nil {
+		t.Fatalf("pr must be idempotent when a PR exists, got %v", err)
+	}
+
+	var res PRResult
+	if jsonErr := json.Unmarshal(buf[:n], &res); jsonErr != nil {
+		t.Fatalf("cannot unmarshal PRResult: %v (raw: %q)", jsonErr, string(buf[:n]))
+	}
+	if res.Number != 42 {
+		t.Errorf("Number = %d, want 42", res.Number)
+	}
+	if res.Pr != 42 {
+		t.Errorf("Pr = %d, want 42", res.Pr)
+	}
+	if res.Created {
+		t.Errorf("Created should be false for idempotent re-run")
 	}
 }

--- a/cmd/pr_test.go
+++ b/cmd/pr_test.go
@@ -11,7 +11,19 @@ import (
 	ghpkg "github.com/pavelpascari/sdf/internal/gh"
 	"github.com/pavelpascari/sdf/internal/stack"
 	"github.com/pavelpascari/sdf/internal/testutil"
+	"github.com/spf13/pflag"
 )
+
+// resetPRFlags restores prCmd's flags to their defaults so that reusing the
+// package-level rootCmd across in-process test invocations does not leak flag
+// state (e.g. a prior --ready or --draft). A real `sdf` run is process-isolated;
+// this reproduces that isolation for tests.
+func resetPRFlags() {
+	prCmd.Flags().VisitAll(func(f *pflag.Flag) {
+		_ = f.Value.Set(f.DefValue)
+		f.Changed = false
+	})
+}
 
 func TestRunPR_EmptyBranchAheadOfBase(t *testing.T) {
 	dir := newTestRepo(t)
@@ -147,6 +159,23 @@ func TestPRIdempotentWhenPRExists(t *testing.T) {
 	err = RunPR([]string{"--json"})
 	if err != nil {
 		t.Fatalf("pr must be idempotent when a PR exists, got %v", err)
+	}
+}
+
+func TestPRReadyRequiresExistingPR(t *testing.T) {
+	t.Cleanup(resetPRFlags)
+	root := bareRepoWithClone(t)
+	if _, err := runNewCore("feat", "main", "feat/a", false, true); err != nil {
+		t.Fatal(err)
+	}
+	s, _ := stack.LoadStack(root, "feat")
+	chdir(t, s.Nodes[0].WorktreePath)
+	err := RunPR([]string{"--ready", "--json"})
+	if err == nil {
+		t.Fatalf("pr --ready with no PR must error clearly")
+	}
+	if !strings.Contains(err.Error(), "no PR") {
+		t.Errorf("error should mention no PR: %v", err)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,11 +53,11 @@ func SetVersion(v string) {
 }
 
 // Execute runs the root command. On error it prints the message to stderr
-// and exits with code 1.
+// and exits with the appropriate code (75 for lock timeouts, 1 otherwise).
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		os.Exit(exitCodeFor(err))
 	}
 }
 

--- a/cmd/split.go
+++ b/cmd/split.go
@@ -491,7 +491,7 @@ func createSplitPRs(root string, s *stack.Stack, cfg cfgpkg.Config, originalBran
 
 		fmt.Printf("  %s %s (base: %s)...\n", ui.SymPlan, title, ui.Branch(base))
 
-		url, err := ghpkg.PRCreate(title, body, base, node.Branch)
+		url, err := ghpkg.PRCreate(title, body, base, node.Branch, false)
 		if err != nil {
 			return fmt.Errorf("PR for %s: %w", node.Branch, err)
 		}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -198,6 +198,26 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		parent := s.ParentBranch(node.Branch)
 
 		if status != "merged" && status != "closed" {
+			// For worktree nodes, check if a rebase is paused (conflict) first.
+			// conflicted takes precedence over in_sync/needs_sync.
+			if s.Worktree && node.WorktreePath != "" {
+				if inProg, err := gitpkg.IsRebaseInProgressAt(node.WorktreePath); err == nil && inProg {
+					nr.SyncState = "conflicted"
+					needsSync = append(needsSync, node.Branch)
+					count, err := gitpkg.CommitCount(parent, node.Branch)
+					if err == nil && count != "0" {
+						fmt.Sscanf(count, "%d", &nr.CommitsAhead)
+					}
+					if verbose {
+						if logOut, err := gitpkg.Log(parent, node.Branch); err == nil && logOut != "" {
+							nr.CommitLog = strings.Split(logOut, "\n")
+						}
+					}
+					nodeResults = append(nodeResults, nr)
+					continue
+				}
+			}
+
 			if node.BaseTip != "" {
 				currentParentTip, err := gitpkg.RevParse(parent)
 				if err == nil && currentParentTip != node.BaseTip {

--- a/cmd/status_worktree_test.go
+++ b/cmd/status_worktree_test.go
@@ -4,6 +4,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"os"
 	"testing"
 
@@ -65,5 +66,44 @@ func TestStatusJSONIncludesWorktreePath(t *testing.T) {
 	}
 	if result.Nodes[0].WorktreePath != wantPath {
 		t.Errorf("Nodes[0].WorktreePath = %q, want %q", result.Nodes[0].WorktreePath, wantPath)
+	}
+}
+
+func TestStatusReportsConflictedSyncState(t *testing.T) {
+	root := bareRepoWithClone(t)
+	if _, err := runNewCore("feat", "main", "feat/a", false, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunBranch([]string{"feat/b", "--no-prefix"}); err != nil {
+		t.Fatal(err)
+	}
+	s, _ := stack.LoadStack(root, "feat")
+	wtA, wtB := s.FindNode("feat/a").WorktreePath, s.FindNode("feat/b").WorktreePath
+	// Create a conflict and pause a rebase in feat/b's worktree.
+	commitInWorktree(t, wtA, "shared.txt", "A\n", "a")
+	commitInWorktree(t, wtB, "shared.txt", "B\n", "b")
+	chdir(t, wtB)
+	resetSyncFlags()
+	_ = RunSync(nil) // conflicts → paused rebase in wtB
+	// status from main repo must report feat/b conflicted.
+	chdir(t, root)
+	resetStatusFlags()
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	_ = RunStatus([]string{"--json"})
+	w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+	var sr StatusResult
+	json.Unmarshal(out, &sr)
+	var got string
+	for _, n := range sr.Nodes {
+		if n.Branch == "feat/b" {
+			got = n.SyncState
+		}
+	}
+	if got != "conflicted" {
+		t.Errorf("feat/b sync_state = %q, want conflicted", got)
 	}
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -39,6 +39,7 @@ type SyncResult struct {
 	PRUpdates []PRUpdate     `json:"pr_updates,omitempty"`
 	Warnings  []string       `json:"warnings,omitempty"`
 	Error     string         `json:"error,omitempty"`
+	ErrorCode string         `json:"error_code,omitempty"`
 }
 
 // BranchResult describes what happened to a single branch during sync.
@@ -148,6 +149,7 @@ func runSyncCmd(cmd *cobra.Command, args []string) error {
 		_ = bus.Finish()
 		if err != nil {
 			result.Error = err.Error()
+			result.ErrorCode = errorCodeFor(err)
 		}
 		if jsonRenderer != nil {
 			result.Warnings = append(result.Warnings, jsonRenderer.Warnings()...)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -761,7 +761,7 @@ func promptCreateMissingPRs(root string, s *stack.Stack, opts *syncOptions, resu
 			}
 		}
 
-		url, err := ghpkg.PRCreate(prTitle, body, base, node.Branch)
+		url, err := ghpkg.PRCreate(prTitle, body, base, node.Branch, false)
 		if err != nil {
 			bus.Warnf("  %s could not create PR: %v", ui.SymFail, err)
 			continue

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -43,12 +43,14 @@ type SyncResult struct {
 
 // BranchResult describes what happened to a single branch during sync.
 type BranchResult struct {
-	Branch      string `json:"branch"`
-	PR          int    `json:"pr,omitempty"`
-	Action      string `json:"action"`
-	Pushed      bool   `json:"pushed,omitempty"`
-	BaseUpdated bool   `json:"base_updated,omitempty"`
-	Reason      string `json:"reason,omitempty"`
+	Branch      string   `json:"branch"`
+	PR          int      `json:"pr,omitempty"`
+	Action      string   `json:"action"`
+	Pushed      bool     `json:"pushed,omitempty"`
+	BaseUpdated bool     `json:"base_updated,omitempty"`
+	Reason      string   `json:"reason,omitempty"`
+	Status      string   `json:"status,omitempty"`    // worktree sync: clean | noop | conflicted
+	Conflicts   []string `json:"conflicts,omitempty"` // worktree sync: conflicted paths
 }
 
 // PRUpdate describes a PR field update during sync.
@@ -189,7 +191,7 @@ func runSyncContinue(root string, result *SyncResult, bus *render.Bus) error {
 					if normalizeSymlinks(prog.WorktreePath) == normWtRoot {
 						s, err := stack.LoadByBranch(root, branch)
 						if err == nil && s.Worktree {
-							return continueWorktreeSync(root, s.StackID, branch, bus)
+							return continueWorktreeSync(root, s.StackID, branch, result, bus)
 						}
 					}
 				}
@@ -202,7 +204,7 @@ func runSyncContinue(root string, result *SyncResult, bus *render.Bus) error {
 		if s, e := stack.LoadByBranch(root, cur); e == nil && s.Worktree {
 			local, _ := stack.LoadLocal(root)
 			if local != nil && local.WorktreeProgress != nil && local.WorktreeProgress[cur] != nil {
-				return continueWorktreeSync(root, s.StackID, cur, bus)
+				return continueWorktreeSync(root, s.StackID, cur, result, bus)
 			}
 			return fmt.Errorf("no paused worktree sync for %s — run `sdf sync` in this worktree", cur)
 		}
@@ -223,7 +225,7 @@ func runSyncContinue(root string, result *SyncResult, bus *render.Bus) error {
 		// This can happen if a worktree conflict was recorded before the per-branch
 		// map was introduced. Route to continueWorktreeSync using the stored stackID.
 		if s, e := stack.LoadByBranch(root, progress.PausedAt); e == nil {
-			return continueWorktreeSync(root, s.StackID, progress.PausedAt, bus)
+			return continueWorktreeSync(root, s.StackID, progress.PausedAt, result, bus)
 		}
 	}
 
@@ -336,7 +338,7 @@ func runSyncFull(root, stackName string, skipConfirm, flagWithContent, jsonMode,
 	if s.Worktree {
 		cur, _ := gitpkg.CurrentBranch()
 		if currentWorktreeNode(s, cur) != nil {
-			return runWorktreeSyncStep(root, s.StackID, cur, bus)
+			return runWorktreeSyncStep(root, s.StackID, cur, result, bus)
 		}
 		return runWorktreeDashboard(root, s, bus)
 	}

--- a/cmd/sync_worktree.go
+++ b/cmd/sync_worktree.go
@@ -28,7 +28,7 @@ func clearWorktreeProgress(root, branch string) error {
 // branch. It reads progress from WorktreeProgress[branch] under the lock,
 // does the rebase-state detection in the worktree, then acquires the stack
 // lock for the BaseTip update, push, save, and WorktreeProgress cleanup.
-func continueWorktreeSync(root, stackID, branch string, bus *render.Bus) error {
+func continueWorktreeSync(root, stackID, branch string, result *SyncResult, bus *render.Bus) error {
 	// Read progress outside the lock first (read-only; detect rebase state).
 	local0, _ := stack.LoadLocal(root)
 	if local0 == nil || local0.WorktreeProgress == nil || local0.WorktreeProgress[branch] == nil {
@@ -41,6 +41,18 @@ func continueWorktreeSync(root, stackID, branch string, bus *render.Bus) error {
 	case inProg:
 		bus.Printf("  rebasing %s (continuing)...", ui.Branch(progress.PausedAt))
 		if err := gitpkg.RebaseContinueAt(wt); err != nil {
+			// Rebase still has conflicts.
+			conflicts, _ := gitpkg.ConflictedFilesAt(wt)
+			if result != nil {
+				// JSON / flow mode: structured output, no Go error.
+				result.Branches = append(result.Branches, BranchResult{
+					Branch:    branch,
+					Status:    "conflicted",
+					Conflicts: conflicts,
+				})
+				return nil
+			}
+			// Human mode: keep the existing error so callers get a non-zero signal.
 			return fmt.Errorf("rebase --continue failed: %w\n\nResolve remaining conflicts, stage them, and run `sdf sync --continue` again", err)
 		}
 	case gitpkg.IsAncestor(progress.ParentTip, progress.PausedAt):
@@ -57,13 +69,17 @@ func continueWorktreeSync(root, stackID, branch string, bus *render.Bus) error {
 	}
 
 	var childBranch string
+	var prNum int
+	var pushOK bool
 	lockErr := stack.WithLock(root, stackID, func(s *stack.Stack) error {
 		node := s.FindNode(progress.PausedAt)
 		if node != nil {
+			prNum = node.PR
 			node.BaseTip = progress.ParentTip
 			if err := gitpkg.PushAt(wt, node.Branch); err != nil {
 				bus.Warnf("  %s push failed for %s: %v", ui.SymFail, ui.Branch(node.Branch), err)
 			} else {
+				pushOK = true
 				bus.Printf("  %s %s rebased and pushed", ui.SymOK, ui.Branch(node.Branch))
 			}
 			// stack.Save is NOT called here; WithLock saves on nil return.
@@ -82,6 +98,15 @@ func continueWorktreeSync(root, stackID, branch string, bus *render.Bus) error {
 		return lockErr
 	}
 
+	if result != nil {
+		result.Branches = append(result.Branches, BranchResult{
+			Branch: branch,
+			PR:     prNum,
+			Status: "clean",
+			Pushed: pushOK,
+		})
+	}
+
 	if childBranch != "" {
 		bus.Printf("\nDownstream %s now needs to sync.", ui.Branch(childBranch))
 	}
@@ -97,7 +122,7 @@ func continueWorktreeSync(root, stackID, branch string, bus *render.Bus) error {
 //  1. Pre-lock: load base branch name, fetch from origin, fast-forward base.
 //  2. Locked: reload a fresh stack, mutate node.BaseTip, push, save.
 //  3. Post-lock: reload stack read-only, refresh PR nav links.
-func runWorktreeSyncStep(root, stackID, branch string, bus *render.Bus) error {
+func runWorktreeSyncStep(root, stackID, branch string, result *SyncResult, bus *render.Bus) error {
 	// --- Phase 1: fetch/ff BEFORE acquiring the lock ---
 	// Quick read-only load to discover the base branch name.
 	sForBase, err := stack.LoadStack(root, stackID)
@@ -115,7 +140,12 @@ func runWorktreeSyncStep(root, stackID, branch string, bus *render.Bus) error {
 	}
 
 	// --- Phase 2: acquire lock, reload fresh, mutate ---
-	worked := false
+	// stepKind is set inside the lock to communicate the outcome to the post-lock
+	// section without holding the lock. Values: "noop", "conflict", "clean".
+	stepKind := ""
+	var stepConflicts []string
+	var stepPR int
+	var stepPushed bool
 	var childBranch string
 
 	lockErr := stack.WithLock(root, stackID, func(s *stack.Stack) error {
@@ -132,7 +162,8 @@ func runWorktreeSyncStep(root, stackID, branch string, bus *render.Bus) error {
 		}
 		if parentTip == node.BaseTip {
 			bus.Printf("%s %s is up to date with %s", ui.SymOK, ui.Branch(branch), ui.Branch(parent))
-			return nil // no-op; worked stays false
+			stepKind = "noop"
+			return nil
 		}
 
 		clean, err := gitpkg.IsCleanAt(wt)
@@ -170,6 +201,17 @@ func runWorktreeSyncStep(root, stackID, branch string, bus *render.Bus) error {
 				ls.WorktreeProgress[branch] = progress
 				return nil
 			})
+
+			stepKind = "conflict"
+			stepConflicts = conflicts
+
+			if result != nil {
+				// JSON / flow mode: populate structured output, no Go error.
+				// Human-readable guidance is skipped; the caller reads the JSON.
+				return nil
+			}
+			// Human mode: print guidance and return an error so humans get
+			// a non-zero exit signal and the existing conflict tests still pass.
 			bus.Warnf("  %s conflict rebasing %s", ui.SymFail, ui.Branch(branch))
 			for _, f := range conflicts {
 				bus.Printf("      %s", f)
@@ -178,9 +220,11 @@ func runWorktreeSyncStep(root, stackID, branch string, bus *render.Bus) error {
 			return fmt.Errorf("conflict in %s", branch)
 		}
 
+		pushOK := false
 		if err := gitpkg.PushAt(wt, branch); err != nil {
 			bus.Warnf("  %s push failed for %s: %v", ui.SymFail, ui.Branch(branch), err)
 		} else {
+			pushOK = true
 			bus.Printf("  %s %s rebased and pushed", ui.SymOK, ui.Branch(branch))
 		}
 
@@ -203,18 +247,47 @@ func runWorktreeSyncStep(root, stackID, branch string, bus *render.Bus) error {
 		if child := findNextOpenNode(s, branch); child != nil {
 			childBranch = child.Branch
 		}
-		worked = true
+		stepKind = "clean"
+		stepPR = node.PR
+		stepPushed = pushOK
 		return nil // stack.WithLock saves on nil return
 	})
 	if lockErr != nil {
 		return lockErr
 	}
 
-	if !worked {
+	// Populate result (json mode only — result is nil in human mode).
+	if result != nil {
+		switch stepKind {
+		case "noop":
+			result.Branches = append(result.Branches, BranchResult{
+				Branch: branch,
+				Status: "noop",
+			})
+		case "conflict":
+			result.Branches = append(result.Branches, BranchResult{
+				Branch:    branch,
+				Status:    "conflicted",
+				Conflicts: stepConflicts,
+			})
+			// Conflict is NOT a Go error in json mode; return nil so runSyncCmd
+			// does not set result.Error.
+			return nil
+		case "clean":
+			result.Branches = append(result.Branches, BranchResult{
+				Branch: branch,
+				PR:     stepPR,
+				Status: "clean",
+				Pushed: stepPushed,
+			})
+		}
+	}
+
+	if stepKind == "" || stepKind == "noop" {
 		return nil
 	}
 
-	// --- Phase 3: post-lock — refresh PR nav links ---
+	// --- Phase 3: post-lock — refresh PR nav links (only on clean rebase) ---
 	// Reload the stack read-only so nav sees the updated BaseTip.
 	freshStack, err := stack.LoadStack(root, stackID)
 	if err != nil {

--- a/cmd/sync_worktree_json_test.go
+++ b/cmd/sync_worktree_json_test.go
@@ -1,0 +1,96 @@
+// cmd/sync_worktree_json_test.go
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/pavelpascari/sdf/internal/stack"
+)
+
+// captureSyncJSON runs `sdf sync --json`, parses SyncResult, returns branches[0].
+func captureSyncJSON(t *testing.T) BranchResult {
+	t.Helper()
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	_ = RunSync([]string{"--json"})
+	w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+	var sr SyncResult
+	if err := json.Unmarshal(out, &sr); err != nil {
+		t.Fatalf("bad json: %v\n%s", err, out)
+	}
+	if len(sr.Branches) == 0 {
+		t.Fatalf("no branches in result: %s", out)
+	}
+	return sr.Branches[0]
+}
+
+func TestWorktreeSyncJSONCleanAndNoop(t *testing.T) {
+	root := bareRepoWithClone(t)
+	if _, err := runNewCore("feat", "main", "feat/a", false, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunBranch([]string{"feat/b", "--no-prefix"}); err != nil {
+		t.Fatal(err)
+	}
+	s, _ := stack.LoadStack(root, "feat")
+	commitInWorktree(t, s.FindNode("feat/a").WorktreePath, "a.txt", "x\n", "a")
+	chdir(t, s.FindNode("feat/b").WorktreePath)
+
+	// First sync: clean rebase.
+	resetSyncFlags()
+	br := captureSyncJSON(t)
+	if br.Status != "clean" || !br.Pushed {
+		t.Errorf("want clean+pushed, got %+v", br)
+	}
+
+	// Second sync: noop.
+	resetSyncFlags()
+	br = captureSyncJSON(t)
+	if br.Status != "noop" {
+		t.Errorf("want noop, got %+v", br)
+	}
+}
+
+func TestWorktreeSyncJSONConflictIsNotError(t *testing.T) {
+	root := bareRepoWithClone(t)
+	if _, err := runNewCore("feat", "main", "feat/a", false, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunBranch([]string{"feat/b", "--no-prefix"}); err != nil {
+		t.Fatal(err)
+	}
+	s, _ := stack.LoadStack(root, "feat")
+	commitInWorktree(t, s.FindNode("feat/a").WorktreePath, "shared.txt", "A\n", "a")
+	commitInWorktree(t, s.FindNode("feat/b").WorktreePath, "shared.txt", "B\n", "b")
+	chdir(t, s.FindNode("feat/b").WorktreePath)
+
+	resetSyncFlags()
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	err := RunSync([]string{"--json"})
+	w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("conflict must not be a process error: %v", err)
+	}
+	out, _ := io.ReadAll(r)
+	var sr SyncResult
+	json.Unmarshal(out, &sr)
+	if sr.Error != "" {
+		t.Errorf("top-level error must be empty on conflict, got %q", sr.Error)
+	}
+	if len(sr.Branches) != 1 || sr.Branches[0].Status != "conflicted" {
+		t.Errorf("want branches[0].status=conflicted, got %+v", sr.Branches)
+	}
+	if len(sr.Branches[0].Conflicts) == 0 {
+		t.Errorf("conflicts must list paths")
+	}
+}

--- a/docs/superpowers/plans/2026-06-17-flow-integration.md
+++ b/docs/superpowers/plans/2026-06-17-flow-integration.md
@@ -1,0 +1,553 @@
+# sdf ↔ flow Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the gaps between flow's integration contract and sdf v0.4.0 — idempotent `new`/`branch`/`pr`, PR draft/ready, additive `--json` fields (`worktree_path`, `pr`, `draft`, `created`, `error_code`), a `conflicted` sync_state, a structured conflict-≠-error contract for worktree `sync`, and a distinguishable lock-timeout error.
+
+**Architecture:** Mostly additive JSON fields + new flags on existing commands, plus one behavior change (idempotency) and the worktree-sync status contract. All idempotency/mutation continues to run under the existing `stack.WithLock`. No new top-level JSON objects — the worktree sync result extends the existing `SyncResult.Branches[]`.
+
+**Tech Stack:** Go 1.26.x, cobra, shells to `git`/`gh`. Tests use real `git` in `t.TempDir()`; `gh` interactions use the spyrecord build tag / `ghpkg.Available()` guards.
+
+## Global Constraints
+- Module `github.com/pavelpascari/sdf`. Spec: `docs/superpowers/specs/2026-06-17-flow-integration-design.md`.
+- **All JSON changes are additive** — never rename or remove an existing field (`number`, `title`, `action`, etc. stay). flow's parser keys on stable names.
+- **Idempotent by default:** re-running `new`/`branch`/`pr` for an existing resource returns its current state, exit 0, with `"created": false` (vs `true` when freshly created). Existence checks run inside `stack.WithLock`.
+- **Conflict ≠ error:** worktree `sync`/`--continue` report a rebase conflict as `branches[0].status:"conflicted"` with `conflicts:[paths]`, exit 0, and an EMPTY top-level `error`. `error`/`error_code` are for real failures only.
+- **Headless:** flow-invoked commands never prompt.
+- **Lock-timeout distinguishable:** `--json` emits `error_code:"lock_timeout"`; non-json exits `75`.
+- `sync_state` enum: `in_sync | needs_sync | conflicted` (empty for base). `status` enum: `open | merged | closed`.
+- Verify with `go build ./... && go test ./... -count=1` (note: pre-existing `cmd/` failures from test helpers running `git add .sdf` against gitignored `.sdf/` are environmental — verify via focused `-run` tests).
+- Commit per task; Conventional Commits; body ends with:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+- Work on branch `flow-integration` (already created off `main`).
+
+### Canonical signatures (consumed across tasks)
+```go
+// internal/stack/lock.go
+var ErrLockTimeout = errors.New("stack lock acquire timed out")   // returned by AcquireLock on timeout
+
+// internal/gh/gh.go
+func PRCreate(title, body, base, head string, draft bool) (string, error)   // signature CHANGED: +draft
+func PRReady(prNumber int) error                                            // NEW: `gh pr ready <n>`
+
+// cmd result structs (additive fields)
+type NewResult struct { Stack, Base, Branch string; WorktreePath string `json:"worktree_path,omitempty"`; Pushed, Created bool; ErrorCode string `json:"error_code,omitempty"` }
+type NewBranchResult struct { Branch, Stack, Parent string; WorktreePath string `json:"worktree_path,omitempty"`; Created bool; ErrorCode string `json:"error_code,omitempty"` }
+type PRResult struct { Number, Pr int; URL, Title string; Draft, Created bool; ErrorCode string `json:"error_code,omitempty"` }
+// BranchResult gains: Status string `json:"status,omitempty"` (clean|noop|conflicted); Conflicts []string `json:"conflicts,omitempty"`
+// SyncResult gains: ErrorCode string `json:"error_code,omitempty"`
+```
+
+---
+
+## Task 1: `stack.ErrLockTimeout` sentinel
+
+**Files:** Modify `internal/stack/lock.go` (`AcquireLock` timeout return). Test: `internal/stack/lock_test.go`.
+
+**Interfaces:** Produces `stack.ErrLockTimeout` (wrapped/returned by `AcquireLock` on timeout).
+
+- [ ] **Step 1: Write the failing test**
+```go
+// add to internal/stack/lock_test.go
+func TestAcquireLockTimeoutReturnsSentinel(t *testing.T) {
+	root := sdfRepo(t)
+	l, err := AcquireLock(root, "feat", time.Second)
+	if err != nil { t.Fatal(err) }
+	defer l.Release()
+	_, err = AcquireLock(root, "feat", 100*time.Millisecond)
+	if !errors.Is(err, ErrLockTimeout) {
+		t.Fatalf("expected ErrLockTimeout, got %v", err)
+	}
+}
+```
+(Add `"errors"` import to the test if missing.)
+
+- [ ] **Step 2: Run to verify it fails** — `go test ./internal/stack/ -run TestAcquireLockTimeoutReturnsSentinel -count=1` → FAIL (undefined `ErrLockTimeout`).
+
+- [ ] **Step 3: Implement.** In `internal/stack/lock.go` add (with `"errors"` imported):
+```go
+// ErrLockTimeout is returned by AcquireLock when the lock cannot be acquired
+// within the timeout (another sdf process holds it). Callers map it to a
+// distinguishable error_code / exit code so orchestrators retry rather than escalate.
+var ErrLockTimeout = errors.New("stack lock acquire timed out")
+```
+In `AcquireLock`, change the timeout return from the ad-hoc `fmt.Errorf("timed out ...")` to wrap the sentinel:
+```go
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("%w: %s (another sdf process may be running)", ErrLockTimeout, path)
+		}
+```
+
+- [ ] **Step 4: Run to verify it passes** — `go test ./internal/stack/ -count=1` → PASS.
+- [ ] **Step 5: Commit** — `feat(stack): add ErrLockTimeout sentinel for lock-acquire timeout`.
+
+---
+
+## Task 2: gh wrappers — `PRCreate(..., draft)` + `PRReady`
+
+**Files:** Modify `internal/gh/gh.go` (`PRCreate` signature, new `PRReady`); update the OTHER `PRCreate` caller in `cmd/sync.go` (`promptCreateMissingPRs`). Test: `internal/gh/gh_test.go` (or the spy-based test file used for gh).
+
+**Interfaces:**
+- Produces: `PRCreate(title, body, base, head string, draft bool) (string, error)`, `PRReady(prNumber int) error`.
+- Consumes: existing `run(...)` gh wrapper.
+
+- [ ] **Step 1: Write the failing test** (use the repo's existing gh-wrapper test pattern; if gh tests shell to a fake `gh` via `Binary`, mirror it). Minimal contract test:
+```go
+// internal/gh/gh_test.go
+func TestPRCreateDraftFlag(t *testing.T) {
+	got := prCreateArgs("t", "b", "main", "feat/x", true)
+	if !containsArg(got, "--draft") { t.Errorf("draft create must pass --draft: %v", got) }
+	got = prCreateArgs("t", "b", "main", "feat/x", false)
+	if containsArg(got, "--draft") { t.Errorf("non-draft must not pass --draft: %v", got) }
+}
+func TestPRReadyArgs(t *testing.T) {
+	if a := prReadyArgs(42); a[0] != "pr" || a[1] != "ready" || a[2] != "42" {
+		t.Errorf("pr ready args = %v", a)
+	}
+}
+func containsArg(a []string, s string) bool { for _, x := range a { if x == s { return true } }; return false }
+```
+(This requires extracting the arg-building into small pure helpers `prCreateArgs`/`prReadyArgs` so they're unit-testable without invoking `gh`.)
+
+- [ ] **Step 2: Run to verify it fails** — `go test ./internal/gh/ -run 'TestPRCreateDraftFlag|TestPRReadyArgs' -count=1` → FAIL (undefined).
+
+- [ ] **Step 3: Implement.** In `internal/gh/gh.go`, refactor `PRCreate` to build args via a helper and accept `draft`, and add `PRReady`:
+```go
+func prCreateArgs(title, body, base, head string, draft bool) []string {
+	args := []string{"pr", "create", "--title", title, "--body", body, "--head", head}
+	if base != "" {
+		args = append(args, "--base", base)
+	}
+	if draft {
+		args = append(args, "--draft")
+	}
+	return args
+}
+
+// PRCreate opens a PR for head against base. When draft is true it is opened as a draft.
+func PRCreate(title, body, base, head string, draft bool) (string, error) {
+	return run(prCreateArgs(title, body, base, head, draft)...)
+}
+
+func prReadyArgs(prNumber int) []string {
+	return []string{"pr", "ready", fmt.Sprintf("%d", prNumber)}
+}
+
+// PRReady marks a draft PR as ready for review. Idempotent: marking an
+// already-ready PR is a no-op success on GitHub's side.
+func PRReady(prNumber int) error {
+	_, err := run(prReadyArgs(prNumber)...)
+	return err
+}
+```
+Update the OTHER caller — `cmd/sync.go` `promptCreateMissingPRs` calls `ghpkg.PRCreate(prTitle, body, base, node.Branch)`; change to `ghpkg.PRCreate(prTitle, body, base, node.Branch, false)`.
+
+- [ ] **Step 4: Run to verify it passes** — `go test ./internal/gh/ -count=1 && go build ./...` → PASS (build confirms the sync.go caller is fixed).
+- [ ] **Step 5: Commit** — `feat(gh): PRCreate --draft support and PRReady wrapper`.
+
+---
+
+## Task 3: `sdf new` — idempotent + `worktree_path` + `created` (J1)
+
+**Files:** Modify `cmd/new.go` (`NewResult`, `runNewCore`). Test: `cmd/new_worktree_test.go`.
+
+**Interfaces:** Consumes `stack.WithLock`. Produces `NewResult{..., WorktreePath, Created, ErrorCode}`.
+
+- [ ] **Step 1: Write the failing tests**
+```go
+// add to cmd/new_worktree_test.go
+func TestNewJSONIncludesWorktreePath(t *testing.T) {
+	root := bareRepoWithClone(t)
+	out, err := RunNewWithOutput([]string{"feat", "--branch", "feat/a", "--worktrees", "--json"})
+	if err != nil { t.Fatal(err) }
+	var r NewResult
+	if e := json.Unmarshal([]byte(out), &r); e != nil { t.Fatal(e) }
+	if r.WorktreePath == "" { t.Errorf("worktree_path must be set for --worktrees") }
+	if !r.Created { t.Errorf("created must be true on first create") }
+	_ = root
+}
+func TestNewIsIdempotent(t *testing.T) {
+	bareRepoWithClone(t)
+	if _, err := RunNewWithOutput([]string{"feat", "--branch", "feat/a", "--worktrees", "--json"}); err != nil { t.Fatal(err) }
+	out, err := RunNewWithOutput([]string{"feat", "--branch", "feat/a", "--worktrees", "--json"})
+	if err != nil { t.Fatalf("re-run must not error: %v", err) }
+	var r NewResult
+	json.Unmarshal([]byte(out), &r)
+	if r.Created { t.Errorf("created must be false on re-run") }
+	if r.Stack != "feat" || r.Branch != "feat/a" { t.Errorf("re-run must return existing state: %+v", r) }
+}
+```
+(Add `"encoding/json"` import if missing.)
+
+- [ ] **Step 2: Run to verify it fails** — `go test ./cmd/ -run 'TestNewJSONIncludesWorktreePath|TestNewIsIdempotent' -count=1` → FAIL (no `WorktreePath`/`Created`; re-run errors "already exists").
+
+- [ ] **Step 3: Implement.** Extend `NewResult`:
+```go
+type NewResult struct {
+	Stack        string `json:"stack"`
+	Base         string `json:"base"`
+	Branch       string `json:"branch"`
+	WorktreePath string `json:"worktree_path,omitempty"`
+	Pushed       bool   `json:"pushed"`
+	Created      bool   `json:"created"`
+	ErrorCode    string `json:"error_code,omitempty"`
+}
+```
+In `runNewCore`, replace the early `if _, err := stack.LoadStack(root, stackName); err == nil { return "", fmt.Errorf("stack %q already exists ...") }` with an idempotent return: load the existing stack, find its first node, build a `NewResult{Created:false, WorktreePath: firstNode.WorktreePath, ...}` and return it (marshal+print when `jsonFlag`, else print an "already exists — returning current state" note to stderr). On the create path set `Created: true` and populate `WorktreePath` from the first node when `worktree` mode. (Populate `WorktreePath` from `node.WorktreePath` after `addWorktreeForNode`.)
+
+- [ ] **Step 4: Run to verify it passes** — `go test ./cmd/ -run 'TestNew' -count=1 && go build ./...` → PASS.
+- [ ] **Step 5: Commit** — `feat(new): idempotent re-run, worktree_path + created in JSON`.
+
+---
+
+## Task 4: `sdf branch` — idempotent + `created` (J2)
+
+**Files:** Modify `cmd/branch.go` (`NewBranchResult`, `runBranch`). Test: `cmd/branch_worktree_test.go`.
+
+**Interfaces:** Produces `NewBranchResult{..., Created, ErrorCode}` (already has `WorktreePath`).
+
+- [ ] **Step 1: Write the failing test**
+```go
+func TestBranchIsIdempotent(t *testing.T) {
+	root := bareRepoWithClone(t)
+	if _, err := runNewCore("feat", "main", "feat/a", false, true); err != nil { t.Fatal(err) }
+	if err := RunBranch([]string{"feat/b", "--no-prefix"}); err != nil { t.Fatal(err) }
+	// Re-running the same branch must not error and must not duplicate the node.
+	if err := RunBranch([]string{"feat/b", "--no-prefix"}); err != nil {
+		t.Fatalf("re-add must be idempotent, got %v", err)
+	}
+	s, _ := stack.LoadStack(root, "feat")
+	count := 0
+	for _, n := range s.Nodes { if n.Branch == "feat/b" { count++ } }
+	if count != 1 { t.Errorf("feat/b appears %d times, want 1", count) }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails** — `go test ./cmd/ -run TestBranchIsIdempotent -count=1` → FAIL (errors "already exists").
+
+- [ ] **Step 3: Implement.** Extend `NewBranchResult`:
+```go
+type NewBranchResult struct {
+	Branch       string `json:"branch"`
+	Stack        string `json:"stack"`
+	Parent       string `json:"parent"`
+	WorktreePath string `json:"worktree_path,omitempty"`
+	Created      bool   `json:"created"`
+	ErrorCode    string `json:"error_code,omitempty"`
+}
+```
+In `runBranch`, replace `if s.FindNode(branchName) != nil { return fmt.Errorf("branch %q already exists ...") }` with an idempotent return: if the node exists, build `NewBranchResult{Created:false, Branch, Stack, Parent: s.ParentBranch(branchName), WorktreePath: node.WorktreePath}` and return it (JSON or human note), without recreating the branch/worktree. On the create path set `Created:true`.
+
+- [ ] **Step 4: Run to verify it passes** — `go test ./cmd/ -run 'TestBranch' -count=1 && go build ./...` → PASS.
+- [ ] **Step 5: Commit** — `feat(branch): idempotent re-add, created in JSON`.
+
+---
+
+## Task 5: `sdf pr` — `--draft`, fields, idempotent (J3)
+
+**Files:** Modify `cmd/pr.go` (flag, `PRResult`, `runPR`). Test: `cmd/pr_test.go` (create if absent).
+
+**Interfaces:** Consumes `ghpkg.PRCreate(...,draft)`, `ghpkg.PRView`. Produces `PRResult{Number, Pr, URL, Title, Draft, Created, ErrorCode}`.
+
+- [ ] **Step 1: Write the failing test** (needs `ghpkg.Available()`; if the test env has no gh, guard with `t.Skip` when `!ghpkg.Available()` — mirror existing pr/gh tests. Assert the result struct shape + idempotency logic that does NOT require gh: the "already has PR" idempotent branch can be unit-tested by pre-seeding `node.PR`):
+```go
+func TestPRIdempotentWhenPRExists(t *testing.T) {
+	root := bareRepoWithClone(t)
+	if _, err := runNewCore("feat", "main", "feat/a", false, true); err != nil { t.Fatal(err) }
+	s, _ := stack.LoadStack(root, "feat")
+	s.Nodes[0].PR = 7   // pretend a PR already exists
+	stack.Save(root, s)
+	// Re-running pr for a branch that already has a PR must NOT error.
+	// (In worktree mode, run from the branch's worktree.)
+	chdir(t, s.Nodes[0].WorktreePath)
+	err := RunPR([]string{"--json"})
+	if err != nil { t.Fatalf("pr must be idempotent when a PR exists, got %v", err) }
+}
+```
+(If `RunPR` needs gh to fetch PR details for the idempotent return and gh is unavailable, the idempotent branch must degrade gracefully: return `{number:7, pr:7, created:false}` with whatever details are obtainable, never error solely because the PR already exists. Implement so the no-gh path still returns the known `node.PR`.)
+
+- [ ] **Step 2: Run to verify it fails** — `go test ./cmd/ -run TestPRIdempotentWhenPRExists -count=1` → FAIL (errors "already has PR #7").
+
+- [ ] **Step 3: Implement.** Add the flag in `pr.go` `init`: `prCmd.Flags().Bool("draft", false, "open the PR as a draft")`. Extend `PRResult`:
+```go
+type PRResult struct {
+	Number    int    `json:"number"`
+	Pr        int    `json:"pr"`
+	URL       string `json:"url"`
+	Title     string `json:"title"`
+	Draft     bool   `json:"draft"`
+	Created   bool   `json:"created"`
+	ErrorCode string `json:"error_code,omitempty"`
+}
+```
+In `runPR`: read `draft, _ := cmd.Flags().GetBool("draft")`. Replace `if node.PR > 0 { return fmt.Errorf("branch %q already has PR #%d", ...) }` with an idempotent return — fetch current details via `ghpkg.PRView(branch)` when available (`url`, `IsDraft`), build `PRResult{Number: node.PR, Pr: node.PR, URL, Title, Draft, Created:false}` and return (JSON/human); if gh unavailable, return `{Number/Pr: node.PR, Created:false}`. On the create path: pass `draft` to `ghpkg.PRCreate(prTitle, body, base, branch, draft)`, and populate the result with `Pr: node.PR`, `Draft: draft`, `Created: true`.
+
+- [ ] **Step 4: Run to verify it passes** — `go test ./cmd/ -run 'TestPR' -count=1 && go build ./...` → PASS.
+- [ ] **Step 5: Commit** — `feat(pr): --draft, idempotent re-run, pr/draft/created JSON fields`.
+
+---
+
+## Task 6: `sdf pr --ready` (J4)
+
+**Files:** Modify `cmd/pr.go` (flag, ready branch in `runPR`, `--branch` flag). Test: `cmd/pr_test.go`.
+
+**Interfaces:** Consumes `ghpkg.PRReady`, `ghpkg.PRView`.
+
+- [ ] **Step 1: Write the failing test** (logic-level; guard gh calls):
+```go
+func TestPRReadyRequiresExistingPR(t *testing.T) {
+	root := bareRepoWithClone(t)
+	if _, err := runNewCore("feat", "main", "feat/a", false, true); err != nil { t.Fatal(err) }
+	s, _ := stack.LoadStack(root, "feat")
+	chdir(t, s.Nodes[0].WorktreePath)
+	err := RunPR([]string{"--ready", "--json"})
+	if err == nil { t.Fatalf("pr --ready with no PR must error clearly") }
+	if !strings.Contains(err.Error(), "no PR") { t.Errorf("error should mention no PR: %v", err) }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails** — undefined `--ready` flag (cobra errors on unknown flag) or wrong behavior.
+
+- [ ] **Step 3: Implement.** In `pr.go` `init`: `prCmd.Flags().Bool("ready", false, "mark the branch's draft PR as ready for review")` and `prCmd.Flags().String("branch", "", "target branch (default: current)")`. At the top of `runPR`, after resolving `branch` (honoring `--branch` when set) and `node`: if `ready` flag set, branch into a ready path:
+```go
+	if ready {
+		if node.PR == 0 {
+			return fmt.Errorf("no PR for branch %q — run `sdf pr` first", branch)
+		}
+		if ghpkg.Available() {
+			if err := ghpkg.PRReady(node.PR); err != nil {
+				return fmt.Errorf("cannot mark PR #%d ready: %w", node.PR, err)
+			}
+		}
+		res := PRResult{Number: node.PR, Pr: node.PR, Draft: false, Created: false}
+		if pv, e := ghpkg.PRView(branch); e == nil { res.URL = pv.URL }
+		return emitPRResult(res, jsonFlag)   // helper that marshals (json) or prints (human)
+	}
+```
+Extract the JSON-or-human emission into a small `emitPRResult(PRResult, json bool) error` helper reused by the create/idempotent/ready paths. `--ready` is idempotent (GitHub `pr ready` on an already-ready PR is a no-op).
+
+- [ ] **Step 4: Run to verify it passes** — `go test ./cmd/ -run 'TestPR' -count=1 && go build ./...` → PASS.
+- [ ] **Step 5: Commit** — `feat(pr): --ready to un-draft a PR`.
+
+---
+
+## Task 7: `status` — `conflicted` sync_state (J5)
+
+**Files:** Modify `cmd/status.go` (sync_state computation). Test: `cmd/status_worktree_test.go`.
+
+**Interfaces:** Consumes `gitpkg.IsRebaseInProgressAt`.
+
+- [ ] **Step 1: Write the failing test**
+```go
+func TestStatusReportsConflictedSyncState(t *testing.T) {
+	root := bareRepoWithClone(t)
+	if _, err := runNewCore("feat", "main", "feat/a", false, true); err != nil { t.Fatal(err) }
+	if err := RunBranch([]string{"feat/b", "--no-prefix"}); err != nil { t.Fatal(err) }
+	s, _ := stack.LoadStack(root, "feat")
+	wtA, wtB := s.FindNode("feat/a").WorktreePath, s.FindNode("feat/b").WorktreePath
+	// Create a conflict and pause a rebase in feat/b's worktree.
+	commitInWorktree(t, wtA, "shared.txt", "A\n", "a")
+	commitInWorktree(t, wtB, "shared.txt", "B\n", "b")
+	chdir(t, wtB)
+	_ = RunSync(nil) // conflicts → paused rebase in wtB
+	// status from main repo must report feat/b conflicted.
+	chdir(t, root)
+	resetStatusFlags()
+	old := os.Stdout; r, w, _ := os.Pipe(); os.Stdout = w
+	_ = RunStatus([]string{"--json"})
+	w.Close(); os.Stdout = old
+	out, _ := io.ReadAll(r)
+	var sr StatusResult
+	json.Unmarshal(out, &sr)
+	var got string
+	for _, n := range sr.Nodes { if n.Branch == "feat/b" { got = n.SyncState } }
+	if got != "conflicted" { t.Errorf("feat/b sync_state = %q, want conflicted", got) }
+}
+```
+(Add imports `io`, `os`, `strings`/`encoding/json` as needed; `resetStatusFlags` exists from prior work.)
+
+- [ ] **Step 2: Run to verify it fails** — `go test ./cmd/ -run TestStatusReportsConflictedSyncState -count=1` → FAIL (status reports `needs_sync`, not `conflicted`).
+
+- [ ] **Step 3: Implement.** In `status.go`, where `nr.SyncState` is computed (the ~line 208-224 block), add a conflicted check that takes precedence: for a worktree node, if `gitpkg.IsRebaseInProgressAt(node.WorktreePath)` is true, set `nr.SyncState = "conflicted"` and skip the in_sync/needs_sync computation for that node. Guard on `s.Worktree && node.WorktreePath != ""`.
+
+- [ ] **Step 4: Run to verify it passes** — `go test ./cmd/ -run 'TestStatus' -count=1 && go build ./...` → PASS.
+- [ ] **Step 5: Commit** — `feat(status): conflicted sync_state for paused worktree rebases`.
+
+---
+
+## Task 8: Worktree `sync`/`--continue` structured status (J6/J7)
+
+**Files:** Modify `cmd/sync.go` (`BranchResult` fields), `cmd/sync_worktree.go` (`runWorktreeSyncStep`, `continueWorktreeSync` populate `result`). Test: `cmd/sync_worktree_test.go`.
+
+**Interfaces:** Produces `BranchResult.Status` (`clean|noop|conflicted`), `BranchResult.Conflicts []string`. The worktree sync step writes exactly one `branches[]` entry and does NOT set top-level `error` on conflict.
+
+This requires threading the `*SyncResult` into the worktree sync functions (today they take `bus` only and ignore `result`). `runSyncCmd` already builds `result` in `--json` mode and routes through `runSyncFull` → `runWorktreeSyncStep`. Pass `result` down.
+
+- [ ] **Step 1: Write the failing tests**
+```go
+func TestWorktreeSyncJSONCleanAndNoop(t *testing.T) {
+	root := bareRepoWithClone(t)
+	if _, err := runNewCore("feat", "main", "feat/a", false, true); err != nil { t.Fatal(err) }
+	if err := RunBranch([]string{"feat/b", "--no-prefix"}); err != nil { t.Fatal(err) }
+	s, _ := stack.LoadStack(root, "feat")
+	commitInWorktree(t, s.FindNode("feat/a").WorktreePath, "a.txt", "x\n", "a")
+	chdir(t, s.FindNode("feat/b").WorktreePath)
+	// First sync: clean rebase.
+	resetSyncFlags()
+	br := captureSyncJSON(t)
+	if br.Status != "clean" || !br.Pushed { t.Errorf("want clean+pushed, got %+v", br) }
+	// Second sync: noop.
+	resetSyncFlags()
+	br = captureSyncJSON(t)
+	if br.Status != "noop" { t.Errorf("want noop, got %+v", br) }
+}
+func TestWorktreeSyncJSONConflictIsNotError(t *testing.T) {
+	root := bareRepoWithClone(t)
+	if _, err := runNewCore("feat", "main", "feat/a", false, true); err != nil { t.Fatal(err) }
+	if err := RunBranch([]string{"feat/b", "--no-prefix"}); err != nil { t.Fatal(err) }
+	s, _ := stack.LoadStack(root, "feat")
+	commitInWorktree(t, s.FindNode("feat/a").WorktreePath, "shared.txt", "A\n", "a")
+	commitInWorktree(t, s.FindNode("feat/b").WorktreePath, "shared.txt", "B\n", "b")
+	chdir(t, s.FindNode("feat/b").WorktreePath)
+	resetSyncFlags()
+	old := os.Stdout; r, w, _ := os.Pipe(); os.Stdout = w
+	err := RunSync([]string{"--json"})
+	w.Close(); os.Stdout = old
+	if err != nil { t.Fatalf("conflict must not be a process error: %v", err) }
+	out, _ := io.ReadAll(r)
+	var sr SyncResult
+	json.Unmarshal(out, &sr)
+	if sr.Error != "" { t.Errorf("top-level error must be empty on conflict, got %q", sr.Error) }
+	if len(sr.Branches) != 1 || sr.Branches[0].Status != "conflicted" { t.Errorf("want branches[0].status=conflicted, got %+v", sr.Branches) }
+	if len(sr.Branches[0].Conflicts) == 0 { t.Errorf("conflicts must list paths") }
+}
+// captureSyncJSON runs `sdf sync --json`, parses SyncResult, returns branches[0].
+func captureSyncJSON(t *testing.T) BranchResult {
+	t.Helper()
+	old := os.Stdout; r, w, _ := os.Pipe(); os.Stdout = w
+	_ = RunSync([]string{"--json"})
+	w.Close(); os.Stdout = old
+	out, _ := io.ReadAll(r)
+	var sr SyncResult
+	if err := json.Unmarshal(out, &sr); err != nil { t.Fatalf("bad json: %v\n%s", err, out) }
+	if len(sr.Branches) == 0 { t.Fatalf("no branches in result: %s", out) }
+	return sr.Branches[0]
+}
+```
+
+- [ ] **Step 2: Run to verify it fails** — `go test ./cmd/ -run 'TestWorktreeSyncJSON' -count=1` → FAIL (no `Status`/`Conflicts`; conflict leaks into `error`).
+
+- [ ] **Step 3: Implement.**
+Add to `BranchResult` (cmd/sync.go):
+```go
+	Status    string   `json:"status,omitempty"`    // worktree sync: clean | noop | conflicted
+	Conflicts []string `json:"conflicts,omitempty"` // worktree sync: conflicted paths
+```
+Thread `result *SyncResult` into `runWorktreeSyncStep(root, stackID, branch string, result *SyncResult, bus *render.Bus)` and `continueWorktreeSync(..., result *SyncResult, ...)` (update the routing calls in `runSyncFull`/`runSyncContinue`).
+- No-op path (parentTip == BaseTip): append `BranchResult{Branch: branch, Status: "noop"}`.
+- Success path (rebased + pushed): append `BranchResult{Branch: branch, Status: "clean", Pushed: true, PR: node.PR}`.
+- Conflict path: gather `conflicts, _ := gitpkg.ConflictedFilesAt(wt)`; append `BranchResult{Branch: branch, Status: "conflicted", Conflicts: conflicts}`; record `WorktreeProgress` as today; **return nil** (no Go error) so `runSyncCmd` does not set `result.Error`. Keep the human-mode warning print for non-json.
+Note: the dirty-worktree rejection and real failures (push error, etc.) still return errors → `result.Error` (and `error_code` from Task 9). Only the *rebase conflict* becomes `status:"conflicted"`.
+
+- [ ] **Step 4: Run to verify it passes** — `go test ./cmd/ -run 'TestWorktreeSync' -count=1 && go build ./...` → PASS (incl. existing worktree sync tests; the older `TestWorktreeSyncRejectsDirtyWorktree` still expects an error — confirm the dirty path still errors).
+- [ ] **Step 5: Commit** — `feat(sync): structured status/conflicts for worktree sync; conflict is not an error`.
+
+---
+
+## Task 9: Lock-timeout `error_code` + exit 75 (concurrency req §F)
+
+**Files:** Modify result structs (`SyncResult`, `NewResult`, `NewBranchResult`, `PRResult` already have `ErrorCode` from Tasks 3-5/8 — add to `SyncResult`), and the command wrappers' error handling in `cmd/sync.go`/`cmd/new.go`/`cmd/branch.go`/`cmd/pr.go`/`main.go` (exit code). Create a small helper. Test: `cmd/lock_timeout_test.go`.
+
+**Interfaces:** Consumes `stack.ErrLockTimeout`. Produces `error_code:"lock_timeout"` in JSON; exit 75 in non-json.
+
+- [ ] **Step 1: Write the failing test** (drive a real lock contention; the cleanest is a unit test on the mapping helper):
+```go
+func TestLockTimeoutMapsToErrorCode(t *testing.T) {
+	if code := errorCodeFor(fmt.Errorf("wrap: %w", stack.ErrLockTimeout)); code != "lock_timeout" {
+		t.Errorf("got %q, want lock_timeout", code)
+	}
+	if code := errorCodeFor(fmt.Errorf("other")); code != "" {
+		t.Errorf("non-lock error must have empty code, got %q", code)
+	}
+	if exitCodeFor(fmt.Errorf("x: %w", stack.ErrLockTimeout)) != 75 {
+		t.Errorf("lock timeout must exit 75")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails** — undefined `errorCodeFor`/`exitCodeFor`.
+
+- [ ] **Step 3: Implement.** Add `SyncResult.ErrorCode string json:"error_code,omitempty"` (others added in their tasks). Add a shared helper file `cmd/errorcode.go`:
+```go
+package cmd
+import ( "errors"; "github.com/pavelpascari/sdf/internal/stack" )
+// errorCodeFor returns a stable machine code for an error, or "" for ordinary errors.
+func errorCodeFor(err error) string {
+	if errors.Is(err, stack.ErrLockTimeout) { return "lock_timeout" }
+	return ""
+}
+// exitCodeFor maps an error to a process exit code: 75 (EX_TEMPFAIL) for a
+// lock-timeout (retryable), 1 otherwise.
+func exitCodeFor(err error) int {
+	if errorCodeFor(err) == "lock_timeout" { return 75 }
+	return 1
+}
+```
+In each command's `--json` error path, set `result.ErrorCode = errorCodeFor(err)` alongside `result.Error = err.Error()`. In `main.go`'s top-level error handling (where non-json errors exit), use `os.Exit(exitCodeFor(err))` for the lock-timeout case (read `main.go` to find the exit path; map there).
+
+- [ ] **Step 4: Run to verify it passes** — `go test ./cmd/ -run TestLockTimeoutMapsToErrorCode -count=1 && go build ./...` → PASS.
+- [ ] **Step 5: Commit** — `feat(cmd): distinguishable lock_timeout error_code + exit 75`.
+
+---
+
+## Task 10: External-merge propagation test (J8)
+
+**Files:** Test: `cmd/status_worktree_test.go` (or a new `cmd/external_merge_test.go`). Code only if the test exposes a gap.
+
+- [ ] **Step 1: Write the test.** Build a 2-branch worktree stack with PRs recorded (`node.PR` set). Simulate a remote merge of the head PR by: marking the head node `merged` in a fresh clone's stack state is not how flow sees it — instead simulate what `status` observes: the head branch's PR shows merged. Since driving real `gh` is unavailable, assert the propagation logic directly: set the head node `Status="merged"` in the stack, then assert `status`/`ParentBranch` cause the child's `sync_state` to be `needs_sync` once the base advanced. Concretely: advance `main`, mark head merged, run `status --json` from main repo, assert child node `sync_state:"needs_sync"`.
+```go
+func TestExternalMergePropagatesNeedsSync(t *testing.T) {
+	root := bareRepoWithClone(t)
+	if _, err := runNewCore("feat", "main", "feat/a", false, true); err != nil { t.Fatal(err) }
+	if err := RunBranch([]string{"feat/b", "--no-prefix"}); err != nil { t.Fatal(err) }
+	s, _ := stack.LoadStack(root, "feat")
+	// Simulate feat/a merged on the remote: mark merged + advance main past feat/a's tip.
+	s.FindNode("feat/a").Status = "merged"
+	stack.Save(root, s)
+	// advance main (the merge commit) so feat/b's effective parent (main) moved
+	commitOnBranchViaWorktree(t, root, "main", "merged.txt", "m\n", "merge of feat/a")
+	chdir(t, root); resetStatusFlags()
+	out := captureStatusJSON(t)
+	var sr StatusResult; json.Unmarshal(out, &sr)
+	for _, n := range sr.Nodes {
+		if n.Branch == "feat/a" && n.Status != "merged" { t.Errorf("feat/a status=%q want merged", n.Status) }
+		if n.Branch == "feat/b" && n.SyncState != "needs_sync" { t.Errorf("feat/b sync_state=%q want needs_sync", n.SyncState) }
+	}
+}
+```
+Provide `captureStatusJSON` and `commitOnBranchViaWorktree` helpers (the latter commits on a branch using a throwaway worktree or `git -C`). If `status` does not already surface `needs_sync` for the child here, fix the sync_state computation (it should via `ParentBranch` skipping the merged node + base drift).
+
+- [ ] **Step 2: Run to verify** — `go test ./cmd/ -run TestExternalMergePropagatesNeedsSync -count=1`. If it passes immediately, J8 is confirmed (no code change). If it fails, fix `status` sync_state to account for merged-parent skip, then pass.
+- [ ] **Step 3: Commit** — `test(status): confirm external-merge propagates needs_sync to child` (or `fix(status): ...` if code changed).
+
+---
+
+## Task 11: Docs + full verification
+
+**Files:** Modify `README.md` (sync_state enum + flow JSON field contract; `pr --draft`/`--ready`). Optionally `www/src/data/cli-reference.json` (auto-regenerated by pre-commit hook).
+
+- [ ] **Step 1: Full verification.**
+  - `go build ./... && go vet ./... && golangci-lint run ./...` (0 issues).
+  - `go test ./internal/... -count=1` (all pass).
+  - The flow-touching cmd tests together: `go test ./cmd/ -run 'TestNew|TestBranch|TestPR|TestStatus|TestWorktreeSync|TestLockTimeout|TestExternalMerge' -count=1` (all pass). Confirm the remaining `cmd/` failures are exactly the known pre-existing `.sdf`-gitignore set.
+- [ ] **Step 2: Document.** Add to `README.md`: the `sync_state` enum (`in_sync|needs_sync|conflicted`), `sdf pr --draft`/`--ready`, the `created`/`error_code`/`worktree_path` JSON fields, and a short "JSON output contract" note pointing integrators at the stable field names (mirror the spec's Field-name contract section). Match README's existing tone.
+- [ ] **Step 3: Commit** — `docs: document flow JSON contract, sync_state enum, pr draft/ready`.
+
+---
+
+## Notes for the implementer
+- **Idempotency is success, not a warning-as-error.** Re-runs return the current resource with `created:false` and exit 0. Never `return fmt.Errorf` on "already exists" for `new`/`branch`/`pr`.
+- **Conflict is `status:"conflicted"`, never a process error or a top-level `error`.** Only genuine failures (dirty worktree, push rejection, lock timeout, IO) set `error`/`error_code`.
+- **Additive JSON only.** Keep `number`/`title`/`action`; add `pr`/`draft`/`created`/`worktree_path`/`status`/`conflicts`/`error_code`.
+- **All mutations stay under `stack.WithLock`** (idempotency existence-checks included) — do not reintroduce a load-outside-lock.
+- The `cmd/` package has known pre-existing test failures (helpers `git add .sdf` vs gitignored `.sdf/`); verify your work with focused `-run` filters.

--- a/docs/superpowers/specs/2026-06-17-flow-integration-design.md
+++ b/docs/superpowers/specs/2026-06-17-flow-integration-design.md
@@ -1,0 +1,212 @@
+# sdf ↔ flow Integration — Design
+
+**Date:** 2026-06-17
+**Status:** Approved (pending spec review)
+**Target:** sdf v0.5.0
+
+## Goal
+
+Make sdf satisfy flow's integration contract: a set of headless, `--json`,
+idempotent jobs that flow (the orchestrator) invokes to drive a worktree-mode
+stack. flow supplies the agent in each worktree and polls a coordinator; sdf is
+the substrate that stacks, syncs, and surfaces PR/branch state. This release
+closes the gaps between flow's contract and sdf v0.4.0.
+
+sdf does **not**: trigger/report CI, spawn agents, run reviews, or autonomously
+merge to the default branch. Those are flow's.
+
+## Current state (v0.4.0) vs contract
+
+Already satisfied (no work): `status --json` already emits `sync_state`,
+`worktree_path`, `pr`, `status`, `ci_status`, `review_status`, `mergeable`,
+`is_draft` (J5); `switch --path-only` (J10); branch-as-worktree (J2 creation);
+`prune` (J9); worktree pull-model `sync` (J6 mechanics).
+
+Gaps this spec closes: idempotency of `new`/`branch`/`pr` (J1–J3); `worktree_path`
+in `new --json` (J1); `pr --draft` + `pr --ready` + PR result fields (J3/J4);
+`conflicted` in the `sync_state` enum (J5); structured `{status, conflicts}` for
+worktree `sync`/`--continue` with conflict-≠-error semantics (J6/J7); a
+distinguishable lock-timeout error (concurrency); a test confirming external-merge
+propagation (J8).
+
+## Design
+
+### A. Idempotency by default (J1/J2/J3)
+
+`new`, `branch`, and `pr` currently hard-error when the target already exists.
+flow re-issues commands on crash-resume, so re-running must succeed and return the
+current state.
+
+- `new <stack>`: if the stack already exists, load it and return the existing
+  first branch's `NewResult` (do not recreate the stack, branch, or worktree).
+- `branch <task>`: if the branch already exists in the stack, return its
+  `NewBranchResult` (`branch`, `parent`, `worktree_path`) without recreating the
+  branch or re-adding the worktree.
+- `pr`: if the branch already has a PR, return its `PRResult` (replaces the
+  `"branch %q already has PR #%d"` error).
+
+Each result gains an additive `"created": bool` field: `true` when this invocation
+created the resource, `false` when it already existed. In non-`--json` mode, an
+"already exists — returning current state" note is printed to stderr; exit code is
+0 in both modes. No prompts.
+
+The idempotency check runs **inside the existing stack lock** (`stack.WithLock`)
+where the command already mutates stack state, so a concurrent create cannot race
+the existence check.
+
+### B. `sdf pr` — draft, ready, fields (J3/J4)
+
+- New flag `--draft`: opens the PR as a draft via `gh pr create --draft`. The gh
+  wrapper signature becomes `ghpkg.PRCreate(title, body, base, head string, draft bool)`.
+- New flag `--ready [--branch <b>]`: flips a draft PR to ready via `gh pr ready <n>`
+  (new `ghpkg.PRReady(number int) error`). Idempotent — marking an already-ready PR
+  is a no-op success. With `--branch`, targets that branch's PR; without, the
+  current worktree's branch. `--ready` does not create a PR; if none exists it errors
+  clearly ("no PR for branch %q").
+- `PRResult` gains `pr` (alias of `number`), `draft` (bool), and `created` (bool):
+  ```go
+  type PRResult struct {
+      Number  int    `json:"number"`
+      Pr      int    `json:"pr"`      // == Number, for flow's contract
+      URL     string `json:"url"`
+      Title   string `json:"title"`
+      Draft   bool   `json:"draft"`
+      Created bool   `json:"created"`
+  }
+  ```
+  `number` and `title` are retained (no breaking change).
+
+### C. `worktree_path` in `NewResult` (J1)
+
+```go
+type NewResult struct {
+    Stack        string `json:"stack"`
+    Base         string `json:"base"`
+    Branch       string `json:"branch"`
+    WorktreePath string `json:"worktree_path,omitempty"` // first branch's worktree
+    Pushed       bool   `json:"pushed"`
+    Created      bool   `json:"created"`
+}
+```
+`worktree_path` is populated from the first branch's node when the stack is in
+worktree mode (`--worktrees`); empty otherwise.
+
+### D. `status` — `conflicted` sync_state (J5)
+
+`status` currently sets `sync_state` only to `in_sync` or `needs_sync`. Add
+`conflicted`: when a node has a worktree (`worktree_path != ""`) with a paused
+rebase (`gitpkg.IsRebaseInProgressAt(worktree_path)` is true), set
+`sync_state:"conflicted"`. Precedence: `conflicted` overrides `needs_sync`.
+
+Documented `sync_state` enum (in code doc + README):
+- `in_sync` — branch is current with its (effective) parent.
+- `needs_sync` — parent advanced (or a parent merged); branch must be synced.
+- `conflicted` — a rebase is paused in this branch's worktree, awaiting resolution.
+- `""` (omitted) — base branch / node without a meaningful sync state.
+
+`status` (`StatusNodeResult.Status`) remains `open | merged | closed`.
+
+### E. Worktree `sync` / `sync --continue` structured status (J6/J7)
+
+This is the load-bearing semantic: **a rebase conflict is a normal, actionable
+outcome, not a process failure.** Today the worktree sync step returns a Go error
+on conflict, which `runSyncCmd` places in `SyncResult.error` (with exit 0 in
+`--json` mode) and never emits a structured status — flow would have to parse the
+error string.
+
+Extend the existing `SyncResult`/`BranchResult` shape (no new top-level object):
+
+```go
+type BranchResult struct {
+    Branch      string   `json:"branch"`
+    PR          int      `json:"pr,omitempty"`
+    Action      string   `json:"action"`            // existing (monolithic sync)
+    Status      string   `json:"status,omitempty"`  // NEW: clean | noop | conflicted
+    Conflicts   []string `json:"conflicts,omitempty"` // NEW: paths, when conflicted
+    Pushed      bool     `json:"pushed,omitempty"`
+    BaseUpdated bool     `json:"base_updated,omitempty"`
+    Reason      string   `json:"reason,omitempty"`
+}
+```
+
+Worktree `sync` (run inside a branch's worktree) populates exactly one entry in
+`branches`:
+- **`clean`** — branch rebased onto its parent and pushed (`pushed:true`).
+- **`noop`** — already up to date with parent (nothing rebased/pushed).
+- **`conflicted`** — rebase paused; `conflicts` lists the conflicted paths; the
+  branch's `SyncProgress`/`WorktreeProgress` is recorded for `--continue`.
+
+On conflict the step returns **no Go error**; `SyncResult.error` stays empty and
+the process exits 0. `SyncResult.error` (and `error_code`, §F) are reserved for
+*real* failures (lock timeout, push rejection that isn't a conflict, IO errors).
+
+`sync --continue` (also inside the worktree) returns the same shape: `clean` once
+the resolved rebase completes and pushes, or `conflicted` again (with the
+remaining `conflicts`) if still unresolved.
+
+flow reads `branches[0].status`. The monolithic (non-worktree) sync path is
+unchanged — it continues to populate `action` and leaves `status` empty.
+
+### F. Distinguishable lock-timeout error (concurrency requirement)
+
+When `stack.AcquireLock` times out (another sdf process holds the lock), the
+failure must be retryable-distinguishable, not an opaque error flow escalates on.
+
+- `SyncResult` (and the other `--json` results: `NewResult`, `NewBranchResult`,
+  `PRResult`, status) gain an additive `error_code string json:"error_code,omitempty"`.
+- On lock-timeout, `--json` output sets `error` (human message) **and**
+  `error_code:"lock_timeout"`.
+- Non-`--json` invocations exit with a distinct, documented non-zero code
+  (`75`, EX_TEMPFAIL) for lock-timeout, vs `1` for ordinary errors.
+- Implementation: `AcquireLock` returns a sentinel (`stack.ErrLockTimeout`);
+  command wrappers map it to `error_code`/exit 75.
+
+### G. External-merge propagation (J8) — confirm with a test
+
+`status`/`fetch` already fetch from origin and poll `gh` PR state, and a merged
+parent yields a child `needs_sync` via `ParentBranch` skipping merged nodes. Add
+an integration test asserting: after a PR is marked merged on the remote, a
+subsequent `status --json` shows that node `status:"merged"` and its child
+`sync_state:"needs_sync"`. Add code only if the test exposes a gap (none expected).
+
+### H. Cross-cutting & non-goals
+
+- **Headless:** every flow-invoked command (`new`, `branch`, `pr`, `pr --ready`,
+  `sync`, `sync --continue`, `status`, `fetch`, `prune`, `switch`) runs without
+  prompts. Verify none prompt in the flow paths (they don't today).
+- **Stable field names:** all JSON changes are additive except the idempotency
+  *behavior* change. No field is renamed or removed.
+- **Non-goals (unchanged):** sdf does not trigger/report CI, spawn agents, run
+  reviews, or autonomously merge to the default branch.
+
+## Testing
+
+- Idempotency: re-run `new`/`branch`/`pr` and assert exit 0, `created:false`, and
+  identical resource (no duplicate node/PR/worktree).
+- `pr --draft`: asserts `draft:true` and a draft PR (via the gh spy).
+- `pr --ready`: asserts a draft flips to ready (`draft:false`), idempotent on
+  already-ready, errors when no PR exists.
+- `new --json`: asserts `worktree_path` present for `--worktrees`, empty otherwise.
+- `status`: a node with a paused rebase in its worktree reports
+  `sync_state:"conflicted"`.
+- Worktree `sync` contract: real-conflict test asserts `branches[0].status ==
+  "conflicted"`, `conflicts` non-empty, top-level `error` empty, exit 0; a clean
+  rebase asserts `status:"clean"`, `pushed:true`; up-to-date asserts `status:"noop"`.
+- `sync --continue`: after staging resolved files, asserts `status:"clean"`.
+- Lock-timeout: a held lock makes a second invocation emit
+  `error_code:"lock_timeout"` (json) / exit 75 (non-json).
+- J8: external-merge propagation test (§G).
+- Existing non-worktree `sync`/`new`/`branch`/`pr` tests must stay green
+  (idempotency and additive fields must not alter their behavior beyond the
+  documented re-run change).
+
+## Field-name contract (for flow's parser)
+
+Stable JSON keys flow depends on:
+- `new`: `stack, base, branch, worktree_path, pushed, created` (+ `error_code`).
+- `branch`: `branch, parent, worktree_path, created` (+ `error_code`).
+- `pr`: `number, pr, url, title, draft, created` (+ `error_code`).
+- `status` node: `branch, status, sync_state, worktree_path, pr` (+ existing extras).
+- `sync`: `branches[].{branch, status, conflicts, pushed}` (+ top-level `error`,
+  `error_code`).
+- `switch --path-only`: bare absolute path on stdout.

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -199,17 +199,31 @@ func MergePRResults(primary, child []PRInfo) []PRInfo {
 	return merged
 }
 
-// PRCreate creates a PR with the given parameters.
-func PRCreate(title, body, base, head string) (string, error) {
-	args := []string{"pr", "create",
-		"--title", title,
-		"--body", body,
-		"--head", head,
-	}
+func prCreateArgs(title, body, base, head string, draft bool) []string {
+	args := []string{"pr", "create", "--title", title, "--body", body, "--head", head}
 	if base != "" {
 		args = append(args, "--base", base)
 	}
-	return run(args...)
+	if draft {
+		args = append(args, "--draft")
+	}
+	return args
+}
+
+// PRCreate opens a PR for head against base. When draft is true it is opened as a draft.
+func PRCreate(title, body, base, head string, draft bool) (string, error) {
+	return run(prCreateArgs(title, body, base, head, draft)...)
+}
+
+func prReadyArgs(prNumber int) []string {
+	return []string{"pr", "ready", fmt.Sprintf("%d", prNumber)}
+}
+
+// PRReady marks a draft PR as ready for review. Idempotent: marking an
+// already-ready PR is a no-op success on GitHub's side.
+func PRReady(prNumber int) error {
+	_, err := run(prReadyArgs(prNumber)...)
+	return err
 }
 
 // PREditBase updates the base branch of a PR.

--- a/internal/gh/gh_test.go
+++ b/internal/gh/gh_test.go
@@ -223,7 +223,7 @@ func TestPRCreate_Arguments(t *testing.T) {
 	})
 	testutil.SetBinary(t, &Binary, fake)
 
-	url, err := PRCreate("feat: add auth", "PR body here", "main", "feat/auth")
+	url, err := PRCreate("feat: add auth", "PR body here", "main", "feat/auth", false)
 	if err != nil {
 		t.Fatalf("PRCreate failed: %v", err)
 	}
@@ -240,6 +240,32 @@ func TestPRCreate_Arguments(t *testing.T) {
 	if log[0] != expected {
 		t.Errorf("unexpected arguments:\n  got:  %s\n  want: %s", log[0], expected)
 	}
+}
+
+func TestPRCreateDraftFlag(t *testing.T) {
+	got := prCreateArgs("t", "b", "main", "feat/x", true)
+	if !containsArg(got, "--draft") {
+		t.Errorf("draft create must pass --draft: %v", got)
+	}
+	got = prCreateArgs("t", "b", "main", "feat/x", false)
+	if containsArg(got, "--draft") {
+		t.Errorf("non-draft must not pass --draft: %v", got)
+	}
+}
+
+func TestPRReadyArgs(t *testing.T) {
+	if a := prReadyArgs(42); a[0] != "pr" || a[1] != "ready" || a[2] != "42" {
+		t.Errorf("pr ready args = %v", a)
+	}
+}
+
+func containsArg(a []string, s string) bool {
+	for _, x := range a {
+		if x == s {
+			return true
+		}
+	}
+	return false
 }
 
 func TestPRView_ParsesJSON(t *testing.T) {

--- a/internal/stack/lock.go
+++ b/internal/stack/lock.go
@@ -3,6 +3,7 @@ package stack
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,6 +16,11 @@ const LockTimeout = 10 * time.Second
 
 // staleAfter is how old a lock may be before it is considered abandoned.
 const staleAfter = 5 * time.Minute
+
+// ErrLockTimeout is returned by AcquireLock when the lock cannot be acquired
+// within the timeout (another sdf process holds it). Callers map it to a
+// distinguishable error_code / exit code so orchestrators retry rather than escalate.
+var ErrLockTimeout = errors.New("stack lock acquire timed out")
 
 // Lock is a held advisory lock on a stack's metadata.
 type Lock struct {
@@ -61,7 +67,7 @@ func AcquireLock(root, stackID string, timeout time.Duration) (*Lock, error) {
 			continue
 		}
 		if time.Now().After(deadline) {
-			return nil, fmt.Errorf("timed out waiting for stack lock %s (another sdf process may be running)", path)
+			return nil, fmt.Errorf("%w: %s (another sdf process may be running)", ErrLockTimeout, path)
 		}
 		time.Sleep(50 * time.Millisecond)
 	}

--- a/internal/stack/lock_test.go
+++ b/internal/stack/lock_test.go
@@ -3,6 +3,7 @@ package stack
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -107,4 +108,17 @@ func TestStaleLockReclaimsOldCorruptFile(t *testing.T) {
 		t.Fatalf("old corrupt lock should be reclaimed: %v", err)
 	}
 	_ = l.Release()
+}
+
+func TestAcquireLockTimeoutReturnsSentinel(t *testing.T) {
+	root := sdfRepo(t)
+	l, err := AcquireLock(root, "feat", time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Release()
+	_, err = AcquireLock(root, "feat", 100*time.Millisecond)
+	if !errors.Is(err, ErrLockTimeout) {
+		t.Fatalf("expected ErrLockTimeout, got %v", err)
+	}
 }

--- a/www/src/data/cli-reference.json
+++ b/www/src/data/cli-reference.json
@@ -259,6 +259,12 @@
       "short": "Create a GitHub PR for the current branch",
       "flags": [
         {
+          "name": "branch",
+          "type": "string",
+          "default": "",
+          "description": "target branch (default: current)"
+        },
+        {
           "name": "draft",
           "type": "bool",
           "default": "false",
@@ -269,6 +275,12 @@
           "type": "bool",
           "default": "false",
           "description": "output result as JSON"
+        },
+        {
+          "name": "ready",
+          "type": "bool",
+          "default": "false",
+          "description": "mark the branch's draft PR as ready for review"
         },
         {
           "name": "title",
@@ -562,5 +574,5 @@
       "description": "Base directory for per-branch worktrees ({repo} = repo dir name)"
     }
   ],
-  "hash": "97c70b4d5356140627dc6771ef30623d27126bf969b610d0b55c1b76ccc0d74f"
+  "hash": "cd5715406722062d56853c06cac58fbda23e89bb2a19f7ec6031db53205ee3c6"
 }

--- a/www/src/data/cli-reference.json
+++ b/www/src/data/cli-reference.json
@@ -259,6 +259,12 @@
       "short": "Create a GitHub PR for the current branch",
       "flags": [
         {
+          "name": "draft",
+          "type": "bool",
+          "default": "false",
+          "description": "open the PR as a draft"
+        },
+        {
           "name": "json",
           "type": "bool",
           "default": "false",
@@ -556,5 +562,5 @@
       "description": "Base directory for per-branch worktrees ({repo} = repo dir name)"
     }
   ],
-  "hash": "8208c90c9a7ae669606f1193a9ebf7ba664dd60a8029f93fe6f514596091e900"
+  "hash": "97c70b4d5356140627dc6771ef30623d27126bf969b610d0b55c1b76ccc0d74f"
 }


### PR DESCRIPTION
## sdf ↔ flow integration (v0.5.0)

Closes [flow](../../flow)'s integration contract on top of worktree mode (v0.4.0). flow is the orchestrator (it supplies the agent in each worktree); sdf is the substrate. Every job below is invoked headlessly with `--json`.

Design: `docs/superpowers/specs/2026-06-17-flow-integration-design.md`

### What's new
- **Idempotent `new`/`branch`/`pr`** — re-running for an existing stack/branch/PR returns the current state (`"created": false`, exit 0), instead of erroring. flow re-issues on crash-resume. The existence check is **race-safe under the stack lock** (concurrent invocations yield exactly one resource, no error).
- **`worktree_path` in `sdf new --json`** — flow knows where to work without a follow-up call.
- **`sdf pr --draft`** — open a PR as a draft; **`sdf pr --ready [--branch <b>]`** — flip a draft to ready-for-review (idempotent).
- **`PRResult`** gains `pr` (== `number`), `draft`, `created` (keeps `number`/`title`).
- **`status` `sync_state` enum** gains **`conflicted`** (a paused worktree rebase), taking precedence over `needs_sync`. Documented enum: `in_sync | needs_sync | conflicted`.
- **Worktree `sync` / `sync --continue`** emit a structured per-branch result — `branches[].status` ∈ `clean | noop | conflicted` plus `conflicts: [paths]`. **A rebase conflict in `--json` mode is `status:"conflicted"` with exit 0 and an empty top-level `error`** — not a process failure (the single most important semantic for flow's conflict loop). Human (non-`--json`) mode still errors so a person gets a non-zero signal.
- **Distinguishable lock-timeout** — `error_code:"lock_timeout"` in `--json` results and exit code **75** (EX_TEMPFAIL) otherwise, so flow retries rather than escalates.
- **External-merge propagation (J8)** confirmed by test: a human-merged PR surfaces as node `status:"merged"` and its child `sync_state:"needs_sync"`.

### Contract
All JSON changes are **additive** — no existing field renamed or removed (flow's parser keys on stable names). The stable field-name contract is documented in `README.md` and the spec. Non-goals unchanged: sdf does not trigger/report CI, spawn agents, run reviews, or autonomously merge to the default branch.

### Verification
Each change landed via test-first commits with independent review; a whole-branch review (run on the strongest model) drove two follow-up fixes — the idempotency existence check now runs **inside** the stack lock (race-safe), and a concurrent loser whose git branch already exists falls through to the in-lock path (idempotent) rather than hard-erroring. `go build`/`go vet`/`golangci-lint` clean; `internal/...` and the worktree-mode `cmd` suites pass. (The repo's pre-existing `cmd` failures — test helpers running `git add .sdf` against a gitignored `.sdf/` — are present on `main` and unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
